### PR TITLE
feat(#4): PostgreSQL 连接与 SQL 迁移框架

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ package-dir = {"" = "src"}
 where = ["src"]
 include = ["data_platform*"]
 
+[tool.setuptools.package-data]
+data_platform = ["ddl/migrations/*.sql"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/src/data_platform/ddl/migrations/0001_init.sql
+++ b/src/data_platform/ddl/migrations/0001_init.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS data_platform;

--- a/src/data_platform/ddl/runner.py
+++ b/src/data_platform/ddl/runner.py
@@ -1,0 +1,217 @@
+"""SQL migration runner for PostgreSQL-backed data-platform metadata."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection, Engine
+
+from data_platform.config import get_settings
+
+
+MIGRATION_FILENAME_PATTERN = re.compile(r"^(?P<version>\d{4})_(?P<name>[a-z][a-z0-9_]*)\.sql$")
+METADATA_TABLE_NAME = "dp_schema_migrations"
+DEFAULT_ADVISORY_LOCK_ID = 91234
+
+
+@dataclass(frozen=True, slots=True)
+class Migration:
+    """A SQL migration loaded from disk."""
+
+    version: str
+    name: str
+    path: Path
+    sql: str
+
+
+class MigrationError(RuntimeError):
+    """Raised when one migration fails inside its transaction."""
+
+    def __init__(self, version: str, sql: str, cause: BaseException) -> None:
+        self.version = version
+        self.sql = sql
+        self.cause = cause
+        super().__init__(f"migration {version} failed: {cause}")
+
+
+class MigrationRunner:
+    """Apply ordered SQL migrations against PostgreSQL."""
+
+    def __init__(
+        self,
+        *,
+        migrations_path: Path | None = None,
+        advisory_lock_id: int = DEFAULT_ADVISORY_LOCK_ID,
+    ) -> None:
+        self.migrations_path = migrations_path or Path(__file__).with_name("migrations")
+        self.advisory_lock_id = int(advisory_lock_id)
+
+    def apply_pending(self, dsn: str) -> list[str]:
+        """Apply pending migrations and return the newly applied versions."""
+
+        migrations = self._load_migrations()
+        engine = self._create_engine(dsn)
+        try:
+            with engine.connect() as connection:
+                self._acquire_lock(connection)
+                try:
+                    self._ensure_metadata_table(connection)
+                    applied_versions = self._fetch_applied_versions(connection)
+                    connection.commit()
+
+                    pending_migrations = [
+                        migration
+                        for migration in migrations
+                        if migration.version not in applied_versions
+                    ]
+                    applied_now: list[str] = []
+                    for migration in pending_migrations:
+                        self._apply_migration(connection, migration)
+                        applied_now.append(migration.version)
+                    return applied_now
+                finally:
+                    self._release_lock(connection)
+        finally:
+            engine.dispose()
+
+    def list_pending(self, dsn: str) -> list[str]:
+        """Return pending migration versions without mutating the database."""
+
+        migrations = self._load_migrations()
+        engine = self._create_engine(dsn)
+        try:
+            with engine.connect() as connection:
+                self._acquire_lock(connection)
+                try:
+                    if self._metadata_table_exists(connection):
+                        applied_versions = self._fetch_applied_versions(connection)
+                    else:
+                        applied_versions = set()
+                    connection.commit()
+                    return [
+                        migration.version
+                        for migration in migrations
+                        if migration.version not in applied_versions
+                    ]
+                finally:
+                    self._release_lock(connection)
+        finally:
+            engine.dispose()
+
+    def _create_engine(self, dsn: str) -> Engine:
+        return create_engine(dsn)
+
+    def _load_migrations(self) -> list[Migration]:
+        if not self.migrations_path.exists():
+            msg = f"migrations path does not exist: {self.migrations_path}"
+            raise FileNotFoundError(msg)
+
+        migrations: list[Migration] = []
+        seen_versions: set[str] = set()
+        for path in sorted(self.migrations_path.glob("*.sql")):
+            match = MIGRATION_FILENAME_PATTERN.fullmatch(path.name)
+            if match is None:
+                msg = (
+                    "migration filenames must use NNNN_<snake_case>.sql: "
+                    f"{path.name}"
+                )
+                raise ValueError(msg)
+
+            version = match.group("version")
+            if version in seen_versions:
+                msg = f"duplicate migration version: {version}"
+                raise ValueError(msg)
+            seen_versions.add(version)
+
+            migrations.append(
+                Migration(
+                    version=version,
+                    name=match.group("name"),
+                    path=path,
+                    sql=path.read_text(encoding="utf-8"),
+                )
+            )
+
+        return migrations
+
+    def _acquire_lock(self, connection: Connection) -> None:
+        connection.execute(text(f"SELECT pg_advisory_lock({self.advisory_lock_id})")).scalar_one()
+        connection.commit()
+
+    def _release_lock(self, connection: Connection) -> None:
+        connection.execute(text(f"SELECT pg_advisory_unlock({self.advisory_lock_id})")).scalar_one()
+        connection.commit()
+
+    def _ensure_metadata_table(self, connection: Connection) -> None:
+        with connection.begin():
+            connection.execute(
+                text(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {METADATA_TABLE_NAME} (
+                        version TEXT PRIMARY KEY,
+                        applied_at TIMESTAMPTZ DEFAULT now()
+                    )
+                    """
+                )
+            )
+
+    def _metadata_table_exists(self, connection: Connection) -> bool:
+        result = connection.execute(
+            text(f"SELECT to_regclass('public.{METADATA_TABLE_NAME}')")
+        ).scalar_one()
+        return result is not None
+
+    def _fetch_applied_versions(self, connection: Connection) -> set[str]:
+        rows = connection.execute(
+            text(f"SELECT version FROM {METADATA_TABLE_NAME} ORDER BY version")
+        ).scalars()
+        return {str(row) for row in rows}
+
+    def _apply_migration(self, connection: Connection, migration: Migration) -> None:
+        try:
+            with connection.begin():
+                connection.exec_driver_sql(migration.sql)
+                connection.execute(
+                    text(
+                        f"INSERT INTO {METADATA_TABLE_NAME} (version) "
+                        "VALUES (:version)"
+                    ),
+                    {"version": migration.version},
+                )
+        except Exception as exc:
+            raise MigrationError(migration.version, migration.sql, exc) from exc
+
+
+def _resolve_dsn() -> str:
+    env_dsn = os.environ.get("DP_PG_DSN")
+    if env_dsn:
+        return env_dsn
+
+    return str(get_settings().pg_dsn)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Apply data-platform PostgreSQL migrations.")
+    parser.add_argument("--upgrade", action="store_true", help="apply pending migrations")
+    parser.add_argument("--dry-run", action="store_true", help="list pending migrations only")
+    args = parser.parse_args(argv)
+
+    if not args.upgrade:
+        parser.error("only --upgrade is supported")
+
+    runner = MigrationRunner()
+    dsn = _resolve_dsn()
+    versions = runner.list_pending(dsn) if args.dry_run else runner.apply_pending(dsn)
+    for version in versions:
+        print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ddl/test_runner.py
+++ b/tests/ddl/test_runner.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import SQLAlchemyError
+
+from data_platform.ddl.runner import MigrationError, MigrationRunner
+
+
+def write_migration(migrations_path: Path, filename: str, sql: str) -> None:
+    migrations_path.mkdir(parents=True, exist_ok=True)
+    (migrations_path / filename).write_text(sql, encoding="utf-8")
+
+
+@pytest.fixture()
+def postgres_dsn() -> Generator[str]:
+    admin_dsn = os.environ.get("DATABASE_URL") or os.environ.get("DP_PG_DSN")
+    if not admin_dsn:
+        pytest.skip("PostgreSQL migration tests require DATABASE_URL or DP_PG_DSN")
+
+    admin_engine = create_engine(admin_dsn, isolation_level="AUTOCOMMIT")
+    database_name = f"dp_migrations_test_{uuid4().hex}"
+    try:
+        with admin_engine.connect() as connection:
+            connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+    except SQLAlchemyError as exc:
+        admin_engine.dispose()
+        pytest.skip(
+            "PostgreSQL migration tests require permission to create test databases: "
+            f"{exc}"
+        )
+
+    test_dsn = str(make_url(admin_dsn).set(database=database_name))
+    try:
+        yield test_dsn
+    finally:
+        with admin_engine.connect() as connection:
+            connection.execute(
+                text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+        admin_engine.dispose()
+
+
+def fetch_scalar(dsn: str, sql: str) -> object:
+    engine = create_engine(dsn)
+    try:
+        with engine.connect() as connection:
+            return connection.execute(text(sql)).scalar_one()
+    finally:
+        engine.dispose()
+
+
+def fetch_versions(dsn: str) -> list[str]:
+    engine = create_engine(dsn)
+    try:
+        with engine.connect() as connection:
+            rows = connection.execute(
+                text("SELECT version FROM dp_schema_migrations ORDER BY version")
+            ).scalars()
+            return [str(row) for row in rows]
+    finally:
+        engine.dispose()
+
+
+def test_load_migrations_requires_filename_format(tmp_path: Path) -> None:
+    write_migration(tmp_path, "0001-init.sql", "SELECT 1;")
+    runner = MigrationRunner(migrations_path=tmp_path)
+
+    with pytest.raises(ValueError, match="NNNN_<snake_case>"):
+        runner._load_migrations()
+
+
+def test_load_migrations_rejects_duplicate_versions(tmp_path: Path) -> None:
+    write_migration(tmp_path, "0001_init.sql", "SELECT 1;")
+    write_migration(tmp_path, "0001_other.sql", "SELECT 2;")
+    runner = MigrationRunner(migrations_path=tmp_path)
+
+    with pytest.raises(ValueError, match="duplicate migration version: 0001"):
+        runner._load_migrations()
+
+
+def test_apply_pending_is_idempotent_and_creates_schema(postgres_dsn: str) -> None:
+    runner = MigrationRunner()
+
+    assert runner.apply_pending(postgres_dsn) == ["0001"]
+    assert runner.apply_pending(postgres_dsn) == []
+    assert fetch_versions(postgres_dsn) == ["0001"]
+    assert fetch_scalar(postgres_dsn, "SELECT to_regclass('public.dp_schema_migrations')")
+    assert (
+        fetch_scalar(
+            postgres_dsn,
+            "SELECT schema_name FROM information_schema.schemata "
+            "WHERE schema_name = 'data_platform'",
+        )
+        == "data_platform"
+    )
+
+
+def test_dry_run_lists_pending_without_creating_metadata_table(
+    postgres_dsn: str,
+    tmp_path: Path,
+) -> None:
+    migrations_path = tmp_path / "migrations"
+    write_migration(
+        migrations_path,
+        "0001_init.sql",
+        "CREATE SCHEMA IF NOT EXISTS data_platform;",
+    )
+    runner = MigrationRunner(migrations_path=migrations_path)
+
+    assert runner.list_pending(postgres_dsn) == ["0001"]
+    assert fetch_scalar(postgres_dsn, "SELECT to_regclass('public.dp_schema_migrations')") is None
+
+
+def test_failed_migration_rolls_back_version_record(
+    postgres_dsn: str,
+    tmp_path: Path,
+) -> None:
+    migrations_path = tmp_path / "migrations"
+    write_migration(migrations_path, "0001_bad.sql", "CREATE TABLE broken (")
+    runner = MigrationRunner(migrations_path=migrations_path)
+
+    with pytest.raises(MigrationError) as exc_info:
+        runner.apply_pending(postgres_dsn)
+
+    assert exc_info.value.version == "0001"
+    assert "CREATE TABLE broken" in exc_info.value.sql
+    assert fetch_scalar(postgres_dsn, "SELECT count(*) FROM dp_schema_migrations") == 0
+
+
+def test_concurrent_runners_serialize_with_advisory_lock(
+    postgres_dsn: str,
+    tmp_path: Path,
+) -> None:
+    migrations_path = tmp_path / "migrations"
+    write_migration(
+        migrations_path,
+        "0001_init.sql",
+        "SELECT pg_sleep(0.2); CREATE SCHEMA IF NOT EXISTS data_platform;",
+    )
+    runner = MigrationRunner(migrations_path=migrations_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(runner.apply_pending, postgres_dsn) for _ in range(2)]
+        results = [future.result(timeout=10) for future in futures]
+
+    assert sorted(results) == [[], ["0001"]]
+    assert fetch_versions(postgres_dsn) == ["0001"]


### PR DESCRIPTION
Closes #4

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/config/settings.py`, `src/data_platform/raw/writer.py`, `tests/dbt/test_dbt_skeleton.py`


---
## 背景与目标
项目文档 §10.2 与 §15 指定 PostgreSQL 承载控制表、队列与 Iceberg PG-backed catalog。本 issue 建立基于 SQLAlchemy + 顺序 SQL migration 文件的迁移框架，所有后续表（cycle 控制表、队列表、catalog 表）共享同一 migration runner，保证 §11.1 中 "单 PG 事务冻结" 的依赖关系干净落地。

## 所属模块
data_platform.ddl

## 实现范围
- 新建 `src/data_platform/ddl/migrations/` 存放 `NNNN_<name>.sql` 文件
- 新建 `src/data_platform/ddl/runner.py`：实现 `MigrationRunner.apply_pending(dsn) -> list[str]`
- 在 PG 中自动创建元数据表 `dp_schema_migrations(version TEXT PRIMARY KEY, applied_at TIMESTAMPTZ DEFAULT now())`
- 提供 CLI 入口 `python -m data_platform.ddl.runner --upgrade`
- 第一份迁移 `0001_init.sql`：`CREATE SCHEMA IF NOT EXISTS data_platform;`
- 单测使用 `pytest-postgresql` 或 docker compose 启动的 PG 验证 idempotency

## 不在本次范围
- 不创建业务表（cycle / queue 留给 #29 等）
- 不实现 down migration（Lite 阶段不要求）
- 不引入 alembic（保持 Lite 简单）

## 关键交付物
- `MigrationRunner` 类：方法 `apply_pending(dsn: str) -> list[str]` 返回新应用的 version 列表
- 文件命名规范：`NNNN_<snake_case>.sql`，4 位数字递增
- CLI：`python -m data_platform.ddl.runner --upgrade [--dry-run]`
- 错误处理：单个迁移失败时回滚事务并抛出 `MigrationError(version, sql, cause)`
- 测试：重复执行不重复应用、并发 lock 通过 `pg_advisory_lock(91234)`

## 验收标准
- [ ] 在空 PG 上 `python -m data_platform.ddl.runner --upgrade` 创建 `dp_schema_migrations` 与 schema `data_platform`
- [ ] 第二次执行返回空列表且不报错
- [ ] 迁移 SQL 中 syntax error 时整体回滚，`dp_schema_migrations` 不留半提交记录
- [ ] 并发两个 runner 进程串行执行（advisory lock 验证）
- [ ] `pytest tests/ddl/` 全部通过

## 验证命令
```bash
cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
docker run -d --rm --name dp-pg -e POSTGRES_PASSWORD=dp -p 5433:5432 postgres:16
sleep 3
DP_PG_DSN="postgresql://postgres:dp@localhost:5433/postgres" python -m data_platform.ddl.runner --upgrade
DP_PG_DSN="postgresql://postgres:dp@localhost:5433/postgres" python -m data_platform.ddl.runner --upgrade
psql "postgresql://postgres:dp@localhost:5433/postgres" -c "select * from dp_schema_migrations;"
docker rm -f dp-pg
```

## 依赖
依赖 #3（配置加载）