### PR TITLE
feat(#53): [milestone-0 review] P0: DataSourceAdapter contract drift

### DIFF
--- a/src/data_platform/adapters/base.py
+++ b/src/data_platform/adapters/base.py
@@ -5,63 +5,24 @@ from __future__ import annotations
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import UTC, date, datetime
 from threading import Lock
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Literal,
     Mapping,
-    Protocol,
-    Sequence,
     TypeAlias,
-    runtime_checkable,
+    cast,
 )
 
-
-@runtime_checkable
-class _ArrowTable(Protocol):
-    num_rows: int
-
-
-if TYPE_CHECKING:
-    Schema: TypeAlias = Any
-    Table: TypeAlias = _ArrowTable
-else:
-    try:
-        from pyarrow import Schema, Table
-        import pyarrow as pa
-    except ModuleNotFoundError:
-
-        class Schema:
-            """Minimal fallback used only when pyarrow is unavailable locally."""
-
-            def __init__(self, fields: Sequence[tuple[str, Any]] | None = None) -> None:
-                self.fields = tuple(fields or ())
-
-        class Table:
-            """Minimal fallback used only when pyarrow is unavailable locally."""
-
-            def __init__(self, rows: Sequence[Mapping[str, Any]] | None = None) -> None:
-                self.num_rows = len(rows or ())
-
-        class _PyArrowFallback:
-            Schema = Schema
-            Table = Table
-
-            @staticmethod
-            def schema(fields: Sequence[tuple[str, Any]]) -> Schema:
-                return Schema(fields)
-
-            @staticmethod
-            def table(rows: Sequence[Mapping[str, Any]]) -> Table:
-                return Table(rows)
-
-        pa = _PyArrowFallback()
+import pyarrow as pa  # type: ignore[import-untyped]
+from pyarrow import Schema, Table
 
 FetchParams: TypeAlias = Mapping[str, Any]
 FetchResult: TypeAlias = Table | list[dict[str, Any]]
 PartitionType: TypeAlias = Literal["daily", "static"]
+_ARROW_TABLE_TYPE: type[Any] = pa.Table
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,6 +54,16 @@ class QuotaConfig:
             msg = "backoff_seconds must be non-negative"
             raise ValueError(msg)
 
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> QuotaConfig:
+        """Build the internal quota config from the external adapter contract dict."""
+
+        return cls(
+            requests_per_minute=int(value["requests_per_minute"]),
+            daily_credit_quota=_optional_int(value.get("daily_credit_quota")),
+            backoff_seconds=float(value.get("backoff_seconds", 1.0)),
+        )
+
 
 class AdapterQuotaExceeded(RuntimeError):
     """Raised when an adapter-level quota is exhausted."""
@@ -118,10 +89,6 @@ class DataSourceAdapter(ABC):
     """Contract implemented by data source adapters."""
 
     @abstractmethod
-    def source_id(self) -> str:
-        """Return the unique source identifier for this adapter."""
-
-    @abstractmethod
     def get_assets(self) -> list[AssetSpec]:
         """Return data assets exposed by this adapter."""
 
@@ -134,15 +101,23 @@ class DataSourceAdapter(ABC):
         """Return staging dbt model names required for this adapter."""
 
     @abstractmethod
-    def get_quota_config(self) -> QuotaConfig:
+    def get_quota_config(self) -> dict[str, Any]:
         """Return quota configuration for this adapter."""
+
+
+class FetchableAdapter(DataSourceAdapter):
+    """Runtime adapter layer with source identity and fetch behavior."""
+
+    @abstractmethod
+    def source_id(self) -> str:
+        """Return the unique source identifier for this adapter."""
 
     @abstractmethod
     def fetch(self, asset_id: str, params: FetchParams) -> FetchResult:
         """Fetch one asset from the source."""
 
 
-class BaseAdapter(DataSourceAdapter):
+class BaseAdapter(FetchableAdapter):
     """Base adapter with shared throttling, retry, and fetch error handling."""
 
     def __init__(
@@ -163,6 +138,7 @@ class BaseAdapter(DataSourceAdapter):
         self._tokens = 0.0
         self._last_token_refill = self._clock()
         self._daily_credits_used = 0
+        self._daily_credit_date = self._utc_today()
 
     def fetch(self, asset_id: str, params: FetchParams) -> FetchResult:
         """Fetch with quota throttling, retry-on-429, and error wrapping."""
@@ -177,7 +153,7 @@ class BaseAdapter(DataSourceAdapter):
             except Exception as exc:
                 if self._is_rate_limit_error(exc) and attempt < self._max_retries:
                     attempt += 1
-                    self._sleep(self.get_quota_config().backoff_seconds)
+                    self._sleep(self._runtime_quota_config().backoff_seconds)
                     continue
                 raise AdapterFetchError(self.source_id(), asset_id, exc) from exc
 
@@ -188,21 +164,22 @@ class BaseAdapter(DataSourceAdapter):
     def _throttle(self) -> None:
         """Block until this adapter has a request token available."""
 
-        quota = self.get_quota_config()
+        quota = self._runtime_quota_config()
         seconds_per_token = 60.0 / quota.requests_per_minute
-        with self._quota_lock:
-            while self._tokens < 1.0:
+        while True:
+            with self._quota_lock:
                 now = self._clock()
                 elapsed = max(0.0, now - self._last_token_refill)
                 self._tokens = min(1.0, self._tokens + (elapsed / seconds_per_token))
                 self._last_token_refill = now
+
                 if self._tokens >= 1.0:
-                    break
+                    self._tokens -= 1.0
+                    return
 
                 wait_seconds = (1.0 - self._tokens) * seconds_per_token
-                self._sleep(wait_seconds)
 
-            self._tokens -= 1.0
+            self._sleep(wait_seconds)
 
     def on_fetch_complete(self, asset_id: str, row_count: int, duration_s: float) -> None:
         """Hook called after successful fetch completion."""
@@ -212,20 +189,32 @@ class BaseAdapter(DataSourceAdapter):
         """Fetch one asset without shared BaseAdapter error handling."""
 
     def _reserve_daily_credit(self) -> None:
-        quota = self.get_quota_config()
+        quota = self._runtime_quota_config()
         if quota.daily_credit_quota is None:
             return
 
         with self._daily_credit_lock:
+            today = self._utc_today()
+            if today != self._daily_credit_date:
+                self._daily_credits_used = 0
+                self._daily_credit_date = today
+
             if self._daily_credits_used >= quota.daily_credit_quota:
                 msg = f"daily credit quota exceeded for source_id={self.source_id()!r}"
                 raise AdapterQuotaExceeded(msg)
             self._daily_credits_used += 1
 
+    def _runtime_quota_config(self) -> QuotaConfig:
+        return QuotaConfig.from_mapping(self.get_quota_config())
+
+    @staticmethod
+    def _utc_today() -> date:
+        return datetime.now(UTC).date()
+
     @staticmethod
     def _row_count(result: FetchResult) -> int:
-        if isinstance(result, Table):
-            return int(result.num_rows)
+        if isinstance(result, _ARROW_TABLE_TYPE):
+            return int(cast(Any, result).num_rows)
         return len(result)
 
     @staticmethod
@@ -247,10 +236,10 @@ class AdapterRegistry:
     """Thread-safe registry for source adapters."""
 
     def __init__(self) -> None:
-        self._adapters: dict[str, DataSourceAdapter] = {}
+        self._adapters: dict[str, FetchableAdapter] = {}
         self._lock = Lock()
 
-    def register(self, adapter: DataSourceAdapter) -> None:
+    def register(self, adapter: FetchableAdapter) -> None:
         source_id = adapter.source_id()
         with self._lock:
             if source_id in self._adapters:
@@ -258,7 +247,7 @@ class AdapterRegistry:
                 raise AdapterAlreadyRegistered(msg)
             self._adapters[source_id] = adapter
 
-    def get(self, source_id: str) -> DataSourceAdapter:
+    def get(self, source_id: str) -> FetchableAdapter:
         with self._lock:
             return self._adapters[source_id]
 
@@ -267,7 +256,14 @@ class AdapterRegistry:
             return list(self._adapters)
 
 
-_REGISTRY = AdapterRegistry()
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+REGISTRY = AdapterRegistry()
+"""Process-global adapter registry for orchestrator assembly."""
 
 __all__ = [
     "AdapterAlreadyRegistered",
@@ -277,9 +273,10 @@ __all__ = [
     "AssetSpec",
     "BaseAdapter",
     "DataSourceAdapter",
+    "FetchableAdapter",
     "FetchParams",
     "FetchResult",
     "PartitionType",
     "QuotaConfig",
-    "_REGISTRY",
+    "REGISTRY",
 ]

--- a/src/data_platform/adapters/tushare/adapter.py
+++ b/src/data_platform/adapters/tushare/adapter.py
@@ -15,7 +15,7 @@ from typing import Any, Protocol, cast
 import pyarrow as pa  # type: ignore[import-untyped]
 import pandas as pd  # type: ignore[import-untyped]
 
-from data_platform.adapters.base import AssetSpec, BaseAdapter, FetchParams, QuotaConfig
+from data_platform.adapters.base import AssetSpec, BaseAdapter, FetchParams
 from data_platform.adapters.tushare.assets import (
     TUSHARE_ASSETS,
     TUSHARE_STOCK_BASIC_ASSET_NAME,
@@ -56,7 +56,10 @@ class TushareAdapter(BaseAdapter):
 
         self._token = resolved_token
         self._client = client
-        self._quota_config = QuotaConfig(requests_per_minute=200, daily_credit_quota=None)
+        self._quota_config: dict[str, Any] = {
+            "requests_per_minute": 200,
+            "daily_credit_quota": None,
+        }
         super().__init__(max_retries=max_retries)
 
     def source_id(self) -> str:
@@ -71,8 +74,8 @@ class TushareAdapter(BaseAdapter):
     def get_staging_dbt_models(self) -> list[str]:
         return ["stg_stock_basic"]
 
-    def get_quota_config(self) -> QuotaConfig:
-        return self._quota_config
+    def get_quota_config(self) -> dict[str, Any]:
+        return dict(self._quota_config)
 
     def _fetch(self, asset_id: str, params: FetchParams) -> pa.Table:
         if asset_id != TUSHARE_STOCK_BASIC_ASSET_NAME:

--- a/tests/adapters/test_base.py
+++ b/tests/adapters/test_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date
 from typing import Any, Mapping
 
 import pytest
@@ -13,6 +14,7 @@ from data_platform.adapters.base import (
     AssetSpec,
     BaseAdapter,
     DataSourceAdapter,
+    FetchableAdapter,
     FetchParams,
     FetchResult,
     QuotaConfig,
@@ -38,13 +40,13 @@ class ExampleAdapter(BaseAdapter):
         self,
         *,
         source: str = "example",
-        quota: QuotaConfig | None = None,
+        quota: dict[str, Any] | None = None,
         side_effects: list[FetchResult | BaseException] | None = None,
         clock: FakeClock | None = None,
         max_retries: int = 3,
     ) -> None:
         self._source = source
-        self._quota = quota or QuotaConfig(requests_per_minute=60_000, daily_credit_quota=None)
+        self._quota = quota or {"requests_per_minute": 60_000, "daily_credit_quota": None}
         self._side_effects = side_effects or [[{"id": 1}]]
         self.fetch_calls: list[tuple[str, FetchParams]] = []
         self.completed: list[tuple[str, int, float]] = []
@@ -66,8 +68,8 @@ class ExampleAdapter(BaseAdapter):
     def get_staging_dbt_models(self) -> list[str]:
         return []
 
-    def get_quota_config(self) -> QuotaConfig:
-        return self._quota
+    def get_quota_config(self) -> dict[str, Any]:
+        return dict(self._quota)
 
     def on_fetch_complete(self, asset_id: str, row_count: int, duration_s: float) -> None:
         self.completed.append((asset_id, row_count, duration_s))
@@ -81,11 +83,33 @@ class ExampleAdapter(BaseAdapter):
 
 
 def test_data_source_adapter_requires_all_methods() -> None:
+    assert DataSourceAdapter.__abstractmethods__ == frozenset(
+        {
+            "get_assets",
+            "get_resources",
+            "get_staging_dbt_models",
+            "get_quota_config",
+        }
+    )
+
     class MissingMethods(DataSourceAdapter):
         pass
 
     with pytest.raises(TypeError):
         MissingMethods()
+
+
+def test_fetchable_adapter_adds_runtime_fetch_methods() -> None:
+    assert FetchableAdapter.__abstractmethods__ == frozenset(
+        {
+            "get_assets",
+            "get_resources",
+            "get_staging_dbt_models",
+            "get_quota_config",
+            "source_id",
+            "fetch",
+        }
+    )
 
 
 def test_asset_spec_and_quota_config_validate() -> None:
@@ -115,7 +139,7 @@ def test_asset_spec_and_quota_config_validate() -> None:
 def test_throttle_waits_sixty_seconds_for_sixty_requests_at_sixty_rpm() -> None:
     clock = FakeClock()
     adapter = ExampleAdapter(
-        quota=QuotaConfig(requests_per_minute=60, daily_credit_quota=None),
+        quota={"requests_per_minute": 60, "daily_credit_quota": None},
         clock=clock,
     )
 
@@ -146,11 +170,11 @@ def test_fetch_retries_429_and_calls_completion_hook() -> None:
     clock = FakeClock()
     rows = [{"id": 1}, {"id": 2}]
     adapter = ExampleAdapter(
-        quota=QuotaConfig(
-            requests_per_minute=60_000,
-            daily_credit_quota=None,
-            backoff_seconds=2.0,
-        ),
+        quota={
+            "requests_per_minute": 60_000,
+            "daily_credit_quota": None,
+            "backoff_seconds": 2.0,
+        },
         side_effects=[RateLimitError("too many requests"), rows],
         clock=clock,
     )
@@ -168,7 +192,7 @@ def test_fetch_retries_429_and_calls_completion_hook() -> None:
 def test_daily_quota_exceeded() -> None:
     clock = FakeClock()
     adapter = ExampleAdapter(
-        quota=QuotaConfig(requests_per_minute=60_000, daily_credit_quota=1),
+        quota={"requests_per_minute": 60_000, "daily_credit_quota": 1},
         side_effects=[[{"id": 1}], [{"id": 2}]],
         clock=clock,
     )
@@ -179,6 +203,20 @@ def test_daily_quota_exceeded() -> None:
         adapter.fetch("asset-a", {})
 
 
+def test_daily_quota_resets_when_utc_day_changes() -> None:
+    clock = FakeClock()
+    adapter = ExampleAdapter(
+        quota={"requests_per_minute": 60_000, "daily_credit_quota": 1},
+        side_effects=[[{"id": 1}], [{"id": 2}]],
+        clock=clock,
+    )
+
+    assert adapter.fetch("asset-a", {}) == [{"id": 1}]
+    adapter._daily_credit_date = date.min
+
+    assert adapter.fetch("asset-a", {}) == [{"id": 2}]
+
+
 def test_adapter_registry_register_get_list_and_duplicate() -> None:
     registry = AdapterRegistry()
     adapter = ExampleAdapter(source="source-a")
@@ -187,7 +225,7 @@ def test_adapter_registry_register_get_list_and_duplicate() -> None:
 
     assert registry.get("source-a") is adapter
     assert registry.list_sources() == ["source-a"]
-    assert isinstance(base._REGISTRY, AdapterRegistry)
+    assert isinstance(base.REGISTRY, AdapterRegistry)
 
     with pytest.raises(AdapterAlreadyRegistered):
         registry.register(adapter)

--- a/tests/adapters/test_tushare.py
+++ b/tests/adapters/test_tushare.py
@@ -12,7 +12,7 @@ pd = pytest.importorskip("pandas")
 pa = pytest.importorskip("pyarrow")
 pq = pytest.importorskip("pyarrow.parquet")
 
-from data_platform.adapters.base import AdapterRegistry, QuotaConfig  # noqa: E402
+from data_platform.adapters.base import AdapterRegistry, DataSourceAdapter  # noqa: E402
 from data_platform.adapters.tushare import (  # noqa: E402
     TUSHARE_STOCK_BASIC_ASSET,
     TushareAdapter,
@@ -85,10 +85,25 @@ def test_tushare_adapter_declares_stock_basic_asset_and_quota() -> None:
     assert adapter.get_assets()[0].dataset == "stock_basic"
     assert adapter.get_assets()[0].partition == "static"
     assert adapter.get_staging_dbt_models() == ["stg_stock_basic"]
-    assert adapter.get_quota_config() == QuotaConfig(
-        requests_per_minute=200,
-        daily_credit_quota=None,
+    assert adapter.get_quota_config() == {
+        "requests_per_minute": 200,
+        "daily_credit_quota": None,
+    }
+
+
+def test_tushare_adapter_matches_documented_datasource_protocol() -> None:
+    adapter = TushareAdapter(token="test-token", client=FakeTushareClient(_stock_basic_frame(1)))
+
+    assert isinstance(adapter, DataSourceAdapter)
+    assert DataSourceAdapter.__abstractmethods__ == frozenset(
+        {
+            "get_assets",
+            "get_resources",
+            "get_staging_dbt_models",
+            "get_quota_config",
+        }
     )
+    assert type(adapter.get_quota_config()) is dict
 
 
 def test_fetch_stock_basic_returns_declared_schema() -> None:


### PR DESCRIPTION
Closes #53

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `docs/spike/iceberg-write-chain.md`, `scripts/bootstrap_dev.sh`, `scripts/smoke_p1a.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/base.py`, `src/data_platform/config/settings.py`, `src/data_platform/raw/writer.py`, `src/data_platform/serving/canonical_writer.py`, `src/data_platform/serving/catalog.py`


---
## 背景与目标
Milestone review for milestone-0 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The project contract lists DataSourceAdapter as get_assets/get_resources/get_staging_dbt_models/get_quota_config, with get_quota_config returning a dict. The implemented ABC adds source_id and fetch as abstract protocol methods and changes get_quota_config to return QuotaConfig. TushareAdapter now follows this local shape, so future adapters and external contracts tests will compound around an incompatible interface.

## 实现范围
- 修改文件: `src/data_platform/adapters/base.py`
- Keep DataSourceAdapter aligned with the documented/contracts protocol, then introduce a separate BaseAdapter or FetchableAdapter layer for source_id, fetch, throttling, and retry behavior. Add contract tests that validate TushareAdapter against the external protocol shape.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/data-platform/.venv/bin/python -m pytest
```
