### PR TITLE
feat(#52): [milestone-0 review] P0: P1a smoke writes an invalid Raw run_id

### DIFF
--- a/scripts/smoke_p1a.sh
+++ b/scripts/smoke_p1a.sh
@@ -239,7 +239,7 @@ artifact = RawWriter().write_arrow(
     adapter.source_id(),
     "stock_basic",
     date(2026, 4, 15),
-    f"p1a-smoke-{uuid.uuid4().hex}",
+    str(uuid.uuid4()),
     table,
 )
 print(artifact.path)

--- a/tests/integration/test_p1a_smoke.py
+++ b/tests/integration/test_p1a_smoke.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -105,6 +105,32 @@ def test_p1a_smoke_allows_explicit_skip_without_dp_pg_dsn(tmp_path: Path) -> Non
 
     assert result.returncode == 0
     assert "P1a smoke skipped" in result.stdout
+
+
+def test_p1a_smoke_seed_fixture_writes_contract_valid_run_id(tmp_path: Path) -> None:
+    env = _base_script_env(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-c", _seed_tushare_fixture_source()],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    artifact_path = Path(result.stdout.strip().splitlines()[-1])
+    run_id = artifact_path.name.removesuffix(".parquet")
+    parsed_run_id = UUID(run_id)
+    manifest = json.loads((artifact_path.parent / "_manifest.json").read_text())
+
+    assert parsed_run_id.version == 4
+    assert run_id == str(parsed_run_id)
+    assert run_id.startswith("p1a-smoke-") is False
+    assert manifest["artifacts"][0]["run_id"] == run_id
+    assert manifest["artifacts"][0]["row_count"] == FIXTURE_ROW_COUNT
 
 
 def test_p1a_smoke_refuses_non_smoke_database(tmp_path: Path) -> None:
@@ -210,6 +236,17 @@ def _run_smoke(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     assert result.returncode == 0, result.stdout + result.stderr
     assert "skipped" not in result.stdout.lower()
     return result
+
+
+def _seed_tushare_fixture_source() -> str:
+    script = (PROJECT_ROOT / "scripts" / "smoke_p1a.sh").read_text()
+    match = re.search(
+        r"seed_tushare_fixture\(\) \{\n\s+\"\$\{PYTHON\}\" - <<'PY'\n(?P<source>.*?)\nPY\n\}",
+        script,
+        re.DOTALL,
+    )
+    assert match is not None
+    return match.group("source")
 
 
 def _query_canonical_payload(env: dict[str, str]) -> dict[str, object]:


### PR DESCRIPTION
Closes #52

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `docs/spike/iceberg-write-chain.md`, `scripts/bootstrap_dev.sh`, `scripts/smoke_p1a.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/config/settings.py`, `src/data_platform/raw/writer.py`, `src/data_platform/serving/canonical_writer.py`, `src/data_platform/serving/catalog.py`, `tests/dbt/fixtures/raw/tushare/stock_basic/dt=20260415/_manifest.json`


---
## 背景与目标
Milestone review for milestone-0 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The smoke fixture calls RawWriter.write_arrow with run_id f"p1a-smoke-{uuid.uuid4().hex}", but RawWriter._validate_run_id accepts only UUID4 or ULID values. This means the milestone's end-to-end smoke fails during the "fetch tushare fixture" step before dbt, canonical write, or DuckDB read can run.

## 实现范围
- 修改文件: `scripts/smoke_p1a.sh`
- Use a contract-valid run_id such as str(uuid.uuid4()) or a ULID in the smoke script. If prefixed run IDs are desired, relax RawWriter._validate_run_id deliberately and update all Raw/dbt fixtures to the same rule.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/data-platform/.venv/bin/python -m pytest
```
