### PR TITLE
feat(#8): DataSourceAdapter 协议定义与基础抽象

### DIFF
--- a/src/data_platform/adapters/base.py
+++ b/src/data_platform/adapters/base.py
@@ -1,0 +1,285 @@
+"""Base abstractions for data source adapters."""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from threading import Lock
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Literal,
+    Mapping,
+    Protocol,
+    Sequence,
+    TypeAlias,
+    runtime_checkable,
+)
+
+
+@runtime_checkable
+class _ArrowTable(Protocol):
+    num_rows: int
+
+
+if TYPE_CHECKING:
+    Schema: TypeAlias = Any
+    Table: TypeAlias = _ArrowTable
+else:
+    try:
+        from pyarrow import Schema, Table
+        import pyarrow as pa
+    except ModuleNotFoundError:
+
+        class Schema:
+            """Minimal fallback used only when pyarrow is unavailable locally."""
+
+            def __init__(self, fields: Sequence[tuple[str, Any]] | None = None) -> None:
+                self.fields = tuple(fields or ())
+
+        class Table:
+            """Minimal fallback used only when pyarrow is unavailable locally."""
+
+            def __init__(self, rows: Sequence[Mapping[str, Any]] | None = None) -> None:
+                self.num_rows = len(rows or ())
+
+        class _PyArrowFallback:
+            Schema = Schema
+            Table = Table
+
+            @staticmethod
+            def schema(fields: Sequence[tuple[str, Any]]) -> Schema:
+                return Schema(fields)
+
+            @staticmethod
+            def table(rows: Sequence[Mapping[str, Any]]) -> Table:
+                return Table(rows)
+
+        pa = _PyArrowFallback()
+
+FetchParams: TypeAlias = Mapping[str, Any]
+FetchResult: TypeAlias = Table | list[dict[str, Any]]
+PartitionType: TypeAlias = Literal["daily", "static"]
+
+
+@dataclass(frozen=True, slots=True)
+class AssetSpec:
+    """Data structure describing an adapter-provided asset."""
+
+    name: str
+    dataset: str
+    partition: PartitionType
+    schema: Schema
+
+
+@dataclass(frozen=True, slots=True)
+class QuotaConfig:
+    """Rate and credit quota configuration for an adapter."""
+
+    requests_per_minute: int
+    daily_credit_quota: int | None
+    backoff_seconds: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.requests_per_minute <= 0:
+            msg = "requests_per_minute must be greater than zero"
+            raise ValueError(msg)
+        if self.daily_credit_quota is not None and self.daily_credit_quota < 0:
+            msg = "daily_credit_quota must be non-negative or None"
+            raise ValueError(msg)
+        if self.backoff_seconds < 0:
+            msg = "backoff_seconds must be non-negative"
+            raise ValueError(msg)
+
+
+class AdapterQuotaExceeded(RuntimeError):
+    """Raised when an adapter-level quota is exhausted."""
+
+
+class AdapterAlreadyRegistered(RuntimeError):
+    """Raised when registering another adapter for the same source."""
+
+
+class AdapterFetchError(RuntimeError):
+    """Raised when adapter fetch I/O fails."""
+
+    def __init__(self, source_id: str, asset_id: str, cause: BaseException) -> None:
+        self.source_id = source_id
+        self.asset_id = asset_id
+        self.cause = cause
+        super().__init__(
+            f"adapter fetch failed for source_id={source_id!r}, asset_id={asset_id!r}: {cause}"
+        )
+
+
+class DataSourceAdapter(ABC):
+    """Contract implemented by data source adapters."""
+
+    @abstractmethod
+    def source_id(self) -> str:
+        """Return the unique source identifier for this adapter."""
+
+    @abstractmethod
+    def get_assets(self) -> list[AssetSpec]:
+        """Return data assets exposed by this adapter."""
+
+    @abstractmethod
+    def get_resources(self) -> dict[str, Any]:
+        """Return runtime resources required by this adapter."""
+
+    @abstractmethod
+    def get_staging_dbt_models(self) -> list[str]:
+        """Return staging dbt model names required for this adapter."""
+
+    @abstractmethod
+    def get_quota_config(self) -> QuotaConfig:
+        """Return quota configuration for this adapter."""
+
+    @abstractmethod
+    def fetch(self, asset_id: str, params: FetchParams) -> FetchResult:
+        """Fetch one asset from the source."""
+
+
+class BaseAdapter(DataSourceAdapter):
+    """Base adapter with shared throttling, retry, and fetch error handling."""
+
+    def __init__(
+        self,
+        *,
+        max_retries: int = 3,
+        clock: Callable[[], float] | None = None,
+        sleep: Callable[[float], None] | None = None,
+    ) -> None:
+        if max_retries < 0:
+            msg = "max_retries must be non-negative"
+            raise ValueError(msg)
+        self._max_retries = max_retries
+        self._clock = clock or time.monotonic
+        self._sleep = sleep or time.sleep
+        self._quota_lock = Lock()
+        self._daily_credit_lock = Lock()
+        self._tokens = 0.0
+        self._last_token_refill = self._clock()
+        self._daily_credits_used = 0
+
+    def fetch(self, asset_id: str, params: FetchParams) -> FetchResult:
+        """Fetch with quota throttling, retry-on-429, and error wrapping."""
+
+        self._reserve_daily_credit()
+        start = self._clock()
+        attempt = 0
+        while True:
+            self._throttle()
+            try:
+                result = self._fetch(asset_id, params)
+            except Exception as exc:
+                if self._is_rate_limit_error(exc) and attempt < self._max_retries:
+                    attempt += 1
+                    self._sleep(self.get_quota_config().backoff_seconds)
+                    continue
+                raise AdapterFetchError(self.source_id(), asset_id, exc) from exc
+
+            duration_s = self._clock() - start
+            self.on_fetch_complete(asset_id, self._row_count(result), duration_s)
+            return result
+
+    def _throttle(self) -> None:
+        """Block until this adapter has a request token available."""
+
+        quota = self.get_quota_config()
+        seconds_per_token = 60.0 / quota.requests_per_minute
+        with self._quota_lock:
+            while self._tokens < 1.0:
+                now = self._clock()
+                elapsed = max(0.0, now - self._last_token_refill)
+                self._tokens = min(1.0, self._tokens + (elapsed / seconds_per_token))
+                self._last_token_refill = now
+                if self._tokens >= 1.0:
+                    break
+
+                wait_seconds = (1.0 - self._tokens) * seconds_per_token
+                self._sleep(wait_seconds)
+
+            self._tokens -= 1.0
+
+    def on_fetch_complete(self, asset_id: str, row_count: int, duration_s: float) -> None:
+        """Hook called after successful fetch completion."""
+
+    @abstractmethod
+    def _fetch(self, asset_id: str, params: FetchParams) -> FetchResult:
+        """Fetch one asset without shared BaseAdapter error handling."""
+
+    def _reserve_daily_credit(self) -> None:
+        quota = self.get_quota_config()
+        if quota.daily_credit_quota is None:
+            return
+
+        with self._daily_credit_lock:
+            if self._daily_credits_used >= quota.daily_credit_quota:
+                msg = f"daily credit quota exceeded for source_id={self.source_id()!r}"
+                raise AdapterQuotaExceeded(msg)
+            self._daily_credits_used += 1
+
+    @staticmethod
+    def _row_count(result: FetchResult) -> int:
+        if isinstance(result, Table):
+            return int(result.num_rows)
+        return len(result)
+
+    @staticmethod
+    def _is_rate_limit_error(exc: BaseException) -> bool:
+        status_code = getattr(exc, "status_code", None)
+        if status_code == 429:
+            return True
+
+        response = getattr(exc, "response", None)
+        response_status_code = getattr(response, "status_code", None)
+        if response_status_code == 429:
+            return True
+
+        code = getattr(exc, "code", None)
+        return code == 429
+
+
+class AdapterRegistry:
+    """Thread-safe registry for source adapters."""
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, DataSourceAdapter] = {}
+        self._lock = Lock()
+
+    def register(self, adapter: DataSourceAdapter) -> None:
+        source_id = adapter.source_id()
+        with self._lock:
+            if source_id in self._adapters:
+                msg = f"adapter already registered for source_id={source_id!r}"
+                raise AdapterAlreadyRegistered(msg)
+            self._adapters[source_id] = adapter
+
+    def get(self, source_id: str) -> DataSourceAdapter:
+        with self._lock:
+            return self._adapters[source_id]
+
+    def list_sources(self) -> list[str]:
+        with self._lock:
+            return list(self._adapters)
+
+
+_REGISTRY = AdapterRegistry()
+
+__all__ = [
+    "AdapterAlreadyRegistered",
+    "AdapterFetchError",
+    "AdapterQuotaExceeded",
+    "AdapterRegistry",
+    "AssetSpec",
+    "BaseAdapter",
+    "DataSourceAdapter",
+    "FetchParams",
+    "FetchResult",
+    "PartitionType",
+    "QuotaConfig",
+    "_REGISTRY",
+]

--- a/tests/adapters/test_base.py
+++ b/tests/adapters/test_base.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from data_platform.adapters import base
+from data_platform.adapters.base import (
+    AdapterAlreadyRegistered,
+    AdapterFetchError,
+    AdapterQuotaExceeded,
+    AdapterRegistry,
+    AssetSpec,
+    BaseAdapter,
+    DataSourceAdapter,
+    FetchParams,
+    FetchResult,
+    QuotaConfig,
+)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleep_calls: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        assert seconds >= 0
+        self.sleep_calls.append(seconds)
+        self.now += seconds
+
+
+class ExampleAdapter(BaseAdapter):
+    def __init__(
+        self,
+        *,
+        source: str = "example",
+        quota: QuotaConfig | None = None,
+        side_effects: list[FetchResult | BaseException] | None = None,
+        clock: FakeClock | None = None,
+        max_retries: int = 3,
+    ) -> None:
+        self._source = source
+        self._quota = quota or QuotaConfig(requests_per_minute=60_000, daily_credit_quota=None)
+        self._side_effects = side_effects or [[{"id": 1}]]
+        self.fetch_calls: list[tuple[str, FetchParams]] = []
+        self.completed: list[tuple[str, int, float]] = []
+        super().__init__(
+            max_retries=max_retries,
+            clock=clock.monotonic if clock else None,
+            sleep=clock.sleep if clock else None,
+        )
+
+    def source_id(self) -> str:
+        return self._source
+
+    def get_assets(self) -> list[AssetSpec]:
+        return []
+
+    def get_resources(self) -> dict[str, Any]:
+        return {}
+
+    def get_staging_dbt_models(self) -> list[str]:
+        return []
+
+    def get_quota_config(self) -> QuotaConfig:
+        return self._quota
+
+    def on_fetch_complete(self, asset_id: str, row_count: int, duration_s: float) -> None:
+        self.completed.append((asset_id, row_count, duration_s))
+
+    def _fetch(self, asset_id: str, params: Mapping[str, Any]) -> FetchResult:
+        self.fetch_calls.append((asset_id, params))
+        effect = self._side_effects.pop(0)
+        if isinstance(effect, BaseException):
+            raise effect
+        return effect
+
+
+def test_data_source_adapter_requires_all_methods() -> None:
+    class MissingMethods(DataSourceAdapter):
+        pass
+
+    with pytest.raises(TypeError):
+        MissingMethods()
+
+
+def test_asset_spec_and_quota_config_validate() -> None:
+    string_type = base.pa.string() if hasattr(base.pa, "string") else "string"
+    schema = base.pa.schema([("asset_id", string_type)])
+
+    asset = AssetSpec(
+        name="stock_basic",
+        dataset="canonical",
+        partition="static",
+        schema=schema,
+    )
+
+    assert asset.name == "stock_basic"
+    assert asset.partition == "static"
+
+    with pytest.raises(ValueError, match="requests_per_minute"):
+        QuotaConfig(requests_per_minute=0, daily_credit_quota=None)
+
+    with pytest.raises(ValueError, match="daily_credit_quota"):
+        QuotaConfig(requests_per_minute=1, daily_credit_quota=-1)
+
+    with pytest.raises(ValueError, match="backoff_seconds"):
+        QuotaConfig(requests_per_minute=1, daily_credit_quota=None, backoff_seconds=-0.1)
+
+
+def test_throttle_waits_sixty_seconds_for_sixty_requests_at_sixty_rpm() -> None:
+    clock = FakeClock()
+    adapter = ExampleAdapter(
+        quota=QuotaConfig(requests_per_minute=60, daily_credit_quota=None),
+        clock=clock,
+    )
+
+    for _ in range(60):
+        adapter._throttle()
+
+    assert clock.now >= 60.0 * 0.95
+    assert clock.now <= 60.0 * 1.05
+
+
+def test_fetch_wraps_unhandled_errors() -> None:
+    clock = FakeClock()
+    cause = RuntimeError("upstream exploded")
+    adapter = ExampleAdapter(source="source-a", side_effects=[cause], clock=clock)
+
+    with pytest.raises(AdapterFetchError) as exc_info:
+        adapter.fetch("asset-a", {"date": "2026-04-15"})
+
+    assert exc_info.value.source_id == "source-a"
+    assert exc_info.value.asset_id == "asset-a"
+    assert exc_info.value.cause is cause
+
+
+def test_fetch_retries_429_and_calls_completion_hook() -> None:
+    class RateLimitError(Exception):
+        status_code = 429
+
+    clock = FakeClock()
+    rows = [{"id": 1}, {"id": 2}]
+    adapter = ExampleAdapter(
+        quota=QuotaConfig(
+            requests_per_minute=60_000,
+            daily_credit_quota=None,
+            backoff_seconds=2.0,
+        ),
+        side_effects=[RateLimitError("too many requests"), rows],
+        clock=clock,
+    )
+
+    result = adapter.fetch("asset-a", {"page": 1})
+
+    assert result == rows
+    assert len(adapter.fetch_calls) == 2
+    assert 2.0 in clock.sleep_calls
+    assert adapter.completed[0][0] == "asset-a"
+    assert adapter.completed[0][1] == 2
+    assert adapter.completed[0][2] >= 2.0
+
+
+def test_daily_quota_exceeded() -> None:
+    clock = FakeClock()
+    adapter = ExampleAdapter(
+        quota=QuotaConfig(requests_per_minute=60_000, daily_credit_quota=1),
+        side_effects=[[{"id": 1}], [{"id": 2}]],
+        clock=clock,
+    )
+
+    assert adapter.fetch("asset-a", {}) == [{"id": 1}]
+
+    with pytest.raises(AdapterQuotaExceeded):
+        adapter.fetch("asset-a", {})
+
+
+def test_adapter_registry_register_get_list_and_duplicate() -> None:
+    registry = AdapterRegistry()
+    adapter = ExampleAdapter(source="source-a")
+
+    registry.register(adapter)
+
+    assert registry.get("source-a") is adapter
+    assert registry.list_sources() == ["source-a"]
+    assert isinstance(base._REGISTRY, AdapterRegistry)
+
+    with pytest.raises(AdapterAlreadyRegistered):
+        registry.register(adapter)


### PR DESCRIPTION
Closes #8

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.gitignore`, `constraints.txt`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`


---
## 背景与目标
项目文档 §9.3、§14、§16.2 要求 `data-platform` 提供 `DataSourceAdapter` 协议实现。注意：协议本身定义在 `contracts` 模块（外部仓库），本项目实现 Python 抽象基类与运行期校验，并提供基础工具方法。先固化抽象层，避免后续 adapter 各自实现散乱。

## 所属模块
data_platform.adapters.base

## 实现范围
- 新建 `src/data_platform/adapters/base.py` 定义 `DataSourceAdapter` ABC
- 抽象方法：`source_id() -> str`、`get_assets() -> list[AssetSpec]`、`get_resources() -> dict[str, Any]`、`get_staging_dbt_models() -> list[str]`、`get_quota_config() -> QuotaConfig`、`fetch(asset_id, params) -> pa.Table | list[dict]`
- dataclass `QuotaConfig`：`requests_per_minute: int`、`daily_credit_quota: int | None`、`backoff_seconds: float = 1.0`
- 提供 `AdapterRegistry`：`register(adapter)`、`get(source_id) -> DataSourceAdapter`、`list_sources() -> list[str]`
- 提供 `BaseAdapter` 基类，封装 quota 限流 token-bucket 与 retry-on-429 通用逻辑
- 抛错类型：`AdapterQuotaExceeded`、`AdapterFetchError(source_id, asset_id, cause)`

## 不在本次范围
- 不实现 Tushare 具体 adapter（留给 #9）
- 不直接调用 LLM（明确 BAN）
- 不定义 Dagster asset（明确 BAN，asset spec 仅是数据结构）

## 关键交付物
- `class DataSourceAdapter(ABC)` + `AssetSpec(name: str, dataset: str, partition: Literal["daily","static"], schema: pa.Schema)`
- `BaseAdapter` 内的 `_throttle()` 实现 token bucket，单测覆盖
- `AdapterRegistry` 是模块级单例 `_REGISTRY`，提供线程安全的 register（用 threading.Lock）
- 所有 fetch 错误必须包装为 `AdapterFetchError` 不裸抛 requests / 第三方异常
- 公共 hook：`on_fetch_complete(asset_id, row_count, duration_s)` 默认空实现，子类可覆盖

## 验收标准
- [ ] `DataSourceAdapter` 任一方法未实现时实例化抛 `TypeError`
- [ ] `BaseAdapter._throttle()` 在 `requests_per_minute=60` 下连续 60 调用总耗时 ≥ 60s（允许 ±5%）
- [ ] `AdapterRegistry.register` 同一 source_id 重复注册抛 `AdapterAlreadyRegistered`
- [ ] `pytest tests/adapters/test_base.py` 通过且覆盖率 ≥80%
- [ ] mypy 严格模式无错误

## 验证命令
```bash
cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
pytest tests/adapters/test_base.py -q --cov=data_platform.adapters.base --cov-report=term
mypy src/data_platform/adapters/base.py
```

## 依赖
依赖 #2（包结构）