### PR TITLE
feat(#15): 端到端最小闭环冒烟（Raw → staging → Canonical → DuckDB）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: smoke-p1a
+
+smoke-p1a:
+	@scripts/smoke_p1a.sh

--- a/scripts/smoke_p1a.sh
+++ b/scripts/smoke_p1a.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -15,13 +15,16 @@ if [[ -z "${PYTHON:-}" ]]; then
   fi
 fi
 
+allow_skip="${DP_SMOKE_P1A_ALLOW_SKIP:-}"
 if [[ -z "${DP_PG_DSN:-}" ]]; then
-  if [[ -n "${DATABASE_URL:-}" ]]; then
-    export DP_PG_DSN="${DATABASE_URL}"
-  else
-    echo "P1a smoke skipped: DATABASE_URL or DP_PG_DSN is required for PostgreSQL"
-    exit 0
-  fi
+  case "${allow_skip}" in
+    1|true|TRUE|yes|YES)
+      echo "P1a smoke skipped: DP_PG_DSN is required for PostgreSQL"
+      exit 0
+      ;;
+  esac
+  echo "P1a smoke failed: DP_PG_DSN is required; DATABASE_URL is not used by this destructive smoke path" >&2
+  exit 2
 fi
 
 SMOKE_WORK_DIR="${DP_SMOKE_WORK_DIR:-${TMPDIR:-/tmp}/data-platform-p1a-smoke}"
@@ -30,12 +33,86 @@ PROFILES_DIR="${SMOKE_WORK_DIR}/dbt_profiles"
 DBT_TARGET_DIR="${SMOKE_WORK_DIR}/dbt_target"
 
 export PYTHONPATH="${ROOT_DIR}/src:${PYTHONPATH:-}"
+export DP_SMOKE_WORK_DIR="${SMOKE_WORK_DIR}"
 export DP_RAW_ZONE_PATH="${DP_RAW_ZONE_PATH:-${SMOKE_WORK_DIR}/raw}"
 export DP_ICEBERG_WAREHOUSE_PATH="${DP_ICEBERG_WAREHOUSE_PATH:-${SMOKE_WORK_DIR}/warehouse}"
 export DP_DUCKDB_PATH="${DP_DUCKDB_PATH:-${SMOKE_WORK_DIR}/data_platform.duckdb}"
-export DP_ICEBERG_CATALOG_NAME="${DP_ICEBERG_CATALOG_NAME:-data_platform}"
-export DP_ENV="${DP_ENV:-test}"
+export DP_ICEBERG_CATALOG_NAME="${DP_ICEBERG_CATALOG_NAME:-data_platform_p1a_smoke}"
+export DP_ENV="${DP_ENV:-}"
 export DBT_PROFILES_DIR="${PROFILES_DIR}"
+
+validate_smoke_target() {
+  "${PYTHON}" - <<'PY'
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+def fail(message: str) -> None:
+    print(f"P1a smoke failed: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def is_relative_to(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def database_name(dsn: str) -> str:
+    if dsn.startswith("jdbc:postgresql://"):
+        dsn = "postgresql://" + dsn.removeprefix("jdbc:postgresql://")
+
+    parsed = urlsplit(dsn)
+    if not parsed.scheme or not parsed.netloc:
+        fail("DP_PG_DSN must be a PostgreSQL URL with an explicit smoke database")
+
+    name = unquote(parsed.path.lstrip("/"))
+    if not name:
+        fail("DP_PG_DSN must include an explicit smoke database name")
+    return name
+
+
+truthy = {"1", "true", "yes"}
+if os.environ.get("DP_ENV") != "test":
+    fail("DP_ENV must be test for smoke-p1a")
+
+if os.environ.get("DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE", "").lower() not in truthy:
+    fail("set DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE=1 to confirm the isolated overwrite")
+
+db_name = database_name(os.environ["DP_PG_DSN"])
+if re.fullmatch(r"dp_p1a_smoke(?:_[A-Za-z0-9]+)?", db_name) is None:
+    fail(
+        "DP_PG_DSN database must match dp_p1a_smoke or dp_p1a_smoke_<suffix>; "
+        f"got {db_name!r}"
+    )
+
+catalog_name = os.environ["DP_ICEBERG_CATALOG_NAME"]
+if re.fullmatch(r"data_platform_p1a_smoke(?:_[A-Za-z0-9]+)?", catalog_name) is None:
+    fail(
+        "DP_ICEBERG_CATALOG_NAME must match data_platform_p1a_smoke or "
+        f"data_platform_p1a_smoke_<suffix>; got {catalog_name!r}"
+    )
+
+smoke_work_dir = Path(os.environ["DP_SMOKE_WORK_DIR"]).expanduser().resolve(strict=False)
+smoke_token = re.compile(r"(?:^|[^A-Za-z0-9])(?:p1a[-_]?smoke|smoke[-_]?p1a)(?:$|[^A-Za-z0-9])")
+if smoke_token.search(str(smoke_work_dir)) is None:
+    fail("DP_SMOKE_WORK_DIR path must include p1a-smoke, p1a_smoke, smoke-p1a, or smoke_p1a")
+
+for key in ("DP_RAW_ZONE_PATH", "DP_ICEBERG_WAREHOUSE_PATH", "DP_DUCKDB_PATH"):
+    path = Path(os.environ[key]).expanduser().resolve(strict=False)
+    if not is_relative_to(path, smoke_work_dir):
+        fail(f"{key} must be inside DP_SMOKE_WORK_DIR")
+PY
+}
+
+validate_smoke_target
 
 mkdir -p \
   "${DP_RAW_ZONE_PATH}" \

--- a/scripts/smoke_p1a.sh
+++ b/scripts/smoke_p1a.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -d "${ROOT_DIR}/.venv/bin" ]]; then
+  export PATH="${ROOT_DIR}/.venv/bin:${PATH}"
+fi
+
+if [[ -z "${PYTHON:-}" ]]; then
+  if [[ -x "${ROOT_DIR}/.venv/bin/python" ]]; then
+    PYTHON="${ROOT_DIR}/.venv/bin/python"
+  else
+    PYTHON="python3"
+  fi
+fi
+
+if [[ -z "${DP_PG_DSN:-}" ]]; then
+  if [[ -n "${DATABASE_URL:-}" ]]; then
+    export DP_PG_DSN="${DATABASE_URL}"
+  else
+    echo "P1a smoke skipped: DATABASE_URL or DP_PG_DSN is required for PostgreSQL"
+    exit 0
+  fi
+fi
+
+SMOKE_WORK_DIR="${DP_SMOKE_WORK_DIR:-${TMPDIR:-/tmp}/data-platform-p1a-smoke}"
+LOG_DIR="${DP_SMOKE_LOG_DIR:-${SMOKE_WORK_DIR}/logs}"
+PROFILES_DIR="${SMOKE_WORK_DIR}/dbt_profiles"
+DBT_TARGET_DIR="${SMOKE_WORK_DIR}/dbt_target"
+
+export PYTHONPATH="${ROOT_DIR}/src:${PYTHONPATH:-}"
+export DP_RAW_ZONE_PATH="${DP_RAW_ZONE_PATH:-${SMOKE_WORK_DIR}/raw}"
+export DP_ICEBERG_WAREHOUSE_PATH="${DP_ICEBERG_WAREHOUSE_PATH:-${SMOKE_WORK_DIR}/warehouse}"
+export DP_DUCKDB_PATH="${DP_DUCKDB_PATH:-${SMOKE_WORK_DIR}/data_platform.duckdb}"
+export DP_ICEBERG_CATALOG_NAME="${DP_ICEBERG_CATALOG_NAME:-data_platform}"
+export DP_ENV="${DP_ENV:-test}"
+export DBT_PROFILES_DIR="${PROFILES_DIR}"
+
+mkdir -p \
+  "${DP_RAW_ZONE_PATH}" \
+  "${DP_ICEBERG_WAREHOUSE_PATH}" \
+  "$(dirname "${DP_DUCKDB_PATH}")" \
+  "${LOG_DIR}" \
+  "${PROFILES_DIR}" \
+  "${DBT_TARGET_DIR}"
+
+cat > "${PROFILES_DIR}/profiles.yml" <<YAML
+data_platform:
+  target: smoke
+  outputs:
+    smoke:
+      type: duckdb
+      path: "{{ env_var('DP_DUCKDB_PATH') }}"
+      threads: 1
+YAML
+
+step_index=0
+started_at="$(date +%s)"
+
+run_step() {
+  local name="$1"
+  shift
+  step_index=$((step_index + 1))
+  local log_file="${LOG_DIR}/step_${step_index}.log"
+
+  printf '[smoke-p1a] step %d: %s\n' "${step_index}" "${name}"
+  if "$@" >"${log_file}" 2>&1; then
+    return 0
+  fi
+
+  local exit_code=$?
+  {
+    printf '\n[smoke-p1a] step failed: %s (exit %d)\n' "${name}" "${exit_code}"
+    printf '[smoke-p1a] last 50 log lines from %s:\n' "${log_file}"
+    tail -n 50 "${log_file}" || true
+  } >&2
+  exit "${exit_code}"
+}
+
+seed_tushare_fixture() {
+  "${PYTHON}" - <<'PY'
+from __future__ import annotations
+
+from datetime import date
+import uuid
+
+import pandas as pd
+
+from data_platform.adapters.tushare import TushareAdapter
+from data_platform.raw import RawWriter
+
+
+class MockTushareClient:
+    def stock_basic(self, **_kwargs: object) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                {
+                    "ts_code": "000001.SZ",
+                    "symbol": "000001",
+                    "name": "Ping An Bank",
+                    "area": "Shenzhen",
+                    "industry": "Banking",
+                    "market": "Main Board",
+                    "list_status": "L",
+                    "list_date": "19910403",
+                    "delist_date": None,
+                    "is_hs": "S",
+                    "act_name": "fixture",
+                    "act_ent_type": "fixture",
+                    "cnspell": "payh",
+                    "curr_type": "CNY",
+                    "enname": "Ping An Bank Co Ltd",
+                    "exchange": "SZSE",
+                    "fullname": "Ping An Bank Co Ltd",
+                },
+                {
+                    "ts_code": "000002.SZ",
+                    "symbol": "000002",
+                    "name": "Vanke A",
+                    "area": "Shenzhen",
+                    "industry": "Real Estate",
+                    "market": "Main Board",
+                    "list_status": "L",
+                    "list_date": "19910129",
+                    "delist_date": None,
+                    "is_hs": "S",
+                    "act_name": "fixture",
+                    "act_ent_type": "fixture",
+                    "cnspell": "wka",
+                    "curr_type": "CNY",
+                    "enname": "China Vanke Co Ltd",
+                    "exchange": "SZSE",
+                    "fullname": "China Vanke Co Ltd",
+                },
+                {
+                    "ts_code": "300001.SZ",
+                    "symbol": "300001",
+                    "name": "Teruide",
+                    "area": "Qingdao",
+                    "industry": "Electrical Equipment",
+                    "market": "ChiNext",
+                    "list_status": "L",
+                    "list_date": "20091030",
+                    "delist_date": None,
+                    "is_hs": "N",
+                    "act_name": "fixture",
+                    "act_ent_type": "fixture",
+                    "cnspell": "tld",
+                    "curr_type": "CNY",
+                    "enname": "Qingdao TGOOD Electric Co Ltd",
+                    "exchange": "SZSE",
+                    "fullname": "Qingdao TGOOD Electric Co Ltd",
+                },
+            ]
+        )
+
+
+adapter = TushareAdapter(token="mock-token", client=MockTushareClient())
+table = adapter.fetch("tushare_stock_basic", {})
+artifact = RawWriter().write_arrow(
+    adapter.source_id(),
+    "stock_basic",
+    date(2026, 4, 15),
+    f"p1a-smoke-{uuid.uuid4().hex}",
+    table,
+)
+print(artifact.path)
+PY
+}
+
+query_canonical_with_duckdb() {
+  "${PYTHON}" - <<'PY'
+from __future__ import annotations
+
+import json
+
+from data_platform.serving.reader import read_canonical
+
+
+expected_columns = [
+    "ts_code",
+    "symbol",
+    "name",
+    "area",
+    "industry",
+    "market",
+    "list_date",
+    "is_active",
+    "source_run_id",
+    "canonical_loaded_at",
+]
+
+table = read_canonical("stock_basic")
+if table.num_rows != 3:
+    raise SystemExit(f"expected 3 canonical.stock_basic rows, got {table.num_rows}")
+if table.schema.names != expected_columns:
+    raise SystemExit(
+        "unexpected canonical.stock_basic columns: "
+        + json.dumps(table.schema.names, sort_keys=True)
+    )
+
+print(json.dumps({"columns": table.schema.names, "row_count": table.num_rows}))
+PY
+}
+
+run_step "migrate" "${PYTHON}" -m data_platform.ddl.runner --upgrade
+run_step "init catalog" "${PYTHON}" "${ROOT_DIR}/scripts/init_iceberg_catalog.py"
+run_step "ensure tables" "${PYTHON}" -m data_platform.ddl.iceberg_tables --ensure
+run_step "fetch tushare fixture" seed_tushare_fixture
+run_step "dbt run" "${ROOT_DIR}/scripts/dbt.sh" run --profiles-dir "${PROFILES_DIR}" --target-path "${DBT_TARGET_DIR}" --select stg_stock_basic
+run_step "canonical write" "${PYTHON}" -m data_platform.serving.canonical_writer --table stock_basic
+run_step "reader query" query_canonical_with_duckdb
+
+duration_s=$(($(date +%s) - started_at))
+printf 'P1a smoke OK duration_s=%d log_dir=%s\n' "${duration_s}" "${LOG_DIR}"

--- a/src/data_platform/ddl/iceberg_tables.py
+++ b/src/data_platform/ddl/iceberg_tables.py
@@ -231,7 +231,16 @@ def _table_schema_as_pyarrow(table: Table) -> pa.Schema:
 
 
 def _schema_field_contract(schema: pa.Schema) -> list[tuple[str, pa.DataType, bool]]:
-    return [(field.name, field.type, field.nullable) for field in schema]
+    return [
+        (field.name, _normalize_iceberg_arrow_type(field.type), field.nullable)
+        for field in schema
+    ]
+
+
+def _normalize_iceberg_arrow_type(data_type: pa.DataType) -> pa.DataType:
+    if pa.types.is_string(data_type) or pa.types.is_large_string(data_type):
+        return pa.string()
+    return data_type
 
 
 def _format_schema_contract(fields: Sequence[tuple[str, pa.DataType, bool]]) -> str:

--- a/src/data_platform/ddl/runner.py
+++ b/src/data_platform/ddl/runner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -105,7 +104,7 @@ class MigrationRunner:
             engine.dispose()
 
     def _create_engine(self, dsn: str) -> Engine:
-        return create_engine(dsn)
+        return create_engine(_sqlalchemy_postgres_uri(dsn))
 
     def _load_migrations(self) -> list[Migration]:
         if not self.migrations_path.exists():
@@ -189,11 +188,15 @@ class MigrationRunner:
 
 
 def _resolve_dsn() -> str:
-    env_dsn = os.environ.get("DP_PG_DSN")
-    if env_dsn:
-        return env_dsn
-
     return str(get_settings().pg_dsn)
+
+
+def _sqlalchemy_postgres_uri(dsn: str) -> str:
+    if dsn.startswith("postgresql://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgresql://")
+    if dsn.startswith("postgres://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgres://")
+    return dsn
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tests/ddl/test_iceberg_tables.py
+++ b/tests/ddl/test_iceberg_tables.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import pyarrow as pa  # type: ignore[import-untyped]
 import pytest
+from pyiceberg.catalog.memory import InMemoryCatalog
 
 from data_platform.ddl import iceberg_tables
 from data_platform.ddl.iceberg_tables import (
@@ -193,6 +195,17 @@ def test_ensure_tables_rejects_existing_table_schema_drift() -> None:
         ensure_tables(catalog, [spec])  # type: ignore[arg-type]
 
     assert catalog.create_calls == []
+
+
+def test_ensure_tables_accepts_real_pyiceberg_string_schema(tmp_path: Path) -> None:
+    catalog = InMemoryCatalog("test", warehouse=str(tmp_path / "warehouse"))
+
+    tables = ensure_tables(catalog, [CANONICAL_STOCK_BASIC_SPEC])
+
+    assert len(tables) == 1
+    assert catalog.load_table("canonical.stock_basic").schema().as_arrow().names == (
+        CANONICAL_STOCK_BASIC_SPEC.schema.names
+    )
 
 
 def test_cli_ensure_uses_project_catalog_and_default_specs(

--- a/tests/ddl/test_runner.py
+++ b/tests/ddl/test_runner.py
@@ -11,6 +11,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import SQLAlchemyError
 
+from data_platform.ddl import runner as runner_module
 from data_platform.ddl.runner import MigrationError, MigrationRunner
 
 
@@ -93,6 +94,22 @@ def test_load_migrations_rejects_duplicate_versions(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="duplicate migration version: 0001"):
         runner._load_migrations()
+
+
+def test_create_engine_rewrites_plain_postgres_dsn_to_psycopg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_dsns: list[str] = []
+    fake_engine = object()
+
+    def fake_create_engine(dsn: str) -> object:
+        seen_dsns.append(dsn)
+        return fake_engine
+
+    monkeypatch.setattr(runner_module, "create_engine", fake_create_engine)
+
+    assert MigrationRunner()._create_engine("postgresql://dp:dp@localhost/db") is fake_engine
+    assert seen_dsns == ["postgresql+psycopg://dp:dp@localhost/db"]
 
 
 def test_apply_pending_is_idempotent_and_creates_schema(postgres_dsn: str) -> None:

--- a/tests/integration/test_p1a_smoke.py
+++ b/tests/integration/test_p1a_smoke.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import SQLAlchemyError
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_ROW_COUNT = 3
+EXPECTED_COLUMNS = [
+    "ts_code",
+    "symbol",
+    "name",
+    "area",
+    "industry",
+    "market",
+    "list_date",
+    "is_active",
+    "source_run_id",
+    "canonical_loaded_at",
+]
+
+
+@pytest.fixture()
+def postgres_dsn() -> Iterator[str]:
+    admin_dsn = os.environ.get("DATABASE_URL")
+    if not admin_dsn:
+        pytest.skip("P1a smoke integration requires DATABASE_URL")
+
+    admin_engine = create_engine(_sqlalchemy_postgres_uri(admin_dsn), isolation_level="AUTOCOMMIT")
+    database_name = f"dp_p1a_smoke_{uuid4().hex}"
+    try:
+        with admin_engine.connect() as connection:
+            connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+    except SQLAlchemyError as exc:
+        admin_engine.dispose()
+        pytest.skip(f"P1a smoke integration requires a usable PostgreSQL DATABASE_URL: {exc}")
+
+    test_dsn = str(make_url(admin_dsn).set(database=database_name))
+    try:
+        yield test_dsn
+    finally:
+        with admin_engine.connect() as connection:
+            connection.execute(
+                text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+        admin_engine.dispose()
+
+
+def test_p1a_smoke_pipeline_is_repeatable(
+    tmp_path: Path,
+    postgres_dsn: str,
+) -> None:
+    env = _smoke_env(tmp_path, postgres_dsn)
+
+    first = _run_smoke(env)
+    second = _run_smoke(env)
+    payload = _query_canonical_payload(env)
+
+    assert "P1a smoke OK" in first.stdout
+    assert "P1a smoke OK" in second.stdout
+    assert _duration_seconds(second.stdout) < 300
+    assert payload["catalog_row_count"] == FIXTURE_ROW_COUNT
+    assert payload["duckdb_row_count"] == FIXTURE_ROW_COUNT
+    assert payload["duckdb_columns"] == EXPECTED_COLUMNS
+
+
+def _smoke_env(tmp_path: Path, postgres_dsn: str) -> dict[str, str]:
+    smoke_dir = tmp_path / "smoke"
+    env = os.environ.copy()
+    env.update(
+        {
+            "DP_PG_DSN": postgres_dsn,
+            "DP_SMOKE_WORK_DIR": str(smoke_dir),
+            "DP_RAW_ZONE_PATH": str(smoke_dir / "raw"),
+            "DP_ICEBERG_WAREHOUSE_PATH": str(smoke_dir / "warehouse"),
+            "DP_DUCKDB_PATH": str(smoke_dir / "data_platform.duckdb"),
+            "DP_ICEBERG_CATALOG_NAME": "data_platform_p1a_test",
+            "DP_ENV": "test",
+            "PYTHON": sys.executable,
+            "PYTHONPATH": str(PROJECT_ROOT / "src"),
+        }
+    )
+    env["PATH"] = f"{Path(sys.executable).parent}{os.pathsep}{env.get('PATH', '')}"
+    return env
+
+
+def _run_smoke(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["bash", str(PROJECT_ROOT / "scripts" / "smoke_p1a.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "skipped" not in result.stdout.lower()
+    return result
+
+
+def _query_canonical_payload(env: dict[str, str]) -> dict[str, object]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+from __future__ import annotations
+
+import json
+
+from data_platform.serving.catalog import load_catalog
+from data_platform.serving.reader import read_canonical
+
+catalog_table = load_catalog().load_table("canonical.stock_basic").scan().to_arrow()
+duckdb_table = read_canonical("stock_basic")
+print(
+    json.dumps(
+        {
+            "catalog_row_count": catalog_table.num_rows,
+            "duckdb_columns": duckdb_table.schema.names,
+            "duckdb_row_count": duckdb_table.num_rows,
+        },
+        sort_keys=True,
+    )
+)
+""",
+        ],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def _duration_seconds(output: str) -> int:
+    match = re.search(r"duration_s=(\d+)", output)
+    assert match is not None, output
+    return int(match.group(1))
+
+
+def _sqlalchemy_postgres_uri(dsn: str) -> str:
+    if dsn.startswith("postgresql://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgresql://")
+    if dsn.startswith("postgres://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgres://")
+    return dsn

--- a/tests/integration/test_p1a_smoke.py
+++ b/tests/integration/test_p1a_smoke.py
@@ -14,6 +14,8 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import SQLAlchemyError
 
+from data_platform.ddl.runner import _sqlalchemy_postgres_uri
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_ROW_COUNT = 3
@@ -84,9 +86,71 @@ def test_p1a_smoke_pipeline_is_repeatable(
     assert payload["duckdb_columns"] == EXPECTED_COLUMNS
 
 
+def test_p1a_smoke_requires_dp_pg_dsn(tmp_path: Path) -> None:
+    env = _base_script_env(tmp_path)
+    env["DATABASE_URL"] = "postgresql://dp:dp@localhost/data_platform"
+
+    result = _run_smoke_raw(env)
+
+    assert result.returncode == 2
+    assert "DP_PG_DSN is required" in result.stderr
+    assert "DATABASE_URL is not used" in result.stderr
+
+
+def test_p1a_smoke_allows_explicit_skip_without_dp_pg_dsn(tmp_path: Path) -> None:
+    env = _base_script_env(tmp_path)
+    env["DP_SMOKE_P1A_ALLOW_SKIP"] = "1"
+
+    result = _run_smoke_raw(env)
+
+    assert result.returncode == 0
+    assert "P1a smoke skipped" in result.stdout
+
+
+def test_p1a_smoke_refuses_non_smoke_database(tmp_path: Path) -> None:
+    env = _base_script_env(tmp_path)
+    env.update(
+        {
+            "DP_PG_DSN": "postgresql://dp:dp@localhost/data_platform",
+            "DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE": "1",
+        }
+    )
+
+    result = _run_smoke_raw(env)
+
+    assert result.returncode == 2
+    assert "database must match dp_p1a_smoke" in result.stderr
+
+
+def test_p1a_smoke_requires_destructive_confirmation(tmp_path: Path) -> None:
+    env = _base_script_env(tmp_path)
+    env["DP_PG_DSN"] = "postgresql://dp:dp@localhost/dp_p1a_smoke_local"
+
+    result = _run_smoke_raw(env)
+
+    assert result.returncode == 2
+    assert "DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE=1" in result.stderr
+
+
+def test_p1a_smoke_requires_test_env(tmp_path: Path) -> None:
+    env = _base_script_env(tmp_path)
+    env.update(
+        {
+            "DP_PG_DSN": "postgresql://dp:dp@localhost/dp_p1a_smoke_local",
+            "DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE": "1",
+        }
+    )
+    env.pop("DP_ENV")
+
+    result = _run_smoke_raw(env)
+
+    assert result.returncode == 2
+    assert "DP_ENV must be test" in result.stderr
+
+
 def _smoke_env(tmp_path: Path, postgres_dsn: str) -> dict[str, str]:
-    smoke_dir = tmp_path / "smoke"
-    env = os.environ.copy()
+    smoke_dir = tmp_path / "p1a-smoke"
+    env = _base_script_env(tmp_path)
     env.update(
         {
             "DP_PG_DSN": postgres_dsn,
@@ -94,8 +158,9 @@ def _smoke_env(tmp_path: Path, postgres_dsn: str) -> dict[str, str]:
             "DP_RAW_ZONE_PATH": str(smoke_dir / "raw"),
             "DP_ICEBERG_WAREHOUSE_PATH": str(smoke_dir / "warehouse"),
             "DP_DUCKDB_PATH": str(smoke_dir / "data_platform.duckdb"),
-            "DP_ICEBERG_CATALOG_NAME": "data_platform_p1a_test",
+            "DP_ICEBERG_CATALOG_NAME": "data_platform_p1a_smoke",
             "DP_ENV": "test",
+            "DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE": "1",
             "PYTHON": sys.executable,
             "PYTHONPATH": str(PROJECT_ROOT / "src"),
         }
@@ -104,8 +169,31 @@ def _smoke_env(tmp_path: Path, postgres_dsn: str) -> dict[str, str]:
     return env
 
 
-def _run_smoke(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(
+def _base_script_env(tmp_path: Path) -> dict[str, str]:
+    smoke_dir = tmp_path / "p1a-smoke"
+    env = os.environ.copy()
+    env.update(
+        {
+            "DP_SMOKE_WORK_DIR": str(smoke_dir),
+            "DP_RAW_ZONE_PATH": str(smoke_dir / "raw"),
+            "DP_ICEBERG_WAREHOUSE_PATH": str(smoke_dir / "warehouse"),
+            "DP_DUCKDB_PATH": str(smoke_dir / "data_platform.duckdb"),
+            "DP_ICEBERG_CATALOG_NAME": "data_platform_p1a_smoke",
+            "DP_ENV": "test",
+            "PYTHON": sys.executable,
+            "PYTHONPATH": str(PROJECT_ROOT / "src"),
+        }
+    )
+    env.pop("DP_PG_DSN", None)
+    env.pop("DATABASE_URL", None)
+    env.pop("DP_SMOKE_P1A_ALLOW_SKIP", None)
+    env.pop("DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE", None)
+    env["PATH"] = f"{Path(sys.executable).parent}{os.pathsep}{env.get('PATH', '')}"
+    return env
+
+
+def _run_smoke_raw(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
         ["bash", str(PROJECT_ROOT / "scripts" / "smoke_p1a.sh")],
         cwd=PROJECT_ROOT,
         env=env,
@@ -114,6 +202,10 @@ def _run_smoke(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
         check=False,
         timeout=300,
     )
+
+
+def _run_smoke(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = _run_smoke_raw(env)
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "skipped" not in result.stdout.lower()
@@ -163,11 +255,3 @@ def _duration_seconds(output: str) -> int:
     match = re.search(r"duration_s=(\d+)", output)
     assert match is not None, output
     return int(match.group(1))
-
-
-def _sqlalchemy_postgres_uri(dsn: str) -> str:
-    if dsn.startswith("postgresql://"):
-        return "postgresql+psycopg://" + dsn.removeprefix("postgresql://")
-    if dsn.startswith("postgres://"):
-        return "postgresql+psycopg://" + dsn.removeprefix("postgres://")
-    return dsn


### PR DESCRIPTION
Closes #15

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `docs/spike/iceberg-write-chain.md`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/base.py`, `src/data_platform/config/settings.py`, `src/data_platform/ddl/iceberg_tables.py`, `src/data_platform/ddl/runner.py`, `src/data_platform/raw/writer.py`, `src/data_platform/serving/canonical_writer.py`


---
## 背景与目标
项目文档 §21 阶段 0 退出条件 "DuckDB 可查到 snapshot" 与 §23 验收第 2 条 "至少 1 个 API 样例完成 Raw → staging → Canonical → DuckDB 读取闭环"。本 issue 把前面 13 个 issue 串成一条可重复执行的 smoke pipeline，是 P1a 完成的最终判定。

## 所属模块
scripts/smoke + tests/integration

## 实现范围
- 新建 `scripts/smoke_p1a.sh`：依次执行 `migrate → init catalog → ensure tables → fetch tushare → dbt run → canonical write → reader query`
- 新建 `tests/integration/test_p1a_smoke.py`：使用 mock tushare + 临时 PG/warehouse/duckdb，跑完整链路并断言最终行数
- 提供 `make smoke-p1a` target（在 `Makefile` 中）
- 总耗时记录到 stdout（用于验证 `< 5 分钟` SLA）
- 失败时打印每一步的最后 50 行日志便于排查

## 不在本次范围
- 不接入 CI（CI 配置留给后续 issue）
- 不接入 Layer B 队列（属于 P1c）
- 不执行真实 Tushare 调用（用 fixture）

## 关键交付物
- `scripts/smoke_p1a.sh` 单一脚本，每步退出码检查
- `tests/integration/test_p1a_smoke.py` 单测覆盖完整链路
- `Makefile` 含 `smoke-p1a:` 目标
- 测试断言：`canonical.stock_basic` 行数 == fixture 行数
- 测试断言：DuckDB 查询返回正确字段集

## 验收标准
- [ ] `make smoke-p1a` 在干净环境一次成功
- [ ] 总耗时 `< 5 分钟`（§19.1 性能基线）
- [ ] 重跑 smoke 行为幂等（重跑后最新 snapshot 行数仍正确）
- [ ] 测试日志显示 "P1a smoke OK" 字样
- [ ] `pytest tests/integration/test_p1a_smoke.py` 通过

## 验证命令
```bash
cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
make smoke-p1a
pytest tests/integration/test_p1a_smoke.py -v
```

## 依赖
依赖 #4, #5, #6, #7, #9, #11, #12, #13