### PR TITLE
feat(#13): Canonical / DuckDB 基础读取接口

### DIFF
--- a/src/data_platform/serving/reader.py
+++ b/src/data_platform/serving/reader.py
@@ -1,0 +1,186 @@
+"""Canonical read APIs backed by DuckDB Iceberg scans."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from functools import lru_cache
+from pathlib import Path
+import re
+from threading import RLock
+from typing import Any
+
+import duckdb
+import pyarrow as pa  # type: ignore[import-untyped]
+
+from data_platform.config import get_settings
+
+
+CANONICAL_NAMESPACE = "canonical"
+TABLE_STOCK_BASIC = "stock_basic"
+_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_CONNECTION_LOCK = RLock()
+
+
+class CanonicalTableNotFound(LookupError):
+    """Raised when a canonical Iceberg table cannot be read."""
+
+    def __init__(self, table: str) -> None:
+        self.table = table
+        super().__init__(f"canonical table not found: {table}")
+
+
+class UnsupportedFilter(ValueError):
+    """Raised when a read_canonical filter is outside the supported contract."""
+
+    def __init__(self, filter_spec: object) -> None:
+        self.filter_spec = filter_spec
+        super().__init__(f"unsupported canonical filter: {filter_spec!r}")
+
+
+def read_canonical(
+    table: str,
+    columns: list[str] | None = None,
+    filters: list[tuple[str, str, Any]] | None = None,
+) -> pa.Table:
+    """Read one canonical Iceberg table as a PyArrow table."""
+
+    _validate_identifier(table)
+    select_list = _compile_select_list(columns)
+    where_clause, parameters = _compile_filters(filters)
+    sql = f"""
+SELECT {select_list}
+FROM {_canonical_table_expression(table)}
+{where_clause}
+"""
+
+    with with_duckdb_connection() as connection:
+        try:
+            return connection.execute(sql, parameters).to_arrow_table()
+        except duckdb.Error as exc:
+            if _is_missing_table_error(exc, table):
+                raise CanonicalTableNotFound(table) from exc
+            raise
+
+
+def get_canonical_stock_basic(active_only: bool = True) -> pa.Table:
+    """Read canonical.stock_basic, filtering to active rows by default."""
+
+    filters = [("is_active", "=", True)] if active_only else None
+    return read_canonical(TABLE_STOCK_BASIC, filters=filters)
+
+
+@contextmanager
+def with_duckdb_connection() -> Iterator[duckdb.DuckDBPyConnection]:
+    """Yield the process-global DuckDB connection for canonical reads."""
+
+    connection = _duckdb_connection()
+    with _CONNECTION_LOCK:
+        yield connection
+
+
+@lru_cache(maxsize=1)
+def _duckdb_connection() -> duckdb.DuckDBPyConnection:
+    settings = get_settings()
+    connection = duckdb.connect(str(settings.duckdb_path))
+    _load_iceberg_extension(connection)
+    return connection
+
+
+def _load_iceberg_extension(connection: duckdb.DuckDBPyConnection) -> None:
+    try:
+        connection.execute("LOAD iceberg")
+    except duckdb.Error:
+        connection.execute("INSTALL iceberg")
+        connection.execute("LOAD iceberg")
+
+
+def _compile_select_list(columns: list[str] | None) -> str:
+    if columns is None:
+        return "*"
+    if not columns:
+        msg = "columns must not be empty"
+        raise ValueError(msg)
+    return ", ".join(_quote_identifier(column) for column in columns)
+
+
+def _compile_filters(
+    filters: list[tuple[str, str, Any]] | None,
+) -> tuple[str, list[Any]]:
+    if not filters:
+        return "", []
+
+    clauses: list[str] = []
+    parameters: list[Any] = []
+    for filter_spec in filters:
+        if len(filter_spec) != 3:
+            raise UnsupportedFilter(filter_spec)
+
+        column, operator, value = filter_spec
+        quoted_column = _quote_identifier(column)
+        normalized_operator = operator.strip().lower()
+        if normalized_operator == "=":
+            clauses.append(f"{quoted_column} = ?")
+            parameters.append(value)
+        elif normalized_operator == "in":
+            values = _filter_values(filter_spec, value)
+            if values:
+                placeholders = ", ".join("?" for _ in values)
+                clauses.append(f"{quoted_column} IN ({placeholders})")
+                parameters.extend(values)
+            else:
+                clauses.append("FALSE")
+        else:
+            raise UnsupportedFilter(filter_spec)
+
+    return "WHERE " + " AND ".join(clauses), parameters
+
+
+def _filter_values(filter_spec: object, value: object) -> list[Any]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise UnsupportedFilter(filter_spec)
+    return list(value)
+
+
+def _canonical_table_expression(table: str) -> str:
+    table_location = _canonical_table_location(table)
+    return f"iceberg_scan({_sql_string_literal(str(table_location))})"
+
+
+def _canonical_table_location(table: str) -> Path:
+    warehouse_path = get_settings().iceberg_warehouse_path.expanduser()
+    return warehouse_path / CANONICAL_NAMESPACE / table
+
+
+def _quote_identifier(identifier: str) -> str:
+    _validate_identifier(identifier)
+    return f'"{identifier}"'
+
+
+def _validate_identifier(identifier: str) -> None:
+    if _IDENTIFIER_PATTERN.fullmatch(identifier):
+        return
+    msg = f"invalid SQL identifier: {identifier!r}"
+    raise ValueError(msg)
+
+
+def _sql_string_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _is_missing_table_error(exc: duckdb.Error, table: str) -> bool:
+    detail = str(exc).lower()
+    expected_location = str(_canonical_table_location(table)).lower()
+    missing_markers = ("does not exist", "no such file", "not found", "cannot open")
+    return (
+        table.lower() in detail or expected_location in detail
+    ) and any(marker in detail for marker in missing_markers)
+
+
+__all__ = [
+    "CanonicalTableNotFound",
+    "UnsupportedFilter",
+    "get_canonical_stock_basic",
+    "read_canonical",
+    "with_duckdb_connection",
+]

--- a/tests/serving/test_reader.py
+++ b/tests/serving/test_reader.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterator
+
+import duckdb
+import pytest
+
+from data_platform.serving import reader
+from data_platform.serving.reader import (
+    CanonicalTableNotFound,
+    UnsupportedFilter,
+    get_canonical_stock_basic,
+    read_canonical,
+    with_duckdb_connection,
+)
+
+
+StockBasicRow = tuple[str, str, str, str, str, str, date, bool, str, datetime]
+
+
+@dataclass(frozen=True, slots=True)
+class FakeSettings:
+    duckdb_path: Path
+    iceberg_warehouse_path: Path
+
+
+@pytest.fixture
+def stock_basic_duckdb(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Path]:
+    duckdb_path = tmp_path / "canonical.duckdb"
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        connection.execute(
+            """
+CREATE TABLE stock_basic (
+    ts_code VARCHAR,
+    symbol VARCHAR,
+    name VARCHAR,
+    area VARCHAR,
+    industry VARCHAR,
+    market VARCHAR,
+    list_date DATE,
+    is_active BOOLEAN,
+    source_run_id VARCHAR,
+    canonical_loaded_at TIMESTAMP
+)
+"""
+        )
+        connection.executemany(
+            """
+INSERT INTO stock_basic VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+""",
+            stock_basic_rows(),
+        )
+    finally:
+        connection.close()
+
+    monkeypatch.setattr(
+        reader,
+        "get_settings",
+        lambda: FakeSettings(
+            duckdb_path=duckdb_path,
+            iceberg_warehouse_path=tmp_path / "warehouse",
+        ),
+    )
+    monkeypatch.setattr(reader, "_load_iceberg_extension", lambda connection: None)
+    monkeypatch.setattr(
+        reader,
+        "_canonical_table_expression",
+        lambda table: reader._quote_identifier(table),
+    )
+    reader._duckdb_connection.cache_clear()
+    yield duckdb_path
+    reader._duckdb_connection.cache_clear()
+
+
+def test_read_canonical_selects_requested_columns(stock_basic_duckdb: Path) -> None:
+    table = read_canonical("stock_basic", columns=["ts_code", "name"])
+
+    assert table.schema.names == ["ts_code", "name"]
+    assert table.column("ts_code").to_pylist() == [
+        "000001.SZ",
+        "000002.SZ",
+        "300001.SZ",
+    ]
+
+
+def test_read_canonical_applies_equals_filter(stock_basic_duckdb: Path) -> None:
+    table = read_canonical("stock_basic", filters=[("market", "=", "主板")])
+
+    assert table.num_rows == 2
+    assert table.column("ts_code").to_pylist() == ["000001.SZ", "000002.SZ"]
+
+
+def test_read_canonical_applies_in_filter(stock_basic_duckdb: Path) -> None:
+    table = read_canonical(
+        "stock_basic",
+        columns=["ts_code", "market"],
+        filters=[("market", "in", ["主板", "创业板"])],
+    )
+
+    assert table.num_rows == 3
+    assert table.schema.names == ["ts_code", "market"]
+
+
+def test_get_canonical_stock_basic_filters_active_rows_by_default(
+    stock_basic_duckdb: Path,
+) -> None:
+    active = get_canonical_stock_basic()
+    all_rows = get_canonical_stock_basic(active_only=False)
+
+    assert active.num_rows == 2
+    assert active.column("ts_code").to_pylist() == ["000001.SZ", "300001.SZ"]
+    assert all_rows.num_rows == 3
+
+
+def test_read_canonical_raises_for_missing_table(stock_basic_duckdb: Path) -> None:
+    with pytest.raises(CanonicalTableNotFound) as exc_info:
+        read_canonical("missing_table")
+
+    assert exc_info.value.table == "missing_table"
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        [("market", ">", "主板")],
+        [("market", "like", "主%")],
+        [("market", "in", "主板")],
+    ],
+)
+def test_read_canonical_rejects_unsupported_filters(
+    stock_basic_duckdb: Path,
+    filters: list[tuple[str, str, object]],
+) -> None:
+    with pytest.raises(UnsupportedFilter):
+        read_canonical("stock_basic", filters=filters)
+
+
+def test_with_duckdb_connection_uses_cached_connection(stock_basic_duckdb: Path) -> None:
+    with with_duckdb_connection() as first:
+        with with_duckdb_connection() as second:
+            assert second is first
+
+
+def stock_basic_rows() -> list[StockBasicRow]:
+    loaded_at = datetime(2026, 4, 15, 10, 30, 0)
+    return [
+        (
+            "000001.SZ",
+            "000001",
+            "平安银行",
+            "深圳",
+            "银行",
+            "主板",
+            date(1991, 4, 3),
+            True,
+            "run-1",
+            loaded_at,
+        ),
+        (
+            "000002.SZ",
+            "000002",
+            "万科A",
+            "深圳",
+            "房地产",
+            "主板",
+            date(1991, 1, 29),
+            False,
+            "run-1",
+            loaded_at,
+        ),
+        (
+            "300001.SZ",
+            "300001",
+            "特锐德",
+            "青岛",
+            "电气设备",
+            "创业板",
+            date(2009, 10, 30),
+            True,
+            "run-1",
+            loaded_at,
+        ),
+    ]


### PR DESCRIPTION
Closes #13

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `docs/spike/iceberg-write-chain.md`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/base.py`, `src/data_platform/config/settings.py`, `src/data_platform/ddl/iceberg_tables.py`, `src/data_platform/ddl/runner.py`, `src/data_platform/raw/writer.py`, `src/data_platform/serving/canonical_writer.py`


---
## 背景与目标
项目文档 §16.1 要求提供 `get_formal_*` 与 canonical 查询的 Python 接口。P1a 阶段先落 canonical 读取通道，formal serving 留待 P1c 与 manifest 联动。本 issue 提供下游模块（`entity-registry` 等）可调用的最小接口。

## 所属模块
data_platform.serving.reader

## 实现范围
- 新建 `src/data_platform/serving/reader.py`：函数 `read_canonical(table: str, columns: list[str] | None = None, filters: list[tuple] | None = None) -> pa.Table`
- 内部使用 DuckDB connection（带连接池单例），通过 iceberg 扩展直读 catalog
- 提供 `get_canonical_stock_basic(active_only: bool = True) -> pa.Table` 便捷函数
- 提供 `with_duckdb_connection()` 上下文管理器
- 错误处理：表不存在抛 `CanonicalTableNotFound(table)`

## 不在本次范围
- 不实现 formal serving / manifest 读取（留给 P1c #35）
- 不实现写入接口
- 不暴露 PyIceberg 对象给消费方（封装边界）

## 关键交付物
- 函数签名 `def read_canonical(table: str, columns: list[str] | None = None, filters: list[tuple[str,str,Any]] | None = None) -> pa.Table`
- 单例 DuckDB 连接通过 `functools.lru_cache(maxsize=1)`
- `filters` 支持 `("col","=",val)`、`("col","in",[...])`，超出抛 `UnsupportedFilter`
- 单测使用 #12 写入后的数据
- `get_canonical_stock_basic(active_only=True)` 默认 `is_active = TRUE`

## 验收标准
- [ ] `read_canonical("stock_basic", columns=["ts_code","name"])` 返回正确字段
- [ ] `read_canonical("stock_basic", filters=[("market","=","主板")])` 行数与 DuckDB CLI 验证一致
- [ ] 读取不存在的表抛 `CanonicalTableNotFound`
- [ ] 单次读取 `< 2 秒`（§19.1 性能基线）
- [ ] `pytest tests/serving/test_reader.py` 通过

## 验证命令
```bash
cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
python -c "from data_platform.serving.reader import get_canonical_stock_basic; \
print(get_canonical_stock_basic().num_rows)"
pytest tests/serving/test_reader.py -q
```

## 依赖
依赖 #12（canonical 已有数据）