### PR TITLE
feat(#26): Canonical 表 schema 演化与 backfill 流程

### DIFF
--- a/docs/ops/canonical-schema-evolution.md
+++ b/docs/ops/canonical-schema-evolution.md
@@ -1,0 +1,131 @@
+# Canonical Schema Evolution SOP
+
+This runbook covers Canonical Iceberg table changes that are intentionally limited to:
+
+- adding nullable columns
+- widening `int32` to `int64`
+- widening `float32` to `float64`
+
+Column deletion, column rename, type narrowing, required-column addition, table rebuilds, and
+business-default inference are out of scope. Raw Zone files must remain Parquet/JSON artifacts and
+must not be converted into an Iceberg layer.
+
+## Preflight
+
+1. Confirm the target table is declared in `src/data_platform/ddl/iceberg_tables.py`.
+2. Update the table `TableSpec` to the target schema.
+3. Run a schema evolution dry-run from Python:
+
+```bash
+PYTHONPATH=src .venv/bin/python - <<'PY'
+from data_platform.ddl.iceberg_tables import CANONICAL_FACT_PRICE_BAR_SPEC
+from data_platform.serving.catalog import load_catalog
+from data_platform.serving.schema_evolution import apply_schema_evolution
+
+plan = apply_schema_evolution(
+    load_catalog(),
+    "canonical.fact_price_bar",
+    CANONICAL_FACT_PRICE_BAR_SPEC.schema,
+)
+print(plan)
+PY
+```
+
+The plan must have an empty `rejections` list before apply. `requires_backfill=True` means at least
+one nullable column was added and a follow-up overwrite is required to populate explicit values.
+
+## Apply
+
+Apply only after reviewing the dry-run output:
+
+```bash
+PYTHONPATH=src .venv/bin/python - <<'PY'
+from data_platform.ddl.iceberg_tables import CANONICAL_FACT_PRICE_BAR_SPEC
+from data_platform.serving.catalog import load_catalog
+from data_platform.serving.schema_evolution import apply_schema_evolution
+
+plan = apply_schema_evolution(
+    load_catalog(),
+    "canonical.fact_price_bar",
+    CANONICAL_FACT_PRICE_BAR_SPEC.schema,
+    dry_run=False,
+)
+print(plan)
+PY
+```
+
+Type widening is metadata-only. Add-column migrations expose `NULL` for historical rows until a
+backfill overwrite is published.
+
+## Backfill
+
+Backfill SQL must explicitly project every business column expected by the canonical table. The
+loader still owns `canonical_loaded_at`.
+
+```bash
+PYTHONPATH=src .venv/bin/python scripts/canonical_backfill.py \
+  --table canonical.fact_price_bar \
+  --sql-file backfill.sql \
+  --dry-run
+```
+
+After the dry-run succeeds, execute without `--dry-run`:
+
+```bash
+PYTHONPATH=src .venv/bin/python scripts/canonical_backfill.py \
+  --table canonical.fact_price_bar \
+  --sql-file backfill.sql
+```
+
+The non-dry run returns a `WriteResult` JSON payload with `snapshot_id` and `row_count`.
+
+## Time Travel Verification
+
+Issue #14 validated that the PG-backed Iceberg catalog preserves old snapshots after add-column
+schema evolution. Re-run the spike and the focused schema tests before shipping a migration:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest \
+  tests/spike/test_iceberg_write_chain.py \
+  tests/serving/test_schema_evolution.py
+```
+
+When PostgreSQL is unavailable, the spike tests skip by design in sandboxed development; run them
+against a real `DATABASE_URL` before production rollout.
+
+To verify old snapshot readability manually, record the current snapshot before applying the change:
+
+```bash
+PYTHONPATH=src .venv/bin/python - <<'PY'
+from data_platform.serving.catalog import load_catalog
+
+table = load_catalog().load_table("canonical.fact_price_bar")
+snapshot = table.current_snapshot()
+print(snapshot.snapshot_id if snapshot else None)
+PY
+```
+
+After apply and backfill, scan the recorded snapshot and confirm the old schema does not expose the
+new column:
+
+```bash
+PYTHONPATH=src .venv/bin/python - <<'PY'
+from data_platform.serving.catalog import load_catalog
+
+table = load_catalog().load_table("canonical.fact_price_bar")
+old_snapshot_id = 123456789
+payload = table.scan(snapshot_id=old_snapshot_id).to_arrow()
+print(payload.schema.names)
+PY
+```
+
+## Rollback
+
+Do not delete or rename columns to roll back a Canonical schema change. Rollback options are:
+
+- stop consumers and keep serving from the previously recorded snapshot while the fix is prepared
+- apply a forward-only correction with another allowed add-column or widening change
+- overwrite the current table from an explicit backfill query that restores the intended values
+
+Keep the recorded snapshot id, applied plan, backfill SQL, and returned `WriteResult` in the
+deployment notes.

--- a/scripts/canonical_backfill.py
+++ b/scripts/canonical_backfill.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""Run a canonical Iceberg table backfill from an explicit DuckDB SELECT."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+from pathlib import Path
+import sys
+from typing import Sequence
+
+from data_platform.config import get_settings
+from data_platform.serving.catalog import load_catalog
+from data_platform.serving.schema_evolution import run_canonical_backfill
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill a canonical Iceberg table from a DuckDB SELECT."
+    )
+    parser.add_argument("--table", required=True, help="canonical table identifier")
+    parser.add_argument("--sql-file", required=True, type=Path, help="file containing SELECT SQL")
+    parser.add_argument(
+        "--duckdb-path",
+        type=Path,
+        default=None,
+        help="DuckDB database path; defaults to DP_DUCKDB_PATH",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate the SELECT without writing an Iceberg snapshot",
+    )
+
+    try:
+        args = parser.parse_args(argv)
+        duckdb_path = args.duckdb_path or get_settings().duckdb_path
+        select_sql = args.sql_file.read_text(encoding="utf-8")
+        result = run_canonical_backfill(
+            load_catalog(),
+            duckdb_path,
+            args.table,
+            select_sql,
+            dry_run=args.dry_run,
+        )
+    except Exception as exc:
+        error_payload = {"error": type(exc).__name__, "detail": str(exc)}
+        print(json.dumps(error_payload, sort_keys=True), file=sys.stderr)
+        return 1
+
+    if result is None:
+        payload = {"dry_run": True, "row_count": None, "snapshot_id": None, "table": args.table}
+    else:
+        payload = asdict(result)
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data_platform/serving/schema_evolution.py
+++ b/src/data_platform/serving/schema_evolution.py
@@ -1,0 +1,345 @@
+"""Canonical Iceberg schema evolution planning and backfill helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+import duckdb
+import pyarrow as pa  # type: ignore[import-untyped]
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.table import Table
+from pyiceberg.types import (
+    BooleanType,
+    DateType,
+    DecimalType,
+    DoubleType,
+    FloatType,
+    IcebergType,
+    IntegerType,
+    LongType,
+    StringType,
+    TimestampType,
+    TimestamptzType,
+)
+
+from data_platform.serving.canonical_writer import (
+    CANONICAL_LOADED_AT_COLUMN,
+    CanonicalLoadSpec,
+    WriteResult,
+    load_canonical_table,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaChange:
+    """One allowed canonical schema evolution step."""
+
+    kind: Literal["add_column", "widen_type"]
+    field_name: str
+    from_type: str | None
+    to_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaEvolutionPlan:
+    """Stable dry-run/apply output for a canonical Iceberg table schema change."""
+
+    table_identifier: str
+    changes: list[SchemaChange]
+    rejections: list[str]
+    requires_backfill: bool
+
+
+def plan_schema_evolution(
+    table_identifier: str,
+    current_schema: pa.Schema,
+    target_schema: pa.Schema,
+) -> SchemaEvolutionPlan:
+    """Compare an Iceberg table schema to a target PyArrow schema."""
+
+    changes: list[SchemaChange] = []
+    rejections: list[str] = []
+    current_fields = {field.name: field for field in current_schema}
+    target_fields = {field.name: field for field in target_schema}
+    current_names = list(current_schema.names)
+    target_names = list(target_schema.names)
+    removed_names = [name for name in current_names if name not in target_fields]
+    added_names = [name for name in target_names if name not in current_fields]
+
+    if removed_names:
+        rejections.extend(
+            f"drop column is not supported for {table_identifier}: {name}"
+            for name in removed_names
+        )
+    if removed_names and added_names:
+        rejections.append(
+            f"rename column is not supported for {table_identifier}: "
+            f"removed={', '.join(removed_names)} added={', '.join(added_names)}"
+        )
+
+    shared_target_order = [name for name in target_names if name in current_fields]
+    if shared_target_order != current_names:
+        rejections.append(
+            f"column reorder is not supported for {table_identifier}; "
+            "existing columns must keep their relative order"
+        )
+
+    if added_names:
+        first_added_index = min(target_names.index(name) for name in added_names)
+        if any(name in current_fields for name in target_names[first_added_index:]):
+            rejections.append(
+                f"add column is only supported at the end of {table_identifier}"
+            )
+
+    for name in current_names:
+        if name not in target_fields:
+            continue
+        current_field = current_fields[name]
+        target_field = target_fields[name]
+        current_type = _normalize_arrow_type(current_field.type)
+        target_type = _normalize_arrow_type(target_field.type)
+
+        if current_field.nullable != target_field.nullable:
+            rejections.append(
+                f"nullability change is not supported for {table_identifier}.{name}: "
+                f"{'nullable' if current_field.nullable else 'required'} -> "
+                f"{'nullable' if target_field.nullable else 'required'}"
+            )
+
+        if current_type.equals(target_type):
+            continue
+        if _is_safe_type_widening(current_type, target_type):
+            changes.append(
+                SchemaChange(
+                    kind="widen_type",
+                    field_name=name,
+                    from_type=_format_arrow_type(current_type),
+                    to_type=_format_arrow_type(target_type),
+                )
+            )
+            continue
+
+        rejections.append(
+            f"type change is not allowed for {table_identifier}.{name}: "
+            f"{_format_arrow_type(current_type)} -> {_format_arrow_type(target_type)}"
+        )
+
+    for name in added_names:
+        target_field = target_fields[name]
+        if not target_field.nullable:
+            rejections.append(
+                f"add required column is not supported for {table_identifier}.{name}"
+            )
+            continue
+        changes.append(
+            SchemaChange(
+                kind="add_column",
+                field_name=name,
+                from_type=None,
+                to_type=_format_arrow_type(_normalize_arrow_type(target_field.type)),
+            )
+        )
+
+    return SchemaEvolutionPlan(
+        table_identifier=table_identifier,
+        changes=changes,
+        rejections=rejections,
+        requires_backfill=any(change.kind == "add_column" for change in changes),
+    )
+
+
+def apply_schema_evolution(
+    catalog: SqlCatalog,
+    table_identifier: str,
+    target_schema: pa.Schema,
+    *,
+    dry_run: bool = True,
+) -> SchemaEvolutionPlan:
+    """Plan and optionally commit allowed Iceberg schema updates."""
+
+    table = catalog.load_table(table_identifier)
+    current_schema = _table_schema_as_pyarrow(table)
+    plan = plan_schema_evolution(table_identifier, current_schema, target_schema)
+    if dry_run or plan.rejections or not plan.changes:
+        return plan
+
+    target_fields = {field.name: field for field in target_schema}
+    update = table.update_schema()
+    for change in plan.changes:
+        target_field = target_fields[change.field_name]
+        iceberg_type = _pyarrow_type_to_iceberg(target_field.type)
+        if change.kind == "add_column":
+            update.add_column(change.field_name, iceberg_type, required=False)
+        elif change.kind == "widen_type":
+            update.update_column(change.field_name, iceberg_type)
+    update.commit()
+    return plan
+
+
+def run_canonical_backfill(
+    catalog: SqlCatalog,
+    duckdb_path: Path,
+    table_identifier: str,
+    select_sql: str,
+    *,
+    dry_run: bool = False,
+) -> WriteResult | None:
+    """Backfill a canonical table from an explicit DuckDB SELECT."""
+
+    cleaned_sql = _clean_select_sql(select_sql)
+    table = catalog.load_table(table_identifier)
+    target_schema = _table_schema_as_pyarrow(table)
+    required_columns = tuple(
+        name for name in target_schema.names if name != CANONICAL_LOADED_AT_COLUMN
+    )
+    if not required_columns:
+        msg = f"{table_identifier} has no backfillable columns"
+        raise ValueError(msg)
+
+    relation = f"canonical_backfill_{uuid4().hex}"
+    _create_backfill_view(duckdb_path, relation, cleaned_sql)
+    spec = CanonicalLoadSpec(
+        identifier=table_identifier,
+        duckdb_relation=relation,
+        required_columns=required_columns,
+    )
+    try:
+        if dry_run:
+            _validate_backfill_relation(duckdb_path, spec)
+            return None
+        return load_canonical_table(catalog, duckdb_path, spec)
+    finally:
+        _drop_backfill_view(duckdb_path, relation)
+
+
+def _table_schema_as_pyarrow(table: Table) -> pa.Schema:
+    table_schema = table.schema
+    schema = table_schema() if callable(table_schema) else table_schema
+    if isinstance(schema, pa.Schema):
+        return schema
+
+    as_arrow = getattr(schema, "as_arrow", None)
+    if callable(as_arrow):
+        arrow_schema = as_arrow()
+        if isinstance(arrow_schema, pa.Schema):
+            return arrow_schema
+
+    msg = "Iceberg table schema cannot be converted to a PyArrow schema"
+    raise TypeError(msg)
+
+
+def _normalize_arrow_type(data_type: pa.DataType) -> pa.DataType:
+    if pa.types.is_string(data_type) or pa.types.is_large_string(data_type):
+        return pa.string()
+    if pa.types.is_float32(data_type):
+        return pa.float32()
+    if pa.types.is_float64(data_type):
+        return pa.float64()
+    return data_type
+
+
+def _is_safe_type_widening(
+    current_type: pa.DataType,
+    target_type: pa.DataType,
+) -> bool:
+    if pa.types.is_int32(current_type) and pa.types.is_int64(target_type):
+        return True
+    if pa.types.is_float32(current_type) and pa.types.is_float64(target_type):
+        return True
+    return False
+
+
+def _format_arrow_type(data_type: pa.DataType) -> str:
+    if pa.types.is_int32(data_type):
+        return "int32"
+    if pa.types.is_int64(data_type):
+        return "int64"
+    if pa.types.is_float32(data_type):
+        return "float32"
+    if pa.types.is_float64(data_type):
+        return "float64"
+    if pa.types.is_string(data_type) or pa.types.is_large_string(data_type):
+        return "string"
+    if pa.types.is_boolean(data_type):
+        return "bool"
+    if pa.types.is_date32(data_type):
+        return "date32"
+    return str(data_type)
+
+
+def _pyarrow_type_to_iceberg(data_type: pa.DataType) -> IcebergType:
+    normalized_type = _normalize_arrow_type(data_type)
+    if pa.types.is_string(normalized_type):
+        return StringType()
+    if pa.types.is_boolean(normalized_type):
+        return BooleanType()
+    if pa.types.is_int32(normalized_type):
+        return IntegerType()
+    if pa.types.is_int64(normalized_type):
+        return LongType()
+    if pa.types.is_float32(normalized_type):
+        return FloatType()
+    if pa.types.is_float64(normalized_type):
+        return DoubleType()
+    if pa.types.is_date32(normalized_type):
+        return DateType()
+    if pa.types.is_timestamp(normalized_type):
+        if normalized_type.tz is None:
+            return TimestampType()
+        return TimestamptzType()
+    if pa.types.is_decimal(normalized_type):
+        return DecimalType(normalized_type.precision, normalized_type.scale)
+
+    msg = f"unsupported PyArrow type for Iceberg schema evolution: {data_type}"
+    raise TypeError(msg)
+
+
+def _clean_select_sql(select_sql: str) -> str:
+    cleaned_sql = select_sql.strip()
+    if cleaned_sql.endswith(";"):
+        cleaned_sql = cleaned_sql[:-1].strip()
+    if not cleaned_sql:
+        msg = "backfill SELECT SQL must not be empty"
+        raise ValueError(msg)
+    return cleaned_sql
+
+
+def _create_backfill_view(duckdb_path: Path, relation: str, select_sql: str) -> None:
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        connection.execute(
+            f'CREATE OR REPLACE VIEW "{relation}" AS {select_sql}'
+        )
+    finally:
+        connection.close()
+
+
+def _validate_backfill_relation(duckdb_path: Path, spec: CanonicalLoadSpec) -> None:
+    quoted_columns = ", ".join(f'"{column}"' for column in spec.required_columns)
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        connection.execute(
+            f'SELECT {quoted_columns} FROM "{spec.duckdb_relation}" LIMIT 0'
+        ).fetchall()
+    finally:
+        connection.close()
+
+
+def _drop_backfill_view(duckdb_path: Path, relation: str) -> None:
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        connection.execute(f'DROP VIEW IF EXISTS "{relation}"')
+    finally:
+        connection.close()
+
+
+__all__ = [
+    "SchemaChange",
+    "SchemaEvolutionPlan",
+    "apply_schema_evolution",
+    "plan_schema_evolution",
+    "run_canonical_backfill",
+]

--- a/src/data_platform/serving/schema_evolution.py
+++ b/src/data_platform/serving/schema_evolution.py
@@ -25,11 +25,18 @@ from pyiceberg.types import (
     TimestamptzType,
 )
 
+from data_platform.ddl.iceberg_tables import CANONICAL_NAMESPACE, DEFAULT_TABLE_SPECS
 from data_platform.serving.canonical_writer import (
     CANONICAL_LOADED_AT_COLUMN,
     CanonicalLoadSpec,
     WriteResult,
     load_canonical_table,
+)
+
+DECLARED_CANONICAL_TABLE_IDENTIFIERS = frozenset(
+    f"{spec.namespace}.{spec.name}"
+    for spec in DEFAULT_TABLE_SPECS
+    if spec.namespace == CANONICAL_NAMESPACE
 )
 
 
@@ -60,6 +67,7 @@ def plan_schema_evolution(
 ) -> SchemaEvolutionPlan:
     """Compare an Iceberg table schema to a target PyArrow schema."""
 
+    table_identifier = _require_declared_canonical_identifier(table_identifier)
     changes: list[SchemaChange] = []
     rejections: list[str] = []
     current_fields = {field.name: field for field in current_schema}
@@ -160,6 +168,7 @@ def apply_schema_evolution(
 ) -> SchemaEvolutionPlan:
     """Plan and optionally commit allowed Iceberg schema updates."""
 
+    table_identifier = _require_declared_canonical_identifier(table_identifier)
     table = catalog.load_table(table_identifier)
     current_schema = _table_schema_as_pyarrow(table)
     plan = plan_schema_evolution(table_identifier, current_schema, target_schema)
@@ -189,6 +198,7 @@ def run_canonical_backfill(
 ) -> WriteResult | None:
     """Backfill a canonical table from an explicit DuckDB SELECT."""
 
+    table_identifier = _require_declared_canonical_identifier(table_identifier)
     cleaned_sql = _clean_select_sql(select_sql)
     table = catalog.load_table(table_identifier)
     target_schema = _table_schema_as_pyarrow(table)
@@ -200,7 +210,6 @@ def run_canonical_backfill(
         raise ValueError(msg)
 
     relation = f"canonical_backfill_{uuid4().hex}"
-    _create_backfill_view(duckdb_path, relation, cleaned_sql)
     spec = CanonicalLoadSpec(
         identifier=table_identifier,
         duckdb_relation=relation,
@@ -208,11 +217,13 @@ def run_canonical_backfill(
     )
     try:
         if dry_run:
-            _validate_backfill_relation(duckdb_path, spec)
+            _validate_backfill_select(duckdb_path, spec, cleaned_sql)
             return None
+        _create_backfill_view(duckdb_path, relation, cleaned_sql)
         return load_canonical_table(catalog, duckdb_path, spec)
     finally:
-        _drop_backfill_view(duckdb_path, relation)
+        if not dry_run:
+            _drop_backfill_view(duckdb_path, relation)
 
 
 def _table_schema_as_pyarrow(table: Table) -> pa.Schema:
@@ -299,12 +310,44 @@ def _pyarrow_type_to_iceberg(data_type: pa.DataType) -> IcebergType:
 
 def _clean_select_sql(select_sql: str) -> str:
     cleaned_sql = select_sql.strip()
-    if cleaned_sql.endswith(";"):
-        cleaned_sql = cleaned_sql[:-1].strip()
     if not cleaned_sql:
         msg = "backfill SELECT SQL must not be empty"
         raise ValueError(msg)
-    return cleaned_sql
+    if ";" in cleaned_sql:
+        msg = "backfill SQL must contain exactly one SELECT statement without semicolons"
+        raise ValueError(msg)
+
+    try:
+        statements = duckdb.extract_statements(cleaned_sql)
+    except duckdb.Error as exc:
+        msg = "backfill SQL must parse as exactly one read-only SELECT statement"
+        raise ValueError(msg) from exc
+    if len(statements) != 1:
+        msg = "backfill SQL must contain exactly one SELECT statement"
+        raise ValueError(msg)
+
+    statement = statements[0]
+    if statement.type != duckdb.StatementType.SELECT:
+        msg = "backfill SQL must be a read-only SELECT statement"
+        raise ValueError(msg)
+    return statement.query.strip()
+
+
+def _require_declared_canonical_identifier(table_identifier: str) -> str:
+    normalized_identifier = table_identifier.strip()
+    namespace, separator, _table_name = normalized_identifier.partition(".")
+    if (
+        not separator
+        or namespace != CANONICAL_NAMESPACE
+        or normalized_identifier not in DECLARED_CANONICAL_TABLE_IDENTIFIERS
+    ):
+        allowed = ", ".join(sorted(DECLARED_CANONICAL_TABLE_IDENTIFIERS))
+        msg = (
+            "schema evolution and backfill only support declared canonical tables; "
+            f"got {table_identifier!r}. allowed={allowed}"
+        )
+        raise ValueError(msg)
+    return normalized_identifier
 
 
 def _create_backfill_view(duckdb_path: Path, relation: str, select_sql: str) -> None:
@@ -317,12 +360,16 @@ def _create_backfill_view(duckdb_path: Path, relation: str, select_sql: str) -> 
         connection.close()
 
 
-def _validate_backfill_relation(duckdb_path: Path, spec: CanonicalLoadSpec) -> None:
+def _validate_backfill_select(
+    duckdb_path: Path,
+    spec: CanonicalLoadSpec,
+    select_sql: str,
+) -> None:
     quoted_columns = ", ".join(f'"{column}"' for column in spec.required_columns)
-    connection = duckdb.connect(str(duckdb_path))
+    connection = duckdb.connect(str(duckdb_path), read_only=True)
     try:
         connection.execute(
-            f'SELECT {quoted_columns} FROM "{spec.duckdb_relation}" LIMIT 0'
+            f"SELECT {quoted_columns} FROM ({select_sql}) AS backfill_source LIMIT 0"
         ).fetchall()
     finally:
         connection.close()

--- a/tests/serving/test_schema_evolution.py
+++ b/tests/serving/test_schema_evolution.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pyarrow as pa  # type: ignore[import-untyped]
+import pytest
+from pyiceberg.catalog.memory import InMemoryCatalog
+
+from data_platform.ddl.iceberg_tables import TIMESTAMP_TYPE
+from data_platform.serving.schema_evolution import (
+    SchemaChange,
+    apply_schema_evolution,
+    plan_schema_evolution,
+    run_canonical_backfill,
+)
+
+
+def test_plan_schema_evolution_add_column_requires_backfill() -> None:
+    current_schema = pa.schema([pa.field("ts_code", pa.string())])
+    target_schema = current_schema.append(pa.field("source_run_id", pa.string()))
+
+    plan = plan_schema_evolution("canonical.stock_basic", current_schema, target_schema)
+
+    assert plan.changes == [
+        SchemaChange(
+            kind="add_column",
+            field_name="source_run_id",
+            from_type=None,
+            to_type="string",
+        )
+    ]
+    assert plan.rejections == []
+    assert plan.requires_backfill is True
+
+
+def test_plan_schema_evolution_allows_whitelisted_type_widening() -> None:
+    current_schema = pa.schema(
+        [
+            pa.field("trade_count", pa.int32()),
+            pa.field("price", pa.float32()),
+            pa.field("name", pa.string()),
+        ]
+    )
+    target_schema = pa.schema(
+        [
+            pa.field("trade_count", pa.int64()),
+            pa.field("price", pa.float64()),
+            pa.field("name", pa.string()),
+        ]
+    )
+
+    plan = plan_schema_evolution("canonical.fact_price_bar", current_schema, target_schema)
+
+    assert plan.changes == [
+        SchemaChange(
+            kind="widen_type",
+            field_name="trade_count",
+            from_type="int32",
+            to_type="int64",
+        ),
+        SchemaChange(
+            kind="widen_type",
+            field_name="price",
+            from_type="float32",
+            to_type="float64",
+        ),
+    ]
+    assert plan.rejections == []
+    assert plan.requires_backfill is False
+
+
+@pytest.mark.parametrize(
+    "target_schema, expected_rejection",
+    [
+        (
+            pa.schema([pa.field("ts_code", pa.string())]),
+            "drop column is not supported",
+        ),
+        (
+            pa.schema(
+                [
+                    pa.field("ts_code", pa.string()),
+                    pa.field("security_name", pa.string()),
+                ]
+            ),
+            "rename column is not supported",
+        ),
+        (
+            pa.schema(
+                [
+                    pa.field("ts_code", pa.string()),
+                    pa.field("name", pa.int32()),
+                ]
+            ),
+            "type change is not allowed",
+        ),
+    ],
+)
+def test_plan_schema_evolution_rejects_breaking_changes(
+    target_schema: pa.Schema,
+    expected_rejection: str,
+) -> None:
+    current_schema = pa.schema(
+        [
+            pa.field("ts_code", pa.string()),
+            pa.field("name", pa.string()),
+        ]
+    )
+
+    plan = plan_schema_evolution("canonical.stock_basic", current_schema, target_schema)
+
+    assert any(expected_rejection in rejection for rejection in plan.rejections)
+
+
+def test_apply_schema_evolution_add_column_preserves_old_snapshot(
+    tmp_path: Path,
+) -> None:
+    catalog = _create_catalog(tmp_path)
+    table = catalog.create_table(
+        "canonical.stock_basic",
+        schema=pa.schema([pa.field("ts_code", pa.string())]),
+    )
+    table.append(pa.table({"ts_code": ["000001.SZ"]}))
+    table = table.refresh()
+    old_snapshot = table.current_snapshot()
+    assert old_snapshot is not None
+
+    target_schema = pa.schema(
+        [
+            pa.field("ts_code", pa.string()),
+            pa.field("source_run_id", pa.string()),
+        ]
+    )
+    dry_run_plan = apply_schema_evolution(
+        catalog,  # type: ignore[arg-type]
+        "canonical.stock_basic",
+        target_schema,
+    )
+    applied_plan = apply_schema_evolution(
+        catalog,  # type: ignore[arg-type]
+        "canonical.stock_basic",
+        target_schema,
+        dry_run=False,
+    )
+
+    refreshed = catalog.load_table("canonical.stock_basic")
+    current_rows = refreshed.scan().to_arrow()
+    old_rows = refreshed.scan(snapshot_id=old_snapshot.snapshot_id).to_arrow()
+
+    assert dry_run_plan.requires_backfill is True
+    assert applied_plan == dry_run_plan
+    assert current_rows.schema.names == ["ts_code", "source_run_id"]
+    assert current_rows.to_pylist() == [
+        {"ts_code": "000001.SZ", "source_run_id": None}
+    ]
+    assert old_rows.schema.names == ["ts_code"]
+    assert old_rows.to_pylist() == [{"ts_code": "000001.SZ"}]
+
+
+def test_apply_schema_evolution_widens_column_type(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+    catalog.create_table(
+        "canonical.fact_price_bar",
+        schema=pa.schema([pa.field("trade_count", pa.int32())]),
+    )
+    target_schema = pa.schema([pa.field("trade_count", pa.int64())])
+
+    plan = apply_schema_evolution(
+        catalog,  # type: ignore[arg-type]
+        "canonical.fact_price_bar",
+        target_schema,
+        dry_run=False,
+    )
+
+    refreshed = catalog.load_table("canonical.fact_price_bar")
+    assert plan.rejections == []
+    assert plan.changes == [
+        SchemaChange(
+            kind="widen_type",
+            field_name="trade_count",
+            from_type="int32",
+            to_type="int64",
+        )
+    ]
+    assert refreshed.schema().as_arrow().field("trade_count").type.equals(pa.int64())
+
+
+def test_run_canonical_backfill_dry_run_does_not_write_snapshot(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+    catalog.create_table("canonical.backfill_target", schema=_backfill_target_schema())
+    duckdb_path = tmp_path / "backfill.duckdb"
+    _write_backfill_source(duckdb_path)
+
+    result = run_canonical_backfill(
+        catalog,  # type: ignore[arg-type]
+        duckdb_path,
+        "canonical.backfill_target",
+        "SELECT id, value FROM source_rows",
+        dry_run=True,
+    )
+
+    assert result is None
+    assert catalog.load_table("canonical.backfill_target").current_snapshot() is None
+
+
+def test_run_canonical_backfill_writes_with_write_result(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+    catalog.create_table("canonical.backfill_target", schema=_backfill_target_schema())
+    duckdb_path = tmp_path / "backfill.duckdb"
+    _write_backfill_source(duckdb_path)
+
+    result = run_canonical_backfill(
+        catalog,  # type: ignore[arg-type]
+        duckdb_path,
+        "canonical.backfill_target",
+        "SELECT id, value FROM source_rows",
+    )
+
+    rows = catalog.load_table("canonical.backfill_target").scan().to_arrow()
+    assert result is not None
+    assert result.table == "canonical.backfill_target"
+    assert result.row_count == 2
+    assert result.snapshot_id
+    assert rows.schema.names == ["id", "value", "canonical_loaded_at"]
+    assert [row["id"] for row in rows.to_pylist()] == ["a", "b"]
+
+
+def _create_catalog(tmp_path: Path) -> InMemoryCatalog:
+    catalog = InMemoryCatalog("test", warehouse=f"file://{tmp_path / 'warehouse'}")
+    catalog.create_namespace_if_not_exists(("canonical",))
+    return catalog
+
+
+def _backfill_target_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("value", pa.int64()),
+            pa.field("canonical_loaded_at", TIMESTAMP_TYPE),
+        ]
+    )
+
+
+def _write_backfill_source(duckdb_path: Path) -> None:
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        connection.execute(
+            """
+            CREATE OR REPLACE TABLE source_rows AS
+            SELECT 'a'::VARCHAR AS id, 1::BIGINT AS value
+            UNION ALL
+            SELECT 'b'::VARCHAR AS id, 2::BIGINT AS value
+            """
+        )
+    finally:
+        connection.close()

--- a/tests/serving/test_schema_evolution.py
+++ b/tests/serving/test_schema_evolution.py
@@ -186,44 +186,132 @@ def test_apply_schema_evolution_widens_column_type(tmp_path: Path) -> None:
     assert refreshed.schema().as_arrow().field("trade_count").type.equals(pa.int64())
 
 
+def test_apply_schema_evolution_rejects_non_canonical_identifier_before_load() -> None:
+    class GuardCatalog:
+        def load_table(self, table_identifier: str) -> None:
+            raise AssertionError(f"unexpected table load: {table_identifier}")
+
+    with pytest.raises(ValueError, match="declared canonical"):
+        apply_schema_evolution(  # type: ignore[arg-type]
+            GuardCatalog(),
+            "formal.object",
+            pa.schema([pa.field("id", pa.string())]),
+            dry_run=False,
+        )
+
+
+def test_apply_schema_evolution_rejects_undeclared_canonical_identifier() -> None:
+    class GuardCatalog:
+        def load_table(self, table_identifier: str) -> None:
+            raise AssertionError(f"unexpected table load: {table_identifier}")
+
+    with pytest.raises(ValueError, match="declared canonical"):
+        apply_schema_evolution(  # type: ignore[arg-type]
+            GuardCatalog(),
+            "canonical.not_declared",
+            pa.schema([pa.field("id", pa.string())]),
+            dry_run=False,
+        )
+
+
 def test_run_canonical_backfill_dry_run_does_not_write_snapshot(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path)
-    catalog.create_table("canonical.backfill_target", schema=_backfill_target_schema())
+    catalog.create_table("canonical.stock_basic", schema=_backfill_target_schema())
     duckdb_path = tmp_path / "backfill.duckdb"
     _write_backfill_source(duckdb_path)
 
     result = run_canonical_backfill(
         catalog,  # type: ignore[arg-type]
         duckdb_path,
-        "canonical.backfill_target",
+        "canonical.stock_basic",
         "SELECT id, value FROM source_rows",
         dry_run=True,
     )
 
     assert result is None
-    assert catalog.load_table("canonical.backfill_target").current_snapshot() is None
+    assert catalog.load_table("canonical.stock_basic").current_snapshot() is None
+    assert _backfill_view_names(duckdb_path) == []
 
 
 def test_run_canonical_backfill_writes_with_write_result(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path)
-    catalog.create_table("canonical.backfill_target", schema=_backfill_target_schema())
+    catalog.create_table("canonical.stock_basic", schema=_backfill_target_schema())
     duckdb_path = tmp_path / "backfill.duckdb"
     _write_backfill_source(duckdb_path)
 
     result = run_canonical_backfill(
         catalog,  # type: ignore[arg-type]
         duckdb_path,
-        "canonical.backfill_target",
+        "canonical.stock_basic",
         "SELECT id, value FROM source_rows",
     )
 
-    rows = catalog.load_table("canonical.backfill_target").scan().to_arrow()
+    rows = catalog.load_table("canonical.stock_basic").scan().to_arrow()
     assert result is not None
-    assert result.table == "canonical.backfill_target"
+    assert result.table == "canonical.stock_basic"
     assert result.row_count == 2
     assert result.snapshot_id
     assert rows.schema.names == ["id", "value", "canonical_loaded_at"]
     assert [row["id"] for row in rows.to_pylist()] == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    "select_sql",
+    [
+        "SELECT id, value FROM source_rows;",
+        "SELECT id, value FROM source_rows; DROP TABLE source_rows",
+        "CREATE TABLE copied_rows AS SELECT id, value FROM source_rows",
+    ],
+)
+def test_run_canonical_backfill_rejects_non_single_select_without_mutating_duckdb(
+    tmp_path: Path,
+    select_sql: str,
+) -> None:
+    catalog = _create_catalog(tmp_path)
+    catalog.create_table("canonical.stock_basic", schema=_backfill_target_schema())
+    duckdb_path = tmp_path / "backfill.duckdb"
+    _write_backfill_source(duckdb_path)
+
+    with pytest.raises(ValueError):
+        run_canonical_backfill(
+            catalog,  # type: ignore[arg-type]
+            duckdb_path,
+            "canonical.stock_basic",
+            select_sql,
+            dry_run=True,
+        )
+
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        assert connection.execute("SELECT count(*) FROM source_rows").fetchone() == (2,)
+    finally:
+        connection.close()
+
+
+def test_run_canonical_backfill_rejects_non_canonical_identifier_before_sql(
+    tmp_path: Path,
+) -> None:
+    class GuardCatalog:
+        def load_table(self, table_identifier: str) -> None:
+            raise AssertionError(f"unexpected table load: {table_identifier}")
+
+    duckdb_path = tmp_path / "backfill.duckdb"
+    _write_backfill_source(duckdb_path)
+
+    with pytest.raises(ValueError, match="declared canonical"):
+        run_canonical_backfill(  # type: ignore[arg-type]
+            GuardCatalog(),
+            duckdb_path,
+            "formal.object",
+            "SELECT id, value FROM source_rows; DROP TABLE source_rows",
+            dry_run=True,
+        )
+
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        assert connection.execute("SELECT count(*) FROM source_rows").fetchone() == (2,)
+    finally:
+        connection.close()
 
 
 def _create_catalog(tmp_path: Path) -> InMemoryCatalog:
@@ -253,5 +341,23 @@ def _write_backfill_source(duckdb_path: Path) -> None:
             SELECT 'b'::VARCHAR AS id, 2::BIGINT AS value
             """
         )
+    finally:
+        connection.close()
+
+
+def _backfill_view_names(duckdb_path: Path) -> list[str]:
+    connection = duckdb.connect(str(duckdb_path))
+    try:
+        return [
+            row[0]
+            for row in connection.execute(
+                """
+                SELECT view_name
+                FROM duckdb_views()
+                WHERE view_name LIKE 'canonical_backfill_%'
+                ORDER BY view_name
+                """
+            ).fetchall()
+        ]
     finally:
         connection.close()


### PR DESCRIPTION
Closes #26

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `docs/spike/iceberg-write-chain.md`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/dbt/macros/stg_latest_raw.sql`, `src/data_platform/dbt/models/intermediate/int_financial_reports_latest.sql`, `src/data_platform/dbt/models/marts/mart_dim_security.sql`


---
### 1. 背景与目标
项目文档 §11.3 / §18 要求验证 Iceberg schema 演化与旧 snapshot 可读，#14 已完成写入链 spike 并产出 `docs/spike/iceberg-write-chain.md`。当前 canonical 写入集中在 `canonical_writer.py` 的 overwrite 模式，`ddl/iceberg_tables.py` 用 `TableSpec` 声明 schema。本 issue 将 add column / type widening 的 SOP、dry-run 计划与 backfill 脚本框架落地，供 #23 新增 canonical 表后安全演化。

### 2. 所属模块
新增 `src/data_platform/serving/schema_evolution.py`、`scripts/canonical_backfill.py`、`docs/ops/canonical-schema-evolution.md`，配套测试在 `tests/serving/` 与 `tests/spike/`。

### 3. 实现范围
- 新增 schema diff 逻辑，比较当前 Iceberg table schema 与目标 `pa.Schema`，只允许 add column 与安全 type widening，拒绝 drop/rename/narrowing。
- 新增 dry-run/apply API，复用 `load_catalog()` 与 PyIceberg table update schema 能力，输出稳定 plan dataclass。
- 新增 backfill CLI 框架，从 DuckDB dbt model 或 SQL select 读取数据，并调用 canonical writer 的通用 `load_canonical_table(...)`。
- 新增 `docs/ops/canonical-schema-evolution.md`，记录 add column、type widening、backfill、time travel 验证步骤，并引用 #14 spike 结论。
- 新增测试覆盖：add column plan、type widening plan、拒绝破坏性变更、旧 snapshot 读取、backfill dry-run 不写表。

### 4. 不在本次范围
- 不实现任意表重建、列删除、列重命名或 breaking migration。
- 不修改 Raw Zone 或 dbt staging 逻辑。
- 不处理 Formal Serving manifest；P1c 另行实现。
- 不自动推断业务默认值；backfill SQL 必须显式提供。

### 5. 关键交付物
- `@dataclass(frozen=True) class SchemaChange`，字段包含 `kind: Literal['add_column', 'widen_type']`、`field_name: str`、`from_type: str | None`、`to_type: str`。
- `@dataclass(frozen=True) class SchemaEvolutionPlan`，字段包含 `table_identifier: str`、`changes: list[SchemaChange]`、`rejections: list[str]`、`requires_backfill: bool`。
- `plan_schema_evolution(table_identifier: str, current_schema: pa.Schema, target_schema: pa.Schema) -> SchemaEvolutionPlan`。
- `apply_schema_evolution(catalog: SqlCatalog, table_identifier: str, target_schema: pa.Schema, *, dry_run: bool = True) -> SchemaEvolutionPlan`。
- `run_canonical_backfill(catalog: SqlCatalog, duckdb_path: Path, table_identifier: str, select_sql: str, *, dry_run: bool = False) -> WriteResult | None`。
- `scripts/canonical_b