### PR TITLE
feat(#5): PG-backed Iceberg SQL Catalog 初始化

### DIFF
--- a/docs/runbook/iceberg-catalog.md
+++ b/docs/runbook/iceberg-catalog.md
@@ -1,0 +1,41 @@
+# Iceberg Catalog Runbook
+
+data-platform Lite mode uses a PyIceberg SQL catalog backed by the same
+PostgreSQL instance as the queue and control tables. The catalog stores only
+Iceberg metadata tables with the `iceberg_` prefix, currently
+`iceberg_tables` and `iceberg_namespace_properties`.
+
+Raw Zone files are not registered in Iceberg. The init command creates only
+these namespaces:
+
+- `canonical`
+- `formal`
+- `analytical`
+
+## Initialize Locally
+
+```bash
+cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+mkdir -p /tmp/dp_warehouse
+DP_ICEBERG_WAREHOUSE_PATH=/tmp/dp_warehouse \
+DP_PG_DSN="postgresql://postgres:dp@localhost:5433/postgres" \
+  python scripts/init_iceberg_catalog.py
+```
+
+The command is idempotent. Re-running it keeps the existing catalog tables and
+namespaces in place without creating duplicates.
+
+## Verify
+
+```bash
+python -c "from data_platform.serving.catalog import load_catalog; print(load_catalog().list_namespaces())"
+```
+
+Expected namespaces:
+
+```python
+[("canonical",), ("formal",), ("analytical",)]
+```
+
+There must be no `raw` namespace. Raw Zone archives remain plain Parquet or
+JSON files outside the Iceberg catalog.

--- a/scripts/init_iceberg_catalog.py
+++ b/scripts/init_iceberg_catalog.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Initialize the PG-backed Iceberg SQL catalog namespaces."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from data_platform.serving.catalog import (  # noqa: E402
+    DEFAULT_NAMESPACES,
+    ensure_namespaces,
+    load_catalog,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Initialize data-platform Iceberg catalog namespaces."
+    )
+    parser.parse_args(argv)
+
+    try:
+        catalog = load_catalog()
+        ensure_namespaces(catalog, DEFAULT_NAMESPACES)
+    except Exception as exc:
+        print(f"failed to initialize Iceberg catalog: {exc}", file=sys.stderr)
+        return 1
+
+    print("initialized Iceberg namespaces: canonical, formal, analytical")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data_platform/serving/catalog.py
+++ b/src/data_platform/serving/catalog.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+import os
 from pathlib import Path
 from typing import Final
 
+from pydantic import ValidationError
+from pyiceberg.catalog import Catalog
 from pyiceberg.catalog.sql import SqlCatalog
 from pyiceberg.typedef import Identifier
 from sqlalchemy.exc import SQLAlchemyError
@@ -43,11 +46,11 @@ SQL_CATALOG_CLASS: type[SqlCatalog] = DataPlatformSqlCatalog
 def load_catalog(name: str | None = None) -> SqlCatalog:
     """Load the project PG-backed PyIceberg SQL catalog."""
 
-    settings = get_settings()
-    catalog_name = name or settings.iceberg_catalog_name
+    pg_dsn, configured_catalog_name, warehouse_path = _catalog_config()
+    catalog_name = name or configured_catalog_name
     properties = {
-        "uri": _sqlalchemy_postgres_uri(str(settings.pg_dsn)),
-        "warehouse": _warehouse_location(settings.iceberg_warehouse_path),
+        "uri": _sqlalchemy_postgres_uri(pg_dsn),
+        "warehouse": _warehouse_location(warehouse_path),
         "pool_pre_ping": "true",
         "init_catalog_tables": "true",
     }
@@ -58,14 +61,74 @@ def load_catalog(name: str | None = None) -> SqlCatalog:
         raise CatalogConnectError(str(exc)) from exc
 
 
-def ensure_namespaces(catalog: SqlCatalog, names: Iterable[str]) -> None:
+def ensure_namespaces(catalog: SqlCatalog, names: Iterable[str | Identifier]) -> None:
     """Create Iceberg namespaces idempotently, excluding Raw Zone by contract."""
 
     for namespace in names:
-        if namespace == RAW_NAMESPACE:
+        normalized_namespace = _normalize_namespace_identifier(namespace)
+        if normalized_namespace[0].lower() == RAW_NAMESPACE:
             msg = "raw namespace must not be created in the Iceberg catalog"
             raise ValueError(msg)
-        catalog.create_namespace_if_not_exists(namespace)
+        try:
+            catalog.create_namespace_if_not_exists(normalized_namespace)
+        except SQLAlchemyError as exc:
+            if _namespace_exists_after_create_error(catalog, normalized_namespace, exc):
+                continue
+            raise
+
+
+def _catalog_config() -> tuple[str, str, Path]:
+    try:
+        settings = get_settings()
+    except ValidationError as exc:
+        jdbc_config = _jdbc_catalog_config_from_env(exc)
+        if jdbc_config is None:
+            raise
+        return jdbc_config
+
+    return (
+        str(settings.pg_dsn),
+        settings.iceberg_catalog_name,
+        settings.iceberg_warehouse_path,
+    )
+
+
+def _jdbc_catalog_config_from_env(
+    validation_error: ValidationError,
+) -> tuple[str, str, Path] | None:
+    raw_pg_dsn = os.environ.get("DP_PG_DSN")
+    warehouse_path = os.environ.get("DP_ICEBERG_WAREHOUSE_PATH")
+    if not raw_pg_dsn or not raw_pg_dsn.startswith("jdbc:postgresql://"):
+        return None
+    if not warehouse_path:
+        return None
+    if not _validation_error_includes_field(validation_error, "pg_dsn"):
+        return None
+
+    catalog_name = os.environ.get("DP_ICEBERG_CATALOG_NAME", "data_platform")
+    return raw_pg_dsn, catalog_name, Path(warehouse_path)
+
+
+def _validation_error_includes_field(error: ValidationError, field_name: str) -> bool:
+    return any(
+        error_detail.get("loc") == (field_name,) for error_detail in error.errors()
+    )
+
+
+def _normalize_namespace_identifier(namespace: str | Identifier) -> Identifier:
+    namespace_string = Catalog.namespace_to_string(namespace)
+    return tuple(namespace_string.split("."))
+
+
+def _namespace_exists_after_create_error(
+    catalog: SqlCatalog,
+    namespace: Identifier,
+    create_error: SQLAlchemyError,
+) -> bool:
+    try:
+        return catalog.namespace_exists(namespace)
+    except SQLAlchemyError as lookup_error:
+        raise create_error from lookup_error
 
 
 def _sqlalchemy_postgres_uri(dsn: str) -> str:

--- a/src/data_platform/serving/catalog.py
+++ b/src/data_platform/serving/catalog.py
@@ -1,0 +1,90 @@
+"""PyIceberg SQL catalog wiring for Canonical/Formal/Analytical zones."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Final
+
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.typedef import Identifier
+from sqlalchemy.exc import SQLAlchemyError
+
+from data_platform.config import get_settings
+
+
+DEFAULT_NAMESPACES: Final[tuple[str, str, str]] = ("canonical", "formal", "analytical")
+DEFAULT_NAMESPACE_IDENTIFIERS: Final[tuple[Identifier, ...]] = tuple(
+    (namespace,) for namespace in DEFAULT_NAMESPACES
+)
+CATALOG_TABLE_PREFIX: Final[str] = "iceberg_"
+RAW_NAMESPACE: Final[str] = "raw"
+
+
+class CatalogConnectError(RuntimeError):
+    """Raised when the configured Iceberg SQL catalog cannot be reached."""
+
+    def __init__(self, detail: str) -> None:
+        self.detail = detail
+        super().__init__(f"failed to connect to Iceberg SQL catalog: {detail}")
+
+
+class DataPlatformSqlCatalog(SqlCatalog):
+    """Project catalog with stable namespace ordering for runbook checks."""
+
+    def list_namespaces(self, namespace: str | Identifier = ()) -> list[Identifier]:
+        namespaces = super().list_namespaces(namespace)
+        return sorted(namespaces, key=_namespace_sort_key)
+
+
+SQL_CATALOG_CLASS: type[SqlCatalog] = DataPlatformSqlCatalog
+
+
+def load_catalog(name: str | None = None) -> SqlCatalog:
+    """Load the project PG-backed PyIceberg SQL catalog."""
+
+    settings = get_settings()
+    catalog_name = name or settings.iceberg_catalog_name
+    properties = {
+        "uri": _sqlalchemy_postgres_uri(str(settings.pg_dsn)),
+        "warehouse": _warehouse_location(settings.iceberg_warehouse_path),
+        "pool_pre_ping": "true",
+        "init_catalog_tables": "true",
+    }
+
+    try:
+        return SQL_CATALOG_CLASS(catalog_name, **properties)
+    except SQLAlchemyError as exc:
+        raise CatalogConnectError(str(exc)) from exc
+
+
+def ensure_namespaces(catalog: SqlCatalog, names: Iterable[str]) -> None:
+    """Create Iceberg namespaces idempotently, excluding Raw Zone by contract."""
+
+    for namespace in names:
+        if namespace == RAW_NAMESPACE:
+            msg = "raw namespace must not be created in the Iceberg catalog"
+            raise ValueError(msg)
+        catalog.create_namespace_if_not_exists(namespace)
+
+
+def _sqlalchemy_postgres_uri(dsn: str) -> str:
+    if dsn.startswith("jdbc:postgresql://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("jdbc:postgresql://")
+    if dsn.startswith("postgresql://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgresql://")
+    if dsn.startswith("postgres://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgres://")
+    return dsn
+
+
+def _warehouse_location(path: Path) -> str:
+    return str(path.expanduser())
+
+
+def _namespace_sort_key(namespace: Identifier) -> tuple[int, str]:
+    try:
+        default_index = DEFAULT_NAMESPACE_IDENTIFIERS.index(namespace)
+    except ValueError:
+        default_index = len(DEFAULT_NAMESPACE_IDENTIFIERS)
+    return (default_index, ".".join(namespace))

--- a/tests/serving/test_catalog.py
+++ b/tests/serving/test_catalog.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import importlib.util
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from data_platform.config import reset_settings_cache
+from data_platform.serving import catalog as catalog_module
+from data_platform.serving.catalog import (
+    DEFAULT_NAMESPACES,
+    CatalogConnectError,
+    ensure_namespaces,
+    load_catalog,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DP_ENV_KEYS = [
+    "DP_PG_DSN",
+    "DP_RAW_ZONE_PATH",
+    "DP_ICEBERG_WAREHOUSE_PATH",
+    "DP_DUCKDB_PATH",
+    "DP_ICEBERG_CATALOG_NAME",
+    "DP_ENV",
+]
+
+
+class FakeCatalog:
+    def __init__(self) -> None:
+        self.namespaces: list[str] = []
+        self.create_calls: list[str] = []
+
+    def create_namespace_if_not_exists(self, namespace: str) -> None:
+        self.create_calls.append(namespace)
+        if namespace not in self.namespaces:
+            self.namespaces.append(namespace)
+
+    def list_namespaces(self) -> list[tuple[str, ...]]:
+        return [(namespace,) for namespace in self.namespaces]
+
+
+@pytest.fixture(autouse=True)
+def isolated_settings_cache(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
+    reset_settings_cache()
+    for key in DP_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    yield
+    reset_settings_cache()
+
+
+def set_required_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DP_PG_DSN", "postgresql://user:pass@localhost/data_platform")
+    monkeypatch.setenv("DP_RAW_ZONE_PATH", str(tmp_path / "raw"))
+    monkeypatch.setenv("DP_ICEBERG_WAREHOUSE_PATH", str(tmp_path / "warehouse"))
+    monkeypatch.setenv("DP_DUCKDB_PATH", str(tmp_path / "duckdb" / "data_platform.duckdb"))
+
+
+def test_ensure_namespaces_is_idempotent_and_does_not_create_raw() -> None:
+    catalog = FakeCatalog()
+
+    ensure_namespaces(catalog, DEFAULT_NAMESPACES)  # type: ignore[arg-type]
+    ensure_namespaces(catalog, DEFAULT_NAMESPACES)  # type: ignore[arg-type]
+
+    assert catalog.list_namespaces() == [("canonical",), ("formal",), ("analytical",)]
+    assert "raw" not in [namespace[0] for namespace in catalog.list_namespaces()]
+    assert catalog.create_calls == [
+        "canonical",
+        "formal",
+        "analytical",
+        "canonical",
+        "formal",
+        "analytical",
+    ]
+
+
+def test_ensure_namespaces_rejects_raw_namespace() -> None:
+    catalog = FakeCatalog()
+
+    with pytest.raises(ValueError, match="raw namespace"):
+        ensure_namespaces(catalog, ["raw"])  # type: ignore[arg-type]
+
+    assert catalog.list_namespaces() == []
+
+
+def test_load_catalog_uses_configured_name_uri_and_warehouse(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    set_required_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("DP_ICEBERG_CATALOG_NAME", "configured_catalog")
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    class CapturingCatalog:
+        def __init__(self, name: str, **properties: str) -> None:
+            self.name = name
+            self.properties = properties
+            calls.append((name, properties))
+
+    monkeypatch.setattr(catalog_module, "SQL_CATALOG_CLASS", CapturingCatalog)
+
+    catalog = load_catalog()
+
+    assert isinstance(catalog, CapturingCatalog)
+    assert calls == [
+        (
+            "configured_catalog",
+            {
+                "uri": "postgresql+psycopg://user:pass@localhost/data_platform",
+                "warehouse": str(tmp_path / "warehouse"),
+                "pool_pre_ping": "true",
+                "init_catalog_tables": "true",
+            },
+        )
+    ]
+
+
+def test_load_catalog_name_argument_overrides_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    set_required_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("DP_ICEBERG_CATALOG_NAME", "configured_catalog")
+    calls: list[str] = []
+
+    class CapturingCatalog:
+        def __init__(self, name: str, **properties: str) -> None:
+            calls.append(name)
+
+    monkeypatch.setattr(catalog_module, "SQL_CATALOG_CLASS", CapturingCatalog)
+
+    load_catalog("override_catalog")
+
+    assert calls == ["override_catalog"]
+
+
+def test_load_catalog_wraps_sqlalchemy_connection_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    set_required_env(monkeypatch, tmp_path)
+
+    class BrokenCatalog:
+        def __init__(self, name: str, **properties: str) -> None:
+            raise SQLAlchemyError("database unavailable")
+
+    monkeypatch.setattr(catalog_module, "SQL_CATALOG_CLASS", BrokenCatalog)
+
+    with pytest.raises(CatalogConnectError) as exc_info:
+        load_catalog()
+
+    assert "database unavailable" in exc_info.value.detail
+
+
+def test_sqlalchemy_postgres_uri_supports_plain_and_jdbc_dsn() -> None:
+    assert (
+        catalog_module._sqlalchemy_postgres_uri("postgresql://user:pass@host:5432/db")
+        == "postgresql+psycopg://user:pass@host:5432/db"
+    )
+    assert (
+        catalog_module._sqlalchemy_postgres_uri("postgres://user:pass@host:5432/db")
+        == "postgresql+psycopg://user:pass@host:5432/db"
+    )
+    assert (
+        catalog_module._sqlalchemy_postgres_uri("jdbc:postgresql://user:pass@host:5432/db")
+        == "postgresql+psycopg://user:pass@host:5432/db"
+    )
+    assert (
+        catalog_module._sqlalchemy_postgres_uri("postgresql+psycopg://user:pass@host:5432/db")
+        == "postgresql+psycopg://user:pass@host:5432/db"
+    )
+
+
+def test_namespace_sort_key_keeps_default_namespaces_in_acceptance_order() -> None:
+    unordered = [("canonical",), ("analytical",), ("raw",), ("formal",)]
+
+    assert sorted(unordered, key=catalog_module._namespace_sort_key) == [
+        ("canonical",),
+        ("formal",),
+        ("analytical",),
+        ("raw",),
+    ]
+
+
+def test_init_iceberg_catalog_cli_returns_zero_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_init_script()
+    fake_catalog = object()
+    calls: list[tuple[object, tuple[str, ...]]] = []
+
+    monkeypatch.setattr(module, "load_catalog", lambda: fake_catalog)
+    monkeypatch.setattr(
+        module,
+        "ensure_namespaces",
+        lambda catalog, names: calls.append((catalog, tuple(names))),
+    )
+
+    assert module.main([]) == 0
+    assert calls == [(fake_catalog, DEFAULT_NAMESPACES)]
+
+
+def test_init_iceberg_catalog_cli_returns_one_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_init_script()
+
+    def fail_to_load() -> object:
+        raise CatalogConnectError("database unavailable")
+
+    monkeypatch.setattr(module, "load_catalog", fail_to_load)
+
+    assert module.main([]) == 1
+    assert "failed to initialize Iceberg catalog" in capsys.readouterr().err
+
+
+def load_init_script() -> object:
+    script_path = PROJECT_ROOT / "scripts" / "init_iceberg_catalog.py"
+    spec = importlib.util.spec_from_file_location("init_iceberg_catalog", script_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed to load init_iceberg_catalog.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/serving/test_catalog.py
+++ b/tests/serving/test_catalog.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import importlib.util
 from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier, Lock
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError
 
 from data_platform.config import reset_settings_cache
 from data_platform.serving import catalog as catalog_module
@@ -30,16 +33,16 @@ DP_ENV_KEYS = [
 
 class FakeCatalog:
     def __init__(self) -> None:
-        self.namespaces: list[str] = []
-        self.create_calls: list[str] = []
+        self.namespaces: list[tuple[str, ...]] = []
+        self.create_calls: list[tuple[str, ...]] = []
 
-    def create_namespace_if_not_exists(self, namespace: str) -> None:
+    def create_namespace_if_not_exists(self, namespace: tuple[str, ...]) -> None:
         self.create_calls.append(namespace)
         if namespace not in self.namespaces:
             self.namespaces.append(namespace)
 
     def list_namespaces(self) -> list[tuple[str, ...]]:
-        return [(namespace,) for namespace in self.namespaces]
+        return self.namespaces
 
 
 @pytest.fixture(autouse=True)
@@ -67,12 +70,12 @@ def test_ensure_namespaces_is_idempotent_and_does_not_create_raw() -> None:
     assert catalog.list_namespaces() == [("canonical",), ("formal",), ("analytical",)]
     assert "raw" not in [namespace[0] for namespace in catalog.list_namespaces()]
     assert catalog.create_calls == [
-        "canonical",
-        "formal",
-        "analytical",
-        "canonical",
-        "formal",
-        "analytical",
+        ("canonical",),
+        ("formal",),
+        ("analytical",),
+        ("canonical",),
+        ("formal",),
+        ("analytical",),
     ]
 
 
@@ -83,6 +86,65 @@ def test_ensure_namespaces_rejects_raw_namespace() -> None:
         ensure_namespaces(catalog, ["raw"])  # type: ignore[arg-type]
 
     assert catalog.list_namespaces() == []
+
+
+@pytest.mark.parametrize(
+    "namespace",
+    [
+        " raw ",
+        "raw.child",
+        ("raw", "child"),
+        (" raw ", "child"),
+    ],
+)
+def test_ensure_namespaces_rejects_normalized_raw_namespace(
+    namespace: str | tuple[str, ...],
+) -> None:
+    catalog = FakeCatalog()
+
+    with pytest.raises(ValueError, match="raw namespace"):
+        ensure_namespaces(catalog, [namespace])  # type: ignore[arg-type]
+
+    assert catalog.list_namespaces() == []
+
+
+def test_ensure_namespaces_suppresses_concurrent_duplicate_create() -> None:
+    barrier = Barrier(2)
+    lock = Lock()
+    shared_namespaces: set[tuple[str, ...]] = set()
+
+    class RacingCatalog:
+        def __init__(self) -> None:
+            self.create_calls: list[tuple[str, ...]] = []
+
+        def create_namespace_if_not_exists(self, namespace: tuple[str, ...]) -> None:
+            self.create_calls.append(namespace)
+            if namespace in shared_namespaces:
+                return
+            barrier.wait(timeout=5)
+            with lock:
+                if namespace in shared_namespaces:
+                    raise IntegrityError("insert namespace", {}, Exception("duplicate"))
+                shared_namespaces.add(namespace)
+
+        def namespace_exists(self, namespace: tuple[str, ...]) -> bool:
+            return namespace in shared_namespaces
+
+    catalogs = [RacingCatalog(), RacingCatalog()]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(ensure_namespaces, racing_catalog, ["canonical"])
+            for racing_catalog in catalogs
+        ]
+        for future in futures:
+            future.result(timeout=5)
+
+    assert shared_namespaces == {("canonical",)}
+    assert [catalog.create_calls for catalog in catalogs] == [
+        [("canonical",)],
+        [("canonical",)],
+    ]
 
 
 def test_load_catalog_uses_configured_name_uri_and_warehouse(
@@ -109,6 +171,35 @@ def test_load_catalog_uses_configured_name_uri_and_warehouse(
             "configured_catalog",
             {
                 "uri": "postgresql+psycopg://user:pass@localhost/data_platform",
+                "warehouse": str(tmp_path / "warehouse"),
+                "pool_pre_ping": "true",
+                "init_catalog_tables": "true",
+            },
+        )
+    ]
+
+
+def test_load_catalog_accepts_jdbc_dsn_from_dp_pg_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    set_required_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("DP_PG_DSN", "jdbc:postgresql://user:pass@host:5432/data_platform")
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    class CapturingCatalog:
+        def __init__(self, name: str, **properties: str) -> None:
+            calls.append((name, properties))
+
+    monkeypatch.setattr(catalog_module, "SQL_CATALOG_CLASS", CapturingCatalog)
+
+    load_catalog()
+
+    assert calls == [
+        (
+            "data_platform",
+            {
+                "uri": "postgresql+psycopg://user:pass@host:5432/data_platform",
                 "warehouse": str(tmp_path / "warehouse"),
                 "pool_pre_ping": "true",
                 "init_catalog_tables": "true",


### PR DESCRIPTION
Closes #5

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/base.py`, `src/data_platform/config/settings.py`, `src/data_platform/ddl/runner.py`, `src/data_platform/raw/writer.py`, `tests/dbt/test_dbt_skeleton.py`, `tests/test_config.py`


---
## 背景与目标
项目文档 §10.2 与 §15 明确 Lite 模式 Iceberg catalog 选型为 PG-backed SQL catalog，复用同一 PostgreSQL。本 issue 通过 PyIceberg 创建 catalog、声明 namespace（`canonical`、`formal`、`analytical`），为 #6~#14 的 Iceberg 写入与查询提供基底。注意 Raw Zone 不进入 catalog（§3 / §6.2 约束）。

## 所属模块
data_platform.ddl + data_platform.serving.catalog

## 实现范围
- 新建 `src/data_platform/serving/catalog.py`：函数 `load_catalog() -> SqlCatalog`，配置 uri、warehouse、jdbc 兼容
- 新建 `scripts/init_iceberg_catalog.py` CLI：调用 `catalog.create_namespace_if_not_exists("canonical")` 等
- 创建 namespace：`canonical`、`formal`、`analytical`（不创建 `raw`）
- 在 `tests/serving/test_catalog.py` 验证 namespace 创建幂等
- 写入 `docs/runbook/iceberg-catalog.md` 简短说明

## 不在本次范围
- 不创建任何具体表（留给 #7 / #12）
- 不实现 catalog 升级或迁移
- 不接入 S3 / MinIO（Lite 用本地文件 warehouse）

## 关键交付物
- 函数签名 `def load_catalog(name: str | None = None) -> SqlCatalog`
- 创建 namespace 的幂等函数 `def ensure_namespaces(catalog: SqlCatalog, names: Iterable[str]) -> None`
- CLI 退出码：成功 0、失败 1
- catalog SQL 表前缀使用 `iceberg_` 避免与业务表冲突
- 错误处理：catalog uri 不可达时抛 `CatalogConnectError(detail)`

## 验收标准
- [ ] CLI 在空 PG + 空 warehouse 上运行成功，PG 中出现 `iceberg_*` 元数据表
- [ ] 重复运行 CLI 不报错且不重复创建 namespace
- [ ] `catalog.list_namespaces()` 返回 `[(canonical,), (formal,), (analytical,)]`
- [ ] 不存在名为 `raw` 的 namespace（边界守护）
- [ ] `pytest tests/serving/test_catalog.py` 通过

## 验证命令
```bash
cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
mkdir -p /tmp/dp_warehouse
DP_ICEBERG_WAREHOUSE_PATH=/tmp/dp_warehouse \
DP_PG_DSN="postgresql://postgres:dp@localhost:5433/postgres" \
  python scripts/init_iceberg_catalog.py
python -c "from data_platform.serving.catalog import load_catalog; print(load_catalog().list_namespaces())"
```

## 依赖
依赖 #4（PG 迁移已就绪）