### PR TITLE
feat(#9): Tushare adapter 最小实现（stock_basic 单 API）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pydantic-settings>=2,<3",
     "pandas>=2,<3",
     "pyarrow>=15,<30",
+    "tushare>=1.4,<2",
 ]
 
 [project.optional-dependencies]

--- a/src/data_platform/adapters/tushare/__init__.py
+++ b/src/data_platform/adapters/tushare/__init__.py
@@ -1,0 +1,39 @@
+"""Tushare adapter package."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from data_platform.adapters.tushare.assets import (
+    TUSHARE_ASSETS,
+    TUSHARE_STOCK_BASIC_ASSET,
+    TUSHARE_STOCK_BASIC_ASSET_NAME,
+    TUSHARE_STOCK_BASIC_FIELDS,
+    TUSHARE_STOCK_BASIC_SCHEMA,
+)
+
+if TYPE_CHECKING:
+    from data_platform.adapters.tushare.adapter import AdapterConfigError, TushareAdapter
+
+
+def __getattr__(name: str) -> Any:
+    if name == "AdapterConfigError":
+        from data_platform.adapters.tushare.adapter import AdapterConfigError
+
+        return AdapterConfigError
+    if name == "TushareAdapter":
+        from data_platform.adapters.tushare.adapter import TushareAdapter
+
+        return TushareAdapter
+    raise AttributeError(name)
+
+
+__all__ = [
+    "AdapterConfigError",
+    "TUSHARE_ASSETS",
+    "TUSHARE_STOCK_BASIC_ASSET",
+    "TUSHARE_STOCK_BASIC_ASSET_NAME",
+    "TUSHARE_STOCK_BASIC_FIELDS",
+    "TUSHARE_STOCK_BASIC_SCHEMA",
+    "TushareAdapter",
+]

--- a/src/data_platform/adapters/tushare/adapter.py
+++ b/src/data_platform/adapters/tushare/adapter.py
@@ -1,0 +1,214 @@
+"""Minimal Tushare adapter for the stock_basic API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import uuid
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime
+from typing import Any, Protocol, cast
+
+import pyarrow as pa  # type: ignore[import-untyped]
+
+from data_platform.adapters.base import AssetSpec, BaseAdapter, FetchParams, QuotaConfig
+from data_platform.adapters.tushare.assets import (
+    TUSHARE_ASSETS,
+    TUSHARE_STOCK_BASIC_ASSET_NAME,
+    TUSHARE_STOCK_BASIC_FIELDS,
+    TUSHARE_STOCK_BASIC_FIELDS_CSV,
+    TUSHARE_STOCK_BASIC_SCHEMA,
+)
+from data_platform.raw import RawArtifact, RawWriter
+
+TOKEN_ENV_VAR = "DP_TUSHARE_TOKEN"
+
+
+class AdapterConfigError(RuntimeError):
+    """Raised when an adapter is missing required runtime configuration."""
+
+
+class _TushareClient(Protocol):
+    def stock_basic(self, **kwargs: Any) -> Any:
+        """Return stock_basic rows from Tushare Pro."""
+
+
+class TushareAdapter(BaseAdapter):
+    """Tushare reference adapter exposing only the stock_basic asset."""
+
+    def __init__(
+        self,
+        *,
+        token: str | None = None,
+        client: _TushareClient | None = None,
+        max_retries: int = 3,
+    ) -> None:
+        resolved_token = token or os.environ.get(TOKEN_ENV_VAR)
+        if not resolved_token:
+            msg = f"{TOKEN_ENV_VAR} is required for the Tushare adapter"
+            raise AdapterConfigError(msg)
+
+        self._token = resolved_token
+        self._client = client
+        self._quota_config = QuotaConfig(requests_per_minute=200, daily_credit_quota=None)
+        super().__init__(max_retries=max_retries)
+
+    def source_id(self) -> str:
+        return "tushare"
+
+    def get_assets(self) -> list[AssetSpec]:
+        return list(TUSHARE_ASSETS)
+
+    def get_resources(self) -> dict[str, Any]:
+        return {"token_env": TOKEN_ENV_VAR}
+
+    def get_staging_dbt_models(self) -> list[str]:
+        return ["stg_stock_basic"]
+
+    def get_quota_config(self) -> QuotaConfig:
+        return self._quota_config
+
+    def _fetch(self, asset_id: str, params: FetchParams) -> pa.Table:
+        if asset_id != TUSHARE_STOCK_BASIC_ASSET_NAME:
+            msg = f"unsupported Tushare asset: {asset_id!r}"
+            raise ValueError(msg)
+
+        request_params = dict(params)
+        request_params["fields"] = TUSHARE_STOCK_BASIC_FIELDS_CSV
+
+        result = self._get_client().stock_basic(**request_params)
+        return _to_stock_basic_table(result)
+
+    def _get_client(self) -> _TushareClient:
+        if self._client is not None:
+            return self._client
+
+        try:
+            import tushare as ts  # type: ignore[import-not-found]
+        except ModuleNotFoundError as exc:
+            msg = "tushare>=1.4 is required to fetch Tushare assets"
+            raise AdapterConfigError(msg) from exc
+
+        client = cast(_TushareClient, ts.pro_api(self._token))
+        self._client = client
+        return client
+
+
+def run_stock_basic(asset_id: str, partition_date: date) -> RawArtifact:
+    """Fetch a Tushare asset and write it as a Raw Zone Parquet artifact."""
+
+    adapter = TushareAdapter()
+    asset = _asset_by_name(adapter, asset_id)
+    table = adapter.fetch(asset.name, {})
+
+    if not isinstance(table, pa.Table):
+        msg = f"Tushare fetch returned unsupported result for asset={asset.name!r}"
+        raise TypeError(msg)
+
+    return RawWriter().write_arrow(
+        adapter.source_id(),
+        asset.dataset,
+        partition_date,
+        str(uuid.uuid4()),
+        table,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fetch Tushare assets into the Raw Zone.")
+    parser.add_argument("--asset", required=True)
+    parser.add_argument("--date", required=True, help="Raw partition date in YYYYMMDD format.")
+    args = parser.parse_args(argv)
+
+    try:
+        partition_date = _parse_partition_date(args.date)
+        artifact = run_stock_basic(args.asset, partition_date)
+    except Exception as exc:
+        _print_error(exc, args.asset)
+        return 1
+
+    print(artifact.path)
+    return 0
+
+
+def _asset_by_name(adapter: TushareAdapter, asset_id: str) -> AssetSpec:
+    for asset in adapter.get_assets():
+        if asset.name == asset_id:
+            return asset
+    msg = f"unsupported Tushare asset: {asset_id!r}"
+    raise ValueError(msg)
+
+
+def _parse_partition_date(value: str) -> date:
+    try:
+        return datetime.strptime(value, "%Y%m%d").date()
+    except ValueError as exc:
+        msg = f"date must use YYYYMMDD format: {value!r}"
+        raise ValueError(msg) from exc
+
+
+def _to_stock_basic_table(value: Any) -> pa.Table:
+    if isinstance(value, pa.Table):
+        table = _ensure_stock_basic_columns(value)
+        return table.select(TUSHARE_STOCK_BASIC_FIELDS).cast(TUSHARE_STOCK_BASIC_SCHEMA)
+
+    rows = _records_from_result(value)
+    columns = {
+        field_name: [_normalize_string(row.get(field_name)) for row in rows]
+        for field_name in TUSHARE_STOCK_BASIC_FIELDS
+    }
+    return pa.table(columns, schema=TUSHARE_STOCK_BASIC_SCHEMA)
+
+
+def _ensure_stock_basic_columns(table: pa.Table) -> pa.Table:
+    result = table
+    for field in TUSHARE_STOCK_BASIC_SCHEMA:
+        if field.name not in result.column_names:
+            result = result.append_column(
+                field.name,
+                pa.nulls(result.num_rows, type=field.type),
+            )
+    return result
+
+
+def _records_from_result(value: Any) -> list[Mapping[str, Any]]:
+    if isinstance(value, list):
+        return [row for row in value if isinstance(row, Mapping)]
+
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        records = to_dict("records")
+        if isinstance(records, list):
+            return [row for row in records if isinstance(row, Mapping)]
+
+    msg = "Tushare stock_basic result must be a pandas DataFrame, Arrow table, or row list"
+    raise TypeError(msg)
+
+
+def _normalize_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    return str(value)
+
+
+def _print_error(exc: BaseException, asset_id: str) -> None:
+    payload = {"error": str(exc), "asset": asset_id}
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "AdapterConfigError",
+    "TOKEN_ENV_VAR",
+    "TushareAdapter",
+    "main",
+    "run_stock_basic",
+]

--- a/src/data_platform/adapters/tushare/adapter.py
+++ b/src/data_platform/adapters/tushare/adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import uuid
 from collections.abc import Mapping, Sequence
@@ -26,6 +27,7 @@ from data_platform.raw import RawArtifact, RawWriter
 
 TOKEN_ENV_VAR = "DP_TUSHARE_TOKEN"
 STOCK_BASIC_IDENTITY_FIELDS = ("ts_code",)
+STOCK_BASIC_TS_CODE_PATTERN = re.compile(r"\d{6}\.(?:SH|SZ|BJ)")
 
 
 class AdapterConfigError(RuntimeError):
@@ -230,18 +232,38 @@ def _validate_stock_basic_records(rows: Sequence[Mapping[str, Any]]) -> None:
             raise ValueError(msg)
 
         for field_name in STOCK_BASIC_IDENTITY_FIELDS:
-            if _is_nullish(row[field_name]):
-                msg = f"Tushare stock_basic row {index} has null identity field: {field_name}"
-                raise ValueError(msg)
+            _validate_stock_basic_identity_value(row[field_name], index, field_name)
 
 
 def _validate_stock_basic_identity_columns(table: pa.Table) -> None:
     for field_name in STOCK_BASIC_IDENTITY_FIELDS:
         values = table[field_name].to_pylist()
         for index, value in enumerate(values):
-            if _is_nullish(value):
-                msg = f"Tushare stock_basic row {index} has null identity field: {field_name}"
-                raise ValueError(msg)
+            _validate_stock_basic_identity_value(value, index, field_name)
+
+
+def _validate_stock_basic_identity_value(value: Any, row_index: int, field_name: str) -> None:
+    if _is_nullish(value):
+        msg = f"Tushare stock_basic row {row_index} has null identity field: {field_name}"
+        raise ValueError(msg)
+
+    if not pd.api.types.is_scalar(value):
+        msg = (
+            f"Tushare stock_basic row {row_index} has non-scalar identity field: "
+            f"{field_name}"
+        )
+        raise ValueError(msg)
+
+    normalized_value = str(value)
+    if not normalized_value.strip():
+        msg = f"Tushare stock_basic row {row_index} has blank identity field: {field_name}"
+        raise ValueError(msg)
+
+    if normalized_value != normalized_value.strip() or not STOCK_BASIC_TS_CODE_PATTERN.fullmatch(
+        normalized_value
+    ):
+        msg = f"Tushare stock_basic row {row_index} has malformed identity field: {field_name}"
+        raise ValueError(msg)
 
 
 def _normalize_string(value: Any) -> str | None:

--- a/src/data_platform/adapters/tushare/adapter.py
+++ b/src/data_platform/adapters/tushare/adapter.py
@@ -25,6 +25,7 @@ from data_platform.adapters.tushare.assets import (
 from data_platform.raw import RawArtifact, RawWriter
 
 TOKEN_ENV_VAR = "DP_TUSHARE_TOKEN"
+STOCK_BASIC_IDENTITY_FIELDS = ("ts_code",)
 
 
 class AdapterConfigError(RuntimeError):
@@ -87,7 +88,7 @@ class TushareAdapter(BaseAdapter):
             return self._client
 
         try:
-            import tushare as ts  # type: ignore[import-not-found]
+            import tushare as ts  # type: ignore[import-untyped]
         except ModuleNotFoundError as exc:
             msg = "tushare>=1.4 is required to fetch Tushare assets"
             raise AdapterConfigError(msg) from exc
@@ -152,48 +153,105 @@ def _parse_partition_date(value: str) -> date:
 
 def _to_stock_basic_table(value: Any) -> pa.Table:
     if isinstance(value, pa.Table):
-        table = _ensure_stock_basic_columns(value)
-        return table.select(TUSHARE_STOCK_BASIC_FIELDS).cast(TUSHARE_STOCK_BASIC_SCHEMA)
+        _validate_stock_basic_fields(value.column_names)
+        _validate_stock_basic_identity_columns(value)
+        return value.select(TUSHARE_STOCK_BASIC_FIELDS).cast(TUSHARE_STOCK_BASIC_SCHEMA)
+
+    field_names = _field_names_from_result(value)
+    if field_names is not None:
+        _validate_stock_basic_fields(field_names)
 
     rows = _records_from_result(value)
+    _validate_stock_basic_records(rows)
     columns = {
-        field_name: [_normalize_string(row.get(field_name)) for row in rows]
+        field_name: [_normalize_string(row[field_name]) for row in rows]
         for field_name in TUSHARE_STOCK_BASIC_FIELDS
     }
     return pa.table(columns, schema=TUSHARE_STOCK_BASIC_SCHEMA)
 
 
-def _ensure_stock_basic_columns(table: pa.Table) -> pa.Table:
-    result = table
-    for field in TUSHARE_STOCK_BASIC_SCHEMA:
-        if field.name not in result.column_names:
-            result = result.append_column(
-                field.name,
-                pa.nulls(result.num_rows, type=field.type),
-            )
-    return result
+def _validate_stock_basic_fields(field_names: Sequence[str]) -> None:
+    available = set(field_names)
+    missing = [
+        field_name for field_name in TUSHARE_STOCK_BASIC_FIELDS if field_name not in available
+    ]
+    if missing:
+        joined = ", ".join(missing)
+        msg = f"Tushare stock_basic response missing required fields: {joined}"
+        raise ValueError(msg)
+
+
+def _field_names_from_result(value: Any) -> list[str] | None:
+    columns = getattr(value, "columns", None)
+    if columns is None:
+        return None
+
+    try:
+        return [str(field_name) for field_name in columns]
+    except TypeError:
+        return None
 
 
 def _records_from_result(value: Any) -> list[Mapping[str, Any]]:
     if isinstance(value, list):
-        return [row for row in value if isinstance(row, Mapping)]
+        return _coerce_record_list(value)
 
     to_dict = getattr(value, "to_dict", None)
     if callable(to_dict):
         records = to_dict("records")
         if isinstance(records, list):
-            return [row for row in records if isinstance(row, Mapping)]
+            return _coerce_record_list(records)
 
     msg = "Tushare stock_basic result must be a pandas DataFrame, Arrow table, or row list"
     raise TypeError(msg)
 
 
+def _coerce_record_list(rows: list[Any]) -> list[Mapping[str, Any]]:
+    records: list[Mapping[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            msg = (
+                "Tushare stock_basic row "
+                f"{index} must be a mapping, got {type(row).__name__}"
+            )
+            raise TypeError(msg)
+        records.append(row)
+    return records
+
+
+def _validate_stock_basic_records(rows: Sequence[Mapping[str, Any]]) -> None:
+    for index, row in enumerate(rows):
+        missing = [
+            field_name for field_name in TUSHARE_STOCK_BASIC_FIELDS if field_name not in row
+        ]
+        if missing:
+            joined = ", ".join(missing)
+            msg = f"Tushare stock_basic row {index} missing required fields: {joined}"
+            raise ValueError(msg)
+
+        for field_name in STOCK_BASIC_IDENTITY_FIELDS:
+            if _is_nullish(row[field_name]):
+                msg = f"Tushare stock_basic row {index} has null identity field: {field_name}"
+                raise ValueError(msg)
+
+
+def _validate_stock_basic_identity_columns(table: pa.Table) -> None:
+    for field_name in STOCK_BASIC_IDENTITY_FIELDS:
+        values = table[field_name].to_pylist()
+        for index, value in enumerate(values):
+            if _is_nullish(value):
+                msg = f"Tushare stock_basic row {index} has null identity field: {field_name}"
+                raise ValueError(msg)
+
+
 def _normalize_string(value: Any) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, float) and math.isnan(value):
+    if _is_nullish(value):
         return None
     return str(value)
+
+
+def _is_nullish(value: Any) -> bool:
+    return value is None or (isinstance(value, float) and math.isnan(value))
 
 
 def _print_error(exc: BaseException, asset_id: str) -> None:

--- a/src/data_platform/adapters/tushare/adapter.py
+++ b/src/data_platform/adapters/tushare/adapter.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import sys
 import uuid
@@ -13,6 +12,7 @@ from datetime import date, datetime
 from typing import Any, Protocol, cast
 
 import pyarrow as pa  # type: ignore[import-untyped]
+import pandas as pd  # type: ignore[import-untyped]
 
 from data_platform.adapters.base import AssetSpec, BaseAdapter, FetchParams, QuotaConfig
 from data_platform.adapters.tushare.assets import (
@@ -251,7 +251,14 @@ def _normalize_string(value: Any) -> str | None:
 
 
 def _is_nullish(value: Any) -> bool:
-    return value is None or (isinstance(value, float) and math.isnan(value))
+    if value is None:
+        return True
+
+    result = pd.isna(value)
+    try:
+        return bool(result)
+    except (TypeError, ValueError):
+        return False
 
 
 def _print_error(exc: BaseException, asset_id: str) -> None:

--- a/src/data_platform/adapters/tushare/assets.py
+++ b/src/data_platform/adapters/tushare/assets.py
@@ -1,0 +1,52 @@
+"""Asset definitions for the Tushare adapter."""
+
+from __future__ import annotations
+
+import pyarrow as pa  # type: ignore[import-untyped]
+
+from data_platform.adapters.base import AssetSpec
+
+TUSHARE_STOCK_BASIC_ASSET_NAME = "tushare_stock_basic"
+
+TUSHARE_STOCK_BASIC_SCHEMA = pa.schema(
+    [
+        ("ts_code", pa.string()),
+        ("symbol", pa.string()),
+        ("name", pa.string()),
+        ("area", pa.string()),
+        ("industry", pa.string()),
+        ("fullname", pa.string()),
+        ("enname", pa.string()),
+        ("cnspell", pa.string()),
+        ("market", pa.string()),
+        ("exchange", pa.string()),
+        ("curr_type", pa.string()),
+        ("list_status", pa.string()),
+        ("list_date", pa.string()),
+        ("delist_date", pa.string()),
+        ("is_hs", pa.string()),
+        ("act_name", pa.string()),
+        ("act_ent_type", pa.string()),
+    ]
+)
+
+TUSHARE_STOCK_BASIC_FIELDS = tuple(TUSHARE_STOCK_BASIC_SCHEMA.names)
+TUSHARE_STOCK_BASIC_FIELDS_CSV = ",".join(TUSHARE_STOCK_BASIC_FIELDS)
+
+TUSHARE_STOCK_BASIC_ASSET = AssetSpec(
+    name=TUSHARE_STOCK_BASIC_ASSET_NAME,
+    dataset="stock_basic",
+    partition="static",
+    schema=TUSHARE_STOCK_BASIC_SCHEMA,
+)
+
+TUSHARE_ASSETS = [TUSHARE_STOCK_BASIC_ASSET]
+
+__all__ = [
+    "TUSHARE_ASSETS",
+    "TUSHARE_STOCK_BASIC_ASSET",
+    "TUSHARE_STOCK_BASIC_ASSET_NAME",
+    "TUSHARE_STOCK_BASIC_FIELDS",
+    "TUSHARE_STOCK_BASIC_FIELDS_CSV",
+    "TUSHARE_STOCK_BASIC_SCHEMA",
+]

--- a/tests/adapters/test_tushare.py
+++ b/tests/adapters/test_tushare.py
@@ -211,6 +211,29 @@ def test_cli_rejects_null_stock_basic_identity_without_artifact(
     assert list(raw_zone_path.rglob("*.parquet")) == []
 
 
+def test_cli_rejects_pandas_nat_stock_basic_identity_without_artifact(
+    raw_zone_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    frame = _stock_basic_frame(1)
+    frame.loc[0, "ts_code"] = pd.NaT
+    _install_tushare_client(monkeypatch, FakeTushareClient(frame))
+
+    exit_code = tushare_adapter_module.main(
+        ["--asset", "tushare_stock_basic", "--date", "20260415"]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["asset"] == "tushare_stock_basic"
+    assert "null identity field: ts_code" in payload["error"]
+    assert list(raw_zone_path.rglob("*.parquet")) == []
+
+
 def test_cli_missing_token_outputs_json_error(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/adapters/test_tushare.py
+++ b/tests/adapters/test_tushare.py
@@ -19,6 +19,7 @@ from data_platform.adapters.tushare import (  # noqa: E402
 )
 from data_platform.adapters.tushare import adapter as tushare_adapter_module  # noqa: E402
 from data_platform.adapters.tushare.assets import (  # noqa: E402
+    TUSHARE_STOCK_BASIC_FIELDS,
     TUSHARE_STOCK_BASIC_FIELDS_CSV,
 )
 
@@ -33,16 +34,39 @@ class FakeTushareClient:
         return self.frame
 
 
-def _stock_basic_frame(row_count: int) -> Any:
-    return pd.DataFrame(
+def _stock_basic_row(index: int) -> dict[str, Any]:
+    row: dict[str, Any] = {field: f"{field}-{index}" for field in TUSHARE_STOCK_BASIC_FIELDS}
+    row.update(
         {
-            "ts_code": [f"{index:06d}.SZ" for index in range(row_count)],
-            "symbol": [f"{index:06d}" for index in range(row_count)],
-            "name": [f"stock-{index}" for index in range(row_count)],
-            "list_date": ["20260415"] * row_count,
-            "extra_column": ["ignored"] * row_count,
+            "ts_code": f"{index:06d}.SZ",
+            "symbol": f"{index:06d}",
+            "name": f"stock-{index}",
+            "list_date": "20260415",
+            "delist_date": None,
         }
     )
+    return row
+
+
+def _stock_basic_frame(row_count: int) -> Any:
+    frame = pd.DataFrame([_stock_basic_row(index) for index in range(row_count)])
+    frame["extra_column"] = ["ignored"] * row_count
+    return frame
+
+
+def _install_tushare_client(
+    monkeypatch: pytest.MonkeyPatch,
+    client: FakeTushareClient,
+) -> list[str]:
+    tokens: list[str] = []
+
+    def pro_api(token: str) -> FakeTushareClient:
+        tokens.append(token)
+        return client
+
+    monkeypatch.setenv("DP_TUSHARE_TOKEN", "test-token")
+    monkeypatch.setitem(sys.modules, "tushare", SimpleNamespace(pro_api=pro_api))
+    return tokens
 
 
 @pytest.fixture
@@ -99,14 +123,7 @@ def test_cli_writes_stock_basic_parquet_artifact(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     client = FakeTushareClient(_stock_basic_frame(5_000))
-    tokens: list[str] = []
-
-    def pro_api(token: str) -> FakeTushareClient:
-        tokens.append(token)
-        return client
-
-    monkeypatch.setenv("DP_TUSHARE_TOKEN", "test-token")
-    monkeypatch.setitem(sys.modules, "tushare", SimpleNamespace(pro_api=pro_api))
+    tokens = _install_tushare_client(monkeypatch, client)
 
     exit_code = tushare_adapter_module.main(
         ["--asset", "tushare_stock_basic", "--date", "20260415"]
@@ -122,6 +139,76 @@ def test_cli_writes_stock_basic_parquet_artifact(
     assert artifact_path.suffix == ".parquet"
     assert len(list(artifact_path.parent.glob("*.parquet"))) == 1
     assert pq.read_table(artifact_path).num_rows == 5_000
+
+
+def test_cli_rejects_missing_required_stock_basic_columns_without_artifact(
+    raw_zone_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    frame = _stock_basic_frame(1).drop(columns=["list_date"])
+    _install_tushare_client(monkeypatch, FakeTushareClient(frame))
+
+    exit_code = tushare_adapter_module.main(
+        ["--asset", "tushare_stock_basic", "--date", "20260415"]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["asset"] == "tushare_stock_basic"
+    assert "missing required fields" in payload["error"]
+    assert "list_date" in payload["error"]
+    assert list(raw_zone_path.rglob("*.parquet")) == []
+
+
+def test_cli_rejects_malformed_stock_basic_rows_without_artifact(
+    raw_zone_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _install_tushare_client(
+        monkeypatch,
+        FakeTushareClient([_stock_basic_row(0), ["not", "a", "mapping"]]),
+    )
+
+    exit_code = tushare_adapter_module.main(
+        ["--asset", "tushare_stock_basic", "--date", "20260415"]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["asset"] == "tushare_stock_basic"
+    assert "row 1 must be a mapping" in payload["error"]
+    assert list(raw_zone_path.rglob("*.parquet")) == []
+
+
+def test_cli_rejects_null_stock_basic_identity_without_artifact(
+    raw_zone_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    frame = _stock_basic_frame(1)
+    frame.loc[0, "ts_code"] = None
+    _install_tushare_client(monkeypatch, FakeTushareClient(frame))
+
+    exit_code = tushare_adapter_module.main(
+        ["--asset", "tushare_stock_basic", "--date", "20260415"]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["asset"] == "tushare_stock_basic"
+    assert "null identity field: ts_code" in payload["error"]
+    assert list(raw_zone_path.rglob("*.parquet")) == []
 
 
 def test_cli_missing_token_outputs_json_error(

--- a/tests/adapters/test_tushare.py
+++ b/tests/adapters/test_tushare.py
@@ -234,6 +234,41 @@ def test_cli_rejects_pandas_nat_stock_basic_identity_without_artifact(
     assert list(raw_zone_path.rglob("*.parquet")) == []
 
 
+@pytest.mark.parametrize(
+    ("identity_value", "expected_error"),
+    [
+        ("", "blank identity field: ts_code"),
+        ("   ", "blank identity field: ts_code"),
+        ("not-a-code", "malformed identity field: ts_code"),
+        ("000001.SHX", "malformed identity field: ts_code"),
+        (["000001.SZ"], "non-scalar identity field: ts_code"),
+    ],
+)
+def test_cli_rejects_invalid_stock_basic_identity_without_artifact(
+    raw_zone_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    identity_value: Any,
+    expected_error: str,
+) -> None:
+    frame = _stock_basic_frame(1)
+    frame.at[0, "ts_code"] = identity_value
+    _install_tushare_client(monkeypatch, FakeTushareClient(frame))
+
+    exit_code = tushare_adapter_module.main(
+        ["--asset", "tushare_stock_basic", "--date", "20260415"]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["asset"] == "tushare_stock_basic"
+    assert expected_error in payload["error"]
+    assert list(raw_zone_path.rglob("*.parquet")) == []
+
+
 def test_cli_missing_token_outputs_json_error(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/adapters/test_tushare.py
+++ b/tests/adapters/test_tushare.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+pa = pytest.importorskip("pyarrow")
+pq = pytest.importorskip("pyarrow.parquet")
+
+from data_platform.adapters.base import AdapterRegistry, QuotaConfig  # noqa: E402
+from data_platform.adapters.tushare import (  # noqa: E402
+    TUSHARE_STOCK_BASIC_ASSET,
+    TushareAdapter,
+)
+from data_platform.adapters.tushare import adapter as tushare_adapter_module  # noqa: E402
+from data_platform.adapters.tushare.assets import (  # noqa: E402
+    TUSHARE_STOCK_BASIC_FIELDS_CSV,
+)
+
+
+class FakeTushareClient:
+    def __init__(self, frame: Any) -> None:
+        self.frame = frame
+        self.calls: list[dict[str, Any]] = []
+
+    def stock_basic(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.frame
+
+
+def _stock_basic_frame(row_count: int) -> Any:
+    return pd.DataFrame(
+        {
+            "ts_code": [f"{index:06d}.SZ" for index in range(row_count)],
+            "symbol": [f"{index:06d}" for index in range(row_count)],
+            "name": [f"stock-{index}" for index in range(row_count)],
+            "list_date": ["20260415"] * row_count,
+            "extra_column": ["ignored"] * row_count,
+        }
+    )
+
+
+@pytest.fixture
+def raw_zone_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    raw_path = tmp_path / "raw"
+    monkeypatch.setenv("DP_RAW_ZONE_PATH", str(raw_path))
+    monkeypatch.setenv("DP_ICEBERG_WAREHOUSE_PATH", str(tmp_path / "iceberg" / "warehouse"))
+    return raw_path
+
+
+def test_tushare_adapter_declares_stock_basic_asset_and_quota() -> None:
+    adapter = TushareAdapter(token="test-token", client=FakeTushareClient(_stock_basic_frame(1)))
+
+    assert adapter.source_id() == "tushare"
+    assert adapter.get_assets() == [TUSHARE_STOCK_BASIC_ASSET]
+    assert adapter.get_assets()[0].dataset == "stock_basic"
+    assert adapter.get_assets()[0].partition == "static"
+    assert adapter.get_staging_dbt_models() == ["stg_stock_basic"]
+    assert adapter.get_quota_config() == QuotaConfig(
+        requests_per_minute=200,
+        daily_credit_quota=None,
+    )
+
+
+def test_fetch_stock_basic_returns_declared_schema() -> None:
+    client = FakeTushareClient(_stock_basic_frame(2))
+    adapter = TushareAdapter(token="test-token", client=client)
+
+    table = adapter.fetch("tushare_stock_basic", {"list_status": "L", "fields": "bad"})
+
+    assert isinstance(table, pa.Table)
+    assert table.schema == TUSHARE_STOCK_BASIC_ASSET.schema
+    assert table.num_rows == 2
+    assert client.calls == [
+        {
+            "list_status": "L",
+            "fields": TUSHARE_STOCK_BASIC_FIELDS_CSV,
+        }
+    ]
+
+
+def test_tushare_adapter_can_be_registered_and_fetched() -> None:
+    registry = AdapterRegistry()
+    adapter = TushareAdapter(token="test-token", client=FakeTushareClient(_stock_basic_frame(1)))
+
+    registry.register(adapter)
+
+    assert registry.get("tushare") is adapter
+
+
+def test_cli_writes_stock_basic_parquet_artifact(
+    raw_zone_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    client = FakeTushareClient(_stock_basic_frame(5_000))
+    tokens: list[str] = []
+
+    def pro_api(token: str) -> FakeTushareClient:
+        tokens.append(token)
+        return client
+
+    monkeypatch.setenv("DP_TUSHARE_TOKEN", "test-token")
+    monkeypatch.setitem(sys.modules, "tushare", SimpleNamespace(pro_api=pro_api))
+
+    exit_code = tushare_adapter_module.main(
+        ["--asset", "tushare_stock_basic", "--date", "20260415"]
+    )
+
+    captured = capsys.readouterr()
+    artifact_path = Path(captured.out.strip())
+
+    assert exit_code == 0
+    assert captured.err == ""
+    assert tokens == ["test-token"]
+    assert artifact_path.parent == raw_zone_path / "tushare" / "stock_basic" / "dt=20260415"
+    assert artifact_path.suffix == ".parquet"
+    assert len(list(artifact_path.parent.glob("*.parquet"))) == 1
+    assert pq.read_table(artifact_path).num_rows == 5_000
+
+
+def test_cli_missing_token_outputs_json_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("DP_TUSHARE_TOKEN", raising=False)
+
+    exit_code = tushare_adapter_module.main(
+        ["--asset", "tushare_stock_basic", "--date", "20260415"]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert exit_code == 1
+    assert captured.out == ""
+    assert payload["asset"] == "tushare_stock_basic"
+    assert "DP_TUSHARE_TOKEN" in payload["error"]


### PR DESCRIPTION
Closes #9

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/base.py`, `src/data_platform/config/settings.py`, `src/data_platform/ddl/runner.py`, `src/data_platform/raw/writer.py`, `src/data_platform/serving/catalog.py`, `tests/dbt/test_dbt_skeleton.py`


---
## 背景与目标
项目文档 §4.1、§14、§21 阶段 0 的"1 个 API 样板"指定首个参考实现。本 issue 实现 Tushare adapter 的最小可运行版本，仅接入 `stock_basic` 一个 API，输出 Raw Zone artifact 供 dbt staging 消费。Tushare 选型由 §5.2 确认。

## 所属模块
data_platform.adapters.tushare

## 实现范围
- 新建 `src/data_platform/adapters/tushare/__init__.py`、`adapter.py`、`assets.py`
- 实现 `TushareAdapter(BaseAdapter)`：`source_id()="tushare"`
- `get_assets()` 仅返回一个 `AssetSpec(name="tushare_stock_basic", dataset="stock_basic", partition="static", schema=...)`
- `fetch("tushare_stock_basic", params)` 调用 tushare pro API（依赖 `tushare>=1.4`），返回 `pa.Table`
- 在 `data_platform.raw.writer` 协助下，提供顶层入口 `python -m data_platform.adapters.tushare.adapter --asset tushare_stock_basic --date 20260415`
- token 通过 `DP_TUSHARE_TOKEN` 环境变量读取，缺失时抛 `AdapterConfigError`

## 不在本次范围
- 不实现其他 Tushare API（行情/财务/指数留给 P1b）
- 不写入 canonical / staging 表（留给 #11 / #12）
- 不实现 incremental backfill 策略

## 关键交付物
- `TushareAdapter.fetch` 返回 schema 与 `AssetSpec.schema` 一致的 `pa.Table`
- CLI 入口写入 Raw Zone 后打印 `RawArtifact` 路径
- 单测使用 `responses` / `pytest-mock` 桩 tushare 客户端，无需真实 token
- quota 默认 `requests_per_minute=200`、`daily_credit_quota=None`
- 失败时 stderr 输出 JSON 结构 `{"error": "...", "asset": "..."}` 便于 orchestrator 抓取

## 验收标准
- [ ] 单测中 mock tushare 返回 5000 行，CLI 写出 1 个 parquet artifact 且行数=5000
- [ ] 没有 `DP_TUSHARE_TOKEN` 时 CLI 退出码非零并输出明确错误
- [ ] `TushareAdapter` 通过 `AdapterRegistry.register` 后可被 `get("tushare")` 取出
- [ ] Raw Zone 路径符合 `tushare/stock_basic/dt=YYYYMMDD/<run_id>.parquet`
- [ ] `pytest tests/adapters/test_tushare.py` 通过

## 验证命令
```bash
cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
pytest tests/adapters/test_tushare.py -q
# 真实拉取（需要 token，可选）
DP_TUSHARE_TOKEN=$TUSHARE_TOKEN DP_RAW_ZONE_PATH=/tmp/dp_raw \
  python -m data_platform.adapters.tushare.adapter --asset tushare_stock_basic --date 20260415
```

## 依赖
依赖 #6（Raw Writer）, #8（adapter 抽象）