### PR TITLE
feat(#12): canonical.stock_basic 写入逻辑（Iceberg upsert）

### DIFF
--- a/src/data_platform/serving/canonical_writer.py
+++ b/src/data_platform/serving/canonical_writer.py
@@ -9,7 +9,7 @@ import logging
 from pathlib import Path
 import sys
 from time import perf_counter
-from typing import Sequence
+from typing import NoReturn, Sequence
 
 import duckdb
 import pyarrow as pa  # type: ignore[import-untyped]
@@ -52,7 +52,17 @@ class WriteResult:
     duration_ms: int
 
 
-def load_canonical_stock_basic(catalog: SqlCatalog, duckdb_path: Path) -> WriteResult:
+class _JsonErrorArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:
+        raise ValueError(message)
+
+
+def load_canonical_stock_basic(
+    catalog: SqlCatalog,
+    duckdb_path: Path,
+    *,
+    allow_empty: bool = False,
+) -> WriteResult:
     """Load DuckDB stg_stock_basic into canonical.stock_basic via full overwrite."""
 
     start = perf_counter()
@@ -60,6 +70,7 @@ def load_canonical_stock_basic(catalog: SqlCatalog, duckdb_path: Path) -> WriteR
     table_arrow = _read_stg_stock_basic(duckdb_path)
     _validate_no_forbidden_payload_fields(table_arrow)
     _validate_payload_fields_match_target(CANONICAL_STOCK_BASIC_IDENTIFIER, table, table_arrow)
+    _validate_non_empty_staging(table_arrow, allow_empty=allow_empty)
 
     table.overwrite(table_arrow)
     refreshed_table = table.refresh()
@@ -83,15 +94,25 @@ def load_canonical_stock_basic(catalog: SqlCatalog, duckdb_path: Path) -> WriteR
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Load staging data into canonical Iceberg tables.")
-    parser.add_argument("--table", required=True, help="canonical table to load")
-    args = parser.parse_args(argv)
-
     try:
+        parser = _JsonErrorArgumentParser(
+            description="Load staging data into canonical Iceberg tables."
+        )
+        parser.add_argument("--table", required=True, help="canonical table to load")
+        parser.add_argument(
+            "--allow-empty",
+            action="store_true",
+            help="intentionally publish an empty canonical table",
+        )
+        args = parser.parse_args(argv)
         if args.table != TABLE_STOCK_BASIC:
             msg = f"unsupported canonical table: {args.table}"
             raise ValueError(msg)
-        result = load_canonical_stock_basic(load_catalog(), get_settings().duckdb_path)
+        result = load_canonical_stock_basic(
+            load_catalog(),
+            get_settings().duckdb_path,
+            allow_empty=args.allow_empty,
+        )
     except Exception as exc:
         error_payload = {"error": type(exc).__name__, "detail": str(exc)}
         print(json.dumps(error_payload, sort_keys=True), file=sys.stderr)
@@ -104,7 +125,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 def _read_stg_stock_basic(duckdb_path: Path) -> pa.Table:
     connection = duckdb.connect(str(duckdb_path))
     try:
-        return connection.execute(STOCK_BASIC_SELECT).arrow().read_all()
+        return connection.execute(STOCK_BASIC_SELECT).to_arrow_table()
     finally:
         connection.close()
 
@@ -142,6 +163,17 @@ def _validate_payload_fields_match_target(
     msg = f"{identifier} payload field set does not match target schema"
     if details:
         msg = msg + " (" + "; ".join(details) + ")"
+    raise ValueError(msg)
+
+
+def _validate_non_empty_staging(table_arrow: pa.Table, *, allow_empty: bool) -> None:
+    if table_arrow.num_rows > 0 or allow_empty:
+        return
+
+    msg = (
+        "stg_stock_basic produced zero rows; refusing to overwrite "
+        "canonical.stock_basic without allow_empty=True"
+    )
     raise ValueError(msg)
 
 

--- a/src/data_platform/serving/canonical_writer.py
+++ b/src/data_platform/serving/canonical_writer.py
@@ -1,0 +1,180 @@
+"""Canonical Iceberg writers for Lite-mode staging outputs."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import logging
+from pathlib import Path
+import sys
+from time import perf_counter
+from typing import Sequence
+
+import duckdb
+import pyarrow as pa  # type: ignore[import-untyped]
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.table import Table
+
+from data_platform.config import get_settings
+from data_platform.serving.catalog import load_catalog
+
+
+logger = logging.getLogger(__name__)
+
+TABLE_STOCK_BASIC = "stock_basic"
+CANONICAL_STOCK_BASIC_IDENTIFIER = "canonical.stock_basic"
+FORBIDDEN_PAYLOAD_FIELDS = frozenset({"submitted_at", "ingest_seq"})
+
+STOCK_BASIC_SELECT = """
+SELECT
+    CAST("ts_code" AS VARCHAR) AS "ts_code",
+    CAST("symbol" AS VARCHAR) AS "symbol",
+    CAST("name" AS VARCHAR) AS "name",
+    CAST("area" AS VARCHAR) AS "area",
+    CAST("industry" AS VARCHAR) AS "industry",
+    CAST("market" AS VARCHAR) AS "market",
+    CAST("list_date" AS DATE) AS "list_date",
+    CAST("is_active" AS BOOLEAN) AS "is_active",
+    CAST("source_run_id" AS VARCHAR) AS "source_run_id",
+    CAST(current_timestamp AS TIMESTAMP) AS "canonical_loaded_at"
+FROM stg_stock_basic
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class WriteResult:
+    """Result of one canonical table overwrite."""
+
+    table: str
+    snapshot_id: int
+    row_count: int
+    duration_ms: int
+
+
+def load_canonical_stock_basic(catalog: SqlCatalog, duckdb_path: Path) -> WriteResult:
+    """Load DuckDB stg_stock_basic into canonical.stock_basic via full overwrite."""
+
+    start = perf_counter()
+    table = catalog.load_table(CANONICAL_STOCK_BASIC_IDENTIFIER)
+    table_arrow = _read_stg_stock_basic(duckdb_path)
+    _validate_no_forbidden_payload_fields(table_arrow)
+    _validate_payload_fields_match_target(CANONICAL_STOCK_BASIC_IDENTIFIER, table, table_arrow)
+
+    table.overwrite(table_arrow)
+    refreshed_table = table.refresh()
+    snapshot_id = _current_snapshot_id(refreshed_table)
+    duration_ms = int((perf_counter() - start) * 1000)
+    result = WriteResult(
+        table=CANONICAL_STOCK_BASIC_IDENTIFIER,
+        snapshot_id=snapshot_id,
+        row_count=table_arrow.num_rows,
+        duration_ms=duration_ms,
+    )
+    logger.info(
+        "canonical_write",
+        extra={
+            "table": result.table,
+            "rows": result.row_count,
+            "snapshot": result.snapshot_id,
+        },
+    )
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Load staging data into canonical Iceberg tables.")
+    parser.add_argument("--table", required=True, help="canonical table to load")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.table != TABLE_STOCK_BASIC:
+            msg = f"unsupported canonical table: {args.table}"
+            raise ValueError(msg)
+        result = load_canonical_stock_basic(load_catalog(), get_settings().duckdb_path)
+    except Exception as exc:
+        error_payload = {"error": type(exc).__name__, "detail": str(exc)}
+        print(json.dumps(error_payload, sort_keys=True), file=sys.stderr)
+        return 1
+
+    print(json.dumps(asdict(result), sort_keys=True))
+    return 0
+
+
+def _read_stg_stock_basic(duckdb_path: Path) -> pa.Table:
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        return connection.execute(STOCK_BASIC_SELECT).arrow().read_all()
+    finally:
+        connection.close()
+
+
+def _validate_no_forbidden_payload_fields(table_arrow: pa.Table) -> None:
+    forbidden_fields = sorted(
+        FORBIDDEN_PAYLOAD_FIELDS.intersection(
+            field_name.lower() for field_name in table_arrow.schema.names
+        )
+    )
+    if not forbidden_fields:
+        return
+
+    msg = "canonical payload must not include producer queue fields: "
+    raise ValueError(msg + ", ".join(forbidden_fields))
+
+
+def _validate_payload_fields_match_target(
+    identifier: str,
+    table: Table,
+    table_arrow: pa.Table,
+) -> None:
+    target_fields = set(_table_field_names(table))
+    payload_fields = set(table_arrow.schema.names)
+    if target_fields == payload_fields:
+        return
+
+    missing = sorted(target_fields - payload_fields)
+    extra = sorted(payload_fields - target_fields)
+    details = []
+    if missing:
+        details.append("missing payload fields: " + ", ".join(missing))
+    if extra:
+        details.append("extra payload fields: " + ", ".join(extra))
+    msg = f"{identifier} payload field set does not match target schema"
+    if details:
+        msg = msg + " (" + "; ".join(details) + ")"
+    raise ValueError(msg)
+
+
+def _table_field_names(table: Table) -> list[str]:
+    table_schema = table.schema
+    schema = table_schema() if callable(table_schema) else table_schema
+    if isinstance(schema, pa.Schema):
+        return list(schema.names)
+
+    as_arrow = getattr(schema, "as_arrow", None)
+    if callable(as_arrow):
+        arrow_schema = as_arrow()
+        if isinstance(arrow_schema, pa.Schema):
+            return list(arrow_schema.names)
+
+    fields = getattr(schema, "fields", None)
+    if fields is not None:
+        return [str(field.name) for field in fields]
+
+    msg = "Iceberg table schema cannot be inspected for field names"
+    raise TypeError(msg)
+
+
+def _current_snapshot_id(table: Table) -> int:
+    snapshot = table.current_snapshot()
+    if snapshot is None:
+        msg = "canonical.stock_basic overwrite did not create a current snapshot"
+        raise RuntimeError(msg)
+    return int(snapshot.snapshot_id)
+
+
+__all__ = ["WriteResult", "load_canonical_stock_basic", "main"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/serving/test_canonical_writer.py
+++ b/tests/serving/test_canonical_writer.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import json
+from pathlib import Path
+from typing import Sequence
+
+import duckdb
+import pyarrow as pa  # type: ignore[import-untyped]
+import pytest
+from pyiceberg.catalog.memory import InMemoryCatalog
+
+from data_platform.ddl.iceberg_tables import CANONICAL_STOCK_BASIC_SPEC
+from data_platform.serving import canonical_writer
+from data_platform.serving.canonical_writer import (
+    CANONICAL_STOCK_BASIC_IDENTIFIER,
+    FORBIDDEN_PAYLOAD_FIELDS,
+    load_canonical_stock_basic,
+)
+
+
+StockBasicRow = tuple[str, str, str, str, str, str, date, bool, str]
+
+
+@dataclass(frozen=True, slots=True)
+class FakeSettings:
+    duckdb_path: Path
+
+
+def test_load_canonical_stock_basic_overwrites_idempotently(tmp_path: Path) -> None:
+    catalog = create_stock_basic_catalog(tmp_path)
+    duckdb_path = tmp_path / "staging.duckdb"
+    rows = stock_basic_rows()
+    write_staging_stock_basic(duckdb_path, rows)
+
+    first = load_canonical_stock_basic(catalog, duckdb_path)  # type: ignore[arg-type]
+    second = load_canonical_stock_basic(catalog, duckdb_path)  # type: ignore[arg-type]
+
+    assert first.table == CANONICAL_STOCK_BASIC_IDENTIFIER
+    assert first.row_count == len(rows)
+    assert second.row_count == len(rows)
+    assert second.snapshot_id != first.snapshot_id
+
+    table = catalog.load_table(CANONICAL_STOCK_BASIC_IDENTIFIER)
+    current_snapshot = table.current_snapshot()
+    assert current_snapshot is not None
+    assert current_snapshot.snapshot_id == second.snapshot_id
+
+    current_rows = table.scan().to_arrow()
+    old_rows = table.scan(snapshot_id=first.snapshot_id).to_arrow()
+    assert current_rows.num_rows == len(rows)
+    assert old_rows.num_rows == len(rows)
+    assert current_rows.schema.names == CANONICAL_STOCK_BASIC_SPEC.schema.names
+
+
+def test_load_canonical_stock_basic_does_not_propagate_queue_fields(
+    tmp_path: Path,
+) -> None:
+    catalog = create_stock_basic_catalog(tmp_path)
+    duckdb_path = tmp_path / "staging.duckdb"
+    write_staging_stock_basic(duckdb_path, stock_basic_rows(), include_queue_fields=True)
+
+    load_canonical_stock_basic(catalog, duckdb_path)  # type: ignore[arg-type]
+
+    payload = catalog.load_table(CANONICAL_STOCK_BASIC_IDENTIFIER).scan().to_arrow()
+    assert not FORBIDDEN_PAYLOAD_FIELDS.intersection(
+        field_name.lower() for field_name in payload.schema.names
+    )
+
+
+@pytest.mark.parametrize(
+    "target_schema, expected_error",
+    [
+        (
+            pa.schema(
+                [
+                    field
+                    for field in CANONICAL_STOCK_BASIC_SPEC.schema
+                    if field.name != "market"
+                ]
+            ),
+            "extra payload fields: market",
+        ),
+        (
+            CANONICAL_STOCK_BASIC_SPEC.schema.append(pa.field("extra", pa.string())),
+            "missing payload fields: extra",
+        ),
+    ],
+)
+def test_load_canonical_stock_basic_rejects_target_payload_field_mismatch(
+    tmp_path: Path,
+    target_schema: pa.Schema,
+    expected_error: str,
+) -> None:
+    catalog = create_stock_basic_catalog(tmp_path, schema=target_schema)
+    duckdb_path = tmp_path / "staging.duckdb"
+    write_staging_stock_basic(duckdb_path, stock_basic_rows())
+
+    with pytest.raises(ValueError, match=expected_error):
+        load_canonical_stock_basic(catalog, duckdb_path)  # type: ignore[arg-type]
+
+    assert catalog.load_table(CANONICAL_STOCK_BASIC_IDENTIFIER).current_snapshot() is None
+
+
+def test_overwrite_failure_does_not_refresh_or_report_snapshot(tmp_path: Path) -> None:
+    duckdb_path = tmp_path / "staging.duckdb"
+    rows = stock_basic_rows()
+    write_staging_stock_basic(duckdb_path, rows)
+
+    class FailingTable:
+        schema = CANONICAL_STOCK_BASIC_SPEC.schema
+
+        def __init__(self) -> None:
+            self.overwritten_rows: int | None = None
+            self.refresh_called = False
+
+        def overwrite(self, table_arrow: pa.Table) -> None:
+            self.overwritten_rows = table_arrow.num_rows
+            raise RuntimeError("overwrite failed")
+
+        def refresh(self) -> FailingTable:
+            self.refresh_called = True
+            return self
+
+    class FakeCatalog:
+        def __init__(self) -> None:
+            self.table = FailingTable()
+
+        def load_table(self, identifier: str) -> FailingTable:
+            assert identifier == CANONICAL_STOCK_BASIC_IDENTIFIER
+            return self.table
+
+    catalog = FakeCatalog()
+
+    with pytest.raises(RuntimeError, match="overwrite failed"):
+        load_canonical_stock_basic(catalog, duckdb_path)  # type: ignore[arg-type]
+
+    assert catalog.table.overwritten_rows == len(rows)
+    assert catalog.table.refresh_called is False
+
+
+def test_cli_writes_result_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    catalog = create_stock_basic_catalog(tmp_path)
+    duckdb_path = tmp_path / "staging.duckdb"
+    write_staging_stock_basic(duckdb_path, stock_basic_rows())
+    monkeypatch.setattr(canonical_writer, "load_catalog", lambda: catalog)
+    monkeypatch.setattr(canonical_writer, "get_settings", lambda: FakeSettings(duckdb_path))
+
+    exit_code = canonical_writer.main(["--table", "stock_basic"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["table"] == CANONICAL_STOCK_BASIC_IDENTIFIER
+    assert payload["row_count"] == len(stock_basic_rows())
+    assert catalog.load_table(CANONICAL_STOCK_BASIC_IDENTIFIER).current_snapshot() is not None
+
+
+def test_cli_reports_failure_as_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = canonical_writer.main(["--table", "canonical_entity"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["error"] == "ValueError"
+    assert "unsupported canonical table" in payload["detail"]
+
+
+def create_stock_basic_catalog(
+    tmp_path: Path,
+    *,
+    schema: pa.Schema = CANONICAL_STOCK_BASIC_SPEC.schema,
+) -> InMemoryCatalog:
+    warehouse_path = tmp_path / "warehouse"
+    catalog = InMemoryCatalog("test", warehouse=f"file://{warehouse_path}")
+    catalog.create_namespace_if_not_exists(("canonical",))
+    catalog.create_table(CANONICAL_STOCK_BASIC_IDENTIFIER, schema=schema)
+    return catalog
+
+
+def write_staging_stock_basic(
+    duckdb_path: Path,
+    rows: Sequence[StockBasicRow],
+    *,
+    include_queue_fields: bool = False,
+) -> None:
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        queue_columns = (
+            ', "submitted_at" TIMESTAMP, "ingest_seq" BIGINT'
+            if include_queue_fields
+            else ""
+        )
+        connection.execute(
+            f"""
+            CREATE OR REPLACE TABLE stg_stock_basic (
+                "ts_code" VARCHAR,
+                "symbol" VARCHAR,
+                "name" VARCHAR,
+                "area" VARCHAR,
+                "industry" VARCHAR,
+                "market" VARCHAR,
+                "list_date" DATE,
+                "is_active" BOOLEAN,
+                "source_run_id" VARCHAR
+                {queue_columns}
+            )
+            """
+        )
+        for row in rows:
+            if include_queue_fields:
+                connection.execute(
+                    """
+                    INSERT INTO stg_stock_basic VALUES (
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?, current_timestamp, 1
+                    )
+                    """,
+                    row,
+                )
+            else:
+                connection.execute(
+                    """
+                    INSERT INTO stg_stock_basic VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    row,
+                )
+    finally:
+        connection.close()
+
+
+def stock_basic_rows() -> list[StockBasicRow]:
+    return [
+        (
+            "000001.SZ",
+            "000001",
+            "Ping An Bank",
+            "Shenzhen",
+            "Bank",
+            "Main",
+            date(1991, 4, 3),
+            True,
+            "run-001",
+        ),
+        (
+            "000002.SZ",
+            "000002",
+            "Vanke A",
+            "Shenzhen",
+            "Real Estate",
+            "Main",
+            date(1991, 1, 29),
+            True,
+            "run-001",
+        ),
+    ]

--- a/tests/serving/test_canonical_writer.py
+++ b/tests/serving/test_canonical_writer.py
@@ -103,6 +103,49 @@ def test_load_canonical_stock_basic_rejects_target_payload_field_mismatch(
     assert catalog.load_table(CANONICAL_STOCK_BASIC_IDENTIFIER).current_snapshot() is None
 
 
+def test_load_canonical_stock_basic_rejects_empty_staging_before_overwrite(
+    tmp_path: Path,
+) -> None:
+    catalog = create_stock_basic_catalog(tmp_path)
+    duckdb_path = tmp_path / "staging.duckdb"
+    rows = stock_basic_rows()
+    write_staging_stock_basic(duckdb_path, rows)
+    first = load_canonical_stock_basic(catalog, duckdb_path)  # type: ignore[arg-type]
+    write_staging_stock_basic(duckdb_path, [])
+
+    with pytest.raises(ValueError, match="zero rows"):
+        load_canonical_stock_basic(catalog, duckdb_path)  # type: ignore[arg-type]
+
+    table = catalog.load_table(CANONICAL_STOCK_BASIC_IDENTIFIER)
+    current_snapshot = table.current_snapshot()
+    assert current_snapshot is not None
+    assert current_snapshot.snapshot_id == first.snapshot_id
+    assert table.scan().to_arrow().num_rows == len(rows)
+
+
+def test_load_canonical_stock_basic_allows_empty_staging_with_explicit_flag(
+    tmp_path: Path,
+) -> None:
+    catalog = create_stock_basic_catalog(tmp_path)
+    duckdb_path = tmp_path / "staging.duckdb"
+    rows = stock_basic_rows()
+    write_staging_stock_basic(duckdb_path, rows)
+    first = load_canonical_stock_basic(catalog, duckdb_path)  # type: ignore[arg-type]
+    write_staging_stock_basic(duckdb_path, [])
+
+    second = load_canonical_stock_basic(  # type: ignore[arg-type]
+        catalog,
+        duckdb_path,
+        allow_empty=True,
+    )
+
+    table = catalog.load_table(CANONICAL_STOCK_BASIC_IDENTIFIER)
+    assert second.row_count == 0
+    assert second.snapshot_id != first.snapshot_id
+    assert table.scan().to_arrow().num_rows == 0
+    assert table.scan(snapshot_id=first.snapshot_id).to_arrow().num_rows == len(rows)
+
+
 def test_overwrite_failure_does_not_refresh_or_report_snapshot(tmp_path: Path) -> None:
     duckdb_path = tmp_path / "staging.duckdb"
     rows = stock_basic_rows()
@@ -173,6 +216,28 @@ def test_cli_reports_failure_as_json(
     payload = json.loads(captured.err)
     assert payload["error"] == "ValueError"
     assert "unsupported canonical table" in payload["detail"]
+
+
+@pytest.mark.parametrize(
+    "argv, expected_detail",
+    [
+        ([], "the following arguments are required: --table"),
+        (["--table", "stock_basic", "--unknown"], "unrecognized arguments: --unknown"),
+    ],
+)
+def test_cli_reports_argument_failures_as_json(
+    argv: list[str],
+    expected_detail: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = canonical_writer.main(argv)
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["error"] == "ValueError"
+    assert expected_detail in payload["detail"]
 
 
 def create_stock_basic_catalog(


### PR DESCRIPTION
Closes #12

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `docs/spike/iceberg-write-chain.md`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/base.py`, `src/data_platform/config/settings.py`, `src/data_platform/ddl/iceberg_tables.py`, `src/data_platform/ddl/runner.py`, `src/data_platform/raw/writer.py`, `src/data_platform/serving/catalog.py`


---
## 背景与目标
项目文档 §8.1 与 §21 阶段 0 退出条件要求把 staging 数据落到 Canonical Iceberg 表，供下游 `entity-registry` / `main-core` 消费。本 issue 实现 `stg_stock_basic` → `canonical.stock_basic` 的 upsert 流程，使用 PyIceberg `overwrite` 或 `merge`，保证 Lite 模式可重跑。

## 所属模块
data_platform.serving.canonical_writer

## 实现范围
- 新建 `src/data_platform/serving/canonical_writer.py`：函数 `load_canonical_stock_basic(catalog, duckdb_path) -> WriteResult`
- 流程：读取 DuckDB `stg_stock_basic` → `pa.Table` → PyIceberg `Table.overwrite(table_arrow)`（Lite 简单策略：全量覆盖）
- 落库时补写 `canonical_loaded_at = now()`
- 提供 CLI `python -m data_platform.serving.canonical_writer --table stock_basic`
- `WriteResult(table: str, snapshot_id: int, row_count: int, duration_ms: int)`
- 单测使用临时 catalog + 内存 DuckDB 验证幂等

## 不在本次范围
- 不写其他 canonical 表（留给 P1b）
- 不实现增量 merge（Lite 阶段允许全量）
- 不暴露 `submitted_at`/`ingest_seq`（明确 BAN，仅 Layer B 用）
- 不触发下游通知

## 关键交付物
- 函数签名 `def load_canonical_stock_basic(catalog: SqlCatalog, duckdb_path: Path) -> WriteResult`
- CLI 退出码：成功 0、失败 1，stderr 输出 JSON
- 写入前校验目标表字段集与 `pa.Table` 字段集严格一致（多/少均 raise）
- 失败回滚：PyIceberg overwrite 失败时不留半快照
- 日志：`logger.info("canonical_write", extra={"table":..., "rows":..., "snapshot":...})`

## 验收标准
- [ ] CLI 在 fixture 上跑通，`catalog.load_table('canonical.stock_basic').current_snapshot()` 非空
- [ ] 重跑 CLI 行数不变、产生新 snapshot（time travel 可见旧版本）
- [ ] DuckDB 通过 iceberg 扩展 `select count(*) from iceberg_scan('<warehouse>/canonical/stock_basic')` 返回正确行数
- [ ] payload 中无 `submitted_at` / `ingest_seq` 字段（边界守护）
- [ ] `pytest tests/serving/test_canonical_writer.py` 通过

## 验证命令
```bash
cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
python -m data_platform.serving.canonical_writer --table stock_basic
duckdb -c "INSTALL iceberg; LOAD iceberg; \
  select count(*) from iceberg_scan('$DP_ICEBERG_WAREHOUSE_PATH/canonical/stock_basic');"
```

## 依赖
依赖 #7（canonical 表已注册）, #11（staging model 可用）