### PR TITLE
feat(#25): asset / resource 工厂供 orchestrator 装配

### DIFF
--- a/src/data_platform/assets.py
+++ b/src/data_platform/assets.py
@@ -1,0 +1,436 @@
+"""Orchestrator-neutral asset and resource factories for data-platform."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import re
+from typing import Any, Literal
+
+from data_platform.adapters.base import AssetSpec, DataSourceAdapter
+from data_platform.adapters.tushare.assets import TUSHARE_ASSETS
+from data_platform.config import Settings, get_settings
+from data_platform.raw import RawReader, RawWriter
+from data_platform.serving.canonical_writer import (
+    CANONICAL_MART_LOAD_SPECS,
+    STOCK_BASIC_LOAD_SPEC,
+)
+from data_platform.serving.catalog import load_catalog
+
+AssetKind = Literal["raw", "dbt", "canonical"]
+AssetKey = tuple[str, ...]
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parent / "dbt"
+DBT_MODEL_DIR = DBT_PROJECT_DIR / "models"
+RAW_FETCH_CALLABLES: Mapping[str, str] = {
+    "tushare": "data_platform.adapters.tushare.adapter:run_tushare_asset",
+}
+DBT_RUNNER_CALLABLE = "dbt.cli.main:dbtRunner"
+CANONICAL_STOCK_BASIC_CALLABLE = (
+    "data_platform.serving.canonical_writer:load_canonical_stock_basic"
+)
+CANONICAL_MARTS_CALLABLE = "data_platform.serving.canonical_writer:load_canonical_marts"
+_REF_PATTERN = re.compile(r"\{\{\s*ref\(\s*['\"]([^'\"]+)['\"]\s*\)\s*\}\}")
+
+
+@dataclass(frozen=True, slots=True)
+class DataPlatformAssetSpec:
+    """Pure Python description of one asset-like unit owned by data-platform."""
+
+    key: AssetKey
+    kind: AssetKind
+    deps: tuple[AssetKey, ...]
+    metadata: dict[str, Any]
+    callable_import_path: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "key", tuple(self.key))
+        object.__setattr__(self, "deps", tuple(tuple(dep) for dep in self.deps))
+        metadata = dict(self.metadata)
+        metadata.setdefault("callable_import_path", self.callable_import_path)
+        object.__setattr__(self, "metadata", metadata)
+
+
+@dataclass(frozen=True, slots=True)
+class _DbtModelInfo:
+    name: str
+    path: Path
+    refs: tuple[str, ...]
+    layer: str
+
+
+class _TushareAssetAdapter(DataSourceAdapter):
+    """Read-only adapter descriptor used by asset specs without requiring a token."""
+
+    def source_id(self) -> str:
+        return "tushare"
+
+    def get_assets(self) -> list[AssetSpec]:
+        return list(TUSHARE_ASSETS)
+
+    def get_resources(self) -> dict[str, Any]:
+        return {"token_env": "DP_TUSHARE_TOKEN"}
+
+    def get_staging_dbt_models(self) -> list[str]:
+        return [f"stg_{asset.dataset}" for asset in TUSHARE_ASSETS]
+
+    def get_quota_config(self) -> dict[str, Any]:
+        return {"requests_per_minute": 200, "daily_credit_quota": None}
+
+
+def build_default_adapters() -> list[DataSourceAdapter]:
+    """Return the default source adapter descriptors for spec generation."""
+
+    return [_TushareAssetAdapter()]
+
+
+def build_assets(
+    adapters: Sequence[DataSourceAdapter] | None = None,
+) -> list[DataPlatformAssetSpec]:
+    """Build the orchestrator-consumable Raw, dbt, and canonical asset specs."""
+
+    resolved_adapters = list(adapters) if adapters is not None else build_default_adapters()
+    specs: list[DataPlatformAssetSpec] = []
+    raw_deps_by_staging_model: dict[str, list[AssetKey]] = {}
+    selected_staging_models: list[str] = []
+
+    for adapter in resolved_adapters:
+        source_id = _adapter_source_id(adapter)
+        resources = _json_safe(adapter.get_resources())
+        quota_config = _json_safe(adapter.get_quota_config())
+        assets = adapter.get_assets()
+        raw_key_by_dataset = {
+            asset.dataset: _raw_key(source_id, asset)
+            for asset in assets
+        }
+
+        for asset in assets:
+            callable_import_path = _raw_callable_import_path(adapter, source_id)
+            specs.append(
+                DataPlatformAssetSpec(
+                    key=raw_key_by_dataset[asset.dataset],
+                    kind="raw",
+                    deps=(),
+                    metadata={
+                        "source_id": source_id,
+                        "asset_name": asset.name,
+                        "dataset": asset.dataset,
+                        "partition": asset.partition,
+                        "schema": _schema_metadata(asset),
+                        "adapter_resources": resources,
+                        "quota_config": quota_config,
+                    },
+                    callable_import_path=callable_import_path,
+                )
+            )
+
+        for model_name in adapter.get_staging_dbt_models():
+            selected_staging_models.append(model_name)
+            dataset = _dataset_from_staging_model(model_name)
+            if dataset is None:
+                continue
+            raw_key = raw_key_by_dataset.get(dataset)
+            if raw_key is not None:
+                raw_deps_by_staging_model.setdefault(model_name, []).append(raw_key)
+
+    dbt_models = _discover_dbt_models(DBT_MODEL_DIR)
+    selected_dbt_models = _selected_dbt_models(
+        selected_staging_models,
+        dbt_models,
+        canonical_relations=_canonical_duckdb_relations(),
+    )
+    specs.extend(_build_dbt_specs(selected_dbt_models, dbt_models, raw_deps_by_staging_model))
+    specs.extend(_build_canonical_specs(selected_dbt_models))
+    return specs
+
+
+def build_resources(settings: Settings | None = None) -> dict[str, Any]:
+    """Build runtime resources used by the external orchestrator wiring."""
+
+    resolved_settings = settings or get_settings()
+    return {
+        "settings": resolved_settings,
+        "raw_writer": RawWriter(
+            resolved_settings.raw_zone_path,
+            iceberg_warehouse_path=resolved_settings.iceberg_warehouse_path,
+        ),
+        "raw_reader": RawReader(resolved_settings.raw_zone_path),
+        "iceberg_catalog": load_catalog(),
+        "duckdb_path": resolved_settings.duckdb_path,
+        "dbt_project_dir": DBT_PROJECT_DIR,
+        "raw_zone_path": resolved_settings.raw_zone_path,
+        "iceberg_warehouse_path": resolved_settings.iceberg_warehouse_path,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point for smoke-checking the exported asset specs."""
+
+    parser = argparse.ArgumentParser(description="Print data-platform asset specs.")
+    parser.add_argument("--json", action="store_true", help="emit JSON output")
+    parser.add_argument("--kind", choices=("raw", "dbt", "canonical"), help="filter by kind")
+    args = parser.parse_args(argv)
+
+    specs = build_assets()
+    if args.kind:
+        specs = [spec for spec in specs if spec.kind == args.kind]
+
+    payload = [_spec_to_json(spec) for spec in specs]
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return 0
+
+    for item in payload:
+        print(" ".join(item["key"]))
+    return 0
+
+
+def _adapter_source_id(adapter: DataSourceAdapter) -> str:
+    source_id = getattr(adapter, "source_id", None)
+    if callable(source_id):
+        value = str(source_id())
+        if value:
+            return value
+
+    resources = adapter.get_resources()
+    configured_source_id = resources.get("source_id")
+    if configured_source_id:
+        return str(configured_source_id)
+
+    class_name = adapter.__class__.__name__
+    suffix = "Adapter"
+    if class_name.endswith(suffix):
+        class_name = class_name[: -len(suffix)]
+    return _to_snake_case(class_name)
+
+
+def _raw_key(source_id: str, asset: AssetSpec) -> AssetKey:
+    return ("raw", source_id, asset.dataset)
+
+
+def _dbt_key(model_name: str) -> AssetKey:
+    return ("dbt", model_name)
+
+
+def _canonical_key(identifier: str) -> AssetKey:
+    return tuple(identifier.split("."))
+
+
+def _raw_callable_import_path(adapter: DataSourceAdapter, source_id: str) -> str:
+    if source_id in RAW_FETCH_CALLABLES:
+        return RAW_FETCH_CALLABLES[source_id]
+    if hasattr(adapter, "fetch"):
+        return f"{adapter.__class__.__module__}:{adapter.__class__.__qualname__}.fetch"
+    return ""
+
+
+def _schema_metadata(asset: AssetSpec) -> list[dict[str, str]]:
+    return [
+        {"name": field.name, "type": str(field.type)}
+        for field in asset.schema
+    ]
+
+
+def _dataset_from_staging_model(model_name: str) -> str | None:
+    prefix = "stg_"
+    if not model_name.startswith(prefix):
+        return None
+    return model_name.removeprefix(prefix)
+
+
+def _discover_dbt_models(model_dir: Path) -> dict[str, _DbtModelInfo]:
+    models: dict[str, _DbtModelInfo] = {}
+    if not model_dir.exists():
+        return models
+
+    for path in sorted(model_dir.rglob("*.sql")):
+        model_name = path.stem
+        sql = path.read_text(encoding="utf-8")
+        refs = tuple(dict.fromkeys(_REF_PATTERN.findall(sql)))
+        layer = path.parent.name
+        models[model_name] = _DbtModelInfo(
+            name=model_name,
+            path=path,
+            refs=refs,
+            layer=layer,
+        )
+    return models
+
+
+def _selected_dbt_models(
+    staging_models: Sequence[str],
+    dbt_models: Mapping[str, _DbtModelInfo],
+    *,
+    canonical_relations: Sequence[str],
+) -> list[str]:
+    selected = set(staging_models)
+    selected.update(canonical_relations)
+
+    changed = True
+    while changed:
+        changed = False
+        for model_name in tuple(selected):
+            info = dbt_models.get(model_name)
+            if info is None:
+                continue
+            for ref in info.refs:
+                if ref not in selected:
+                    selected.add(ref)
+                    changed = True
+
+    ordered: list[str] = []
+    visited: set[str] = set()
+
+    def visit(model_name: str) -> None:
+        if model_name in visited:
+            return
+        info = dbt_models.get(model_name)
+        if info is not None:
+            for ref in info.refs:
+                if ref in selected:
+                    visit(ref)
+        visited.add(model_name)
+        if model_name in selected:
+            ordered.append(model_name)
+
+    for model_name in staging_models:
+        visit(model_name)
+    for model_name in canonical_relations:
+        visit(model_name)
+    for model_name in sorted(selected):
+        visit(model_name)
+    return ordered
+
+
+def _canonical_duckdb_relations() -> tuple[str, ...]:
+    return (
+        STOCK_BASIC_LOAD_SPEC.duckdb_relation,
+        *(spec.duckdb_relation for spec in CANONICAL_MART_LOAD_SPECS),
+    )
+
+
+def _build_dbt_specs(
+    selected_model_names: Sequence[str],
+    dbt_models: Mapping[str, _DbtModelInfo],
+    raw_deps_by_staging_model: Mapping[str, list[AssetKey]],
+) -> list[DataPlatformAssetSpec]:
+    specs: list[DataPlatformAssetSpec] = []
+    for model_name in selected_model_names:
+        info = dbt_models.get(model_name)
+        deps = [
+            _dbt_key(ref)
+            for ref in (info.refs if info is not None else ())
+        ]
+        deps.extend(raw_deps_by_staging_model.get(model_name, ()))
+        layer = info.layer if info is not None else _model_layer(model_name)
+        metadata: dict[str, Any] = {
+            "model": model_name,
+            "layer": layer,
+            "dbt_project_dir": str(DBT_PROJECT_DIR),
+            "dbt_args": ["run", "--select", model_name],
+        }
+        if info is not None:
+            metadata["model_path"] = str(info.path.relative_to(DBT_PROJECT_DIR))
+
+        specs.append(
+            DataPlatformAssetSpec(
+                key=_dbt_key(model_name),
+                kind="dbt",
+                deps=tuple(dict.fromkeys(deps)),
+                metadata=metadata,
+                callable_import_path=DBT_RUNNER_CALLABLE,
+            )
+        )
+    return specs
+
+
+def _build_canonical_specs(
+    selected_dbt_models: Sequence[str],
+) -> list[DataPlatformAssetSpec]:
+    selected = set(selected_dbt_models)
+    specs = [
+        DataPlatformAssetSpec(
+            key=_canonical_key(STOCK_BASIC_LOAD_SPEC.identifier),
+            kind="canonical",
+            deps=(_dbt_key(STOCK_BASIC_LOAD_SPEC.duckdb_relation),),
+            metadata={
+                "identifier": STOCK_BASIC_LOAD_SPEC.identifier,
+                "duckdb_relation": STOCK_BASIC_LOAD_SPEC.duckdb_relation,
+                "required_columns": list(STOCK_BASIC_LOAD_SPEC.required_columns),
+                "writer": "stock_basic",
+            },
+            callable_import_path=CANONICAL_STOCK_BASIC_CALLABLE,
+        )
+    ]
+
+    for load_spec in CANONICAL_MART_LOAD_SPECS:
+        deps: tuple[AssetKey, ...] = ()
+        if load_spec.duckdb_relation in selected:
+            deps = (_dbt_key(load_spec.duckdb_relation),)
+        specs.append(
+            DataPlatformAssetSpec(
+                key=_canonical_key(load_spec.identifier),
+                kind="canonical",
+                deps=deps,
+                metadata={
+                    "identifier": load_spec.identifier,
+                    "duckdb_relation": load_spec.duckdb_relation,
+                    "required_columns": list(load_spec.required_columns),
+                    "writer": "marts",
+                    "write_group": "canonical_marts",
+                },
+                callable_import_path=CANONICAL_MARTS_CALLABLE,
+            )
+        )
+    return specs
+
+
+def _model_layer(model_name: str) -> str:
+    if model_name.startswith("stg_"):
+        return "staging"
+    if model_name.startswith("int_"):
+        return "intermediate"
+    if model_name.startswith("mart_"):
+        return "marts"
+    return "unknown"
+
+
+def _spec_to_json(spec: DataPlatformAssetSpec) -> dict[str, Any]:
+    return _json_safe(asdict(spec))
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    return str(value)
+
+
+def _to_snake_case(value: str) -> str:
+    value = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", value)
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    return value.lower()
+
+
+__all__ = [
+    "AssetKey",
+    "AssetKind",
+    "DBT_PROJECT_DIR",
+    "DataPlatformAssetSpec",
+    "build_assets",
+    "build_default_adapters",
+    "build_resources",
+    "main",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data_platform/assets.py
+++ b/src/data_platform/assets.py
@@ -33,6 +33,8 @@ CANONICAL_STOCK_BASIC_CALLABLE = (
     "data_platform.serving.canonical_writer:load_canonical_stock_basic"
 )
 CANONICAL_MARTS_CALLABLE = "data_platform.serving.canonical_writer:load_canonical_marts"
+CANONICAL_MARTS_ASSET_KEY: AssetKey = ("canonical", "canonical_marts")
+CANONICAL_MARTS_ASSET_IDENTIFIER = "canonical.canonical_marts"
 _REF_PATTERN = re.compile(r"\{\{\s*ref\(\s*['\"]([^'\"]+)['\"]\s*\)\s*\}\}")
 
 
@@ -158,7 +160,7 @@ def build_resources(settings: Settings | None = None) -> dict[str, Any]:
             iceberg_warehouse_path=resolved_settings.iceberg_warehouse_path,
         ),
         "raw_reader": RawReader(resolved_settings.raw_zone_path),
-        "iceberg_catalog": load_catalog(),
+        "iceberg_catalog": load_catalog(settings=resolved_settings),
         "duckdb_path": resolved_settings.duckdb_path,
         "dbt_project_dir": DBT_PROJECT_DIR,
         "raw_zone_path": resolved_settings.raw_zone_path,
@@ -350,7 +352,6 @@ def _build_dbt_specs(
 def _build_canonical_specs(
     selected_dbt_models: Sequence[str],
 ) -> list[DataPlatformAssetSpec]:
-    selected = set(selected_dbt_models)
     specs = [
         DataPlatformAssetSpec(
             key=_canonical_key(STOCK_BASIC_LOAD_SPEC.identifier),
@@ -366,25 +367,34 @@ def _build_canonical_specs(
         )
     ]
 
-    for load_spec in CANONICAL_MART_LOAD_SPECS:
-        deps: tuple[AssetKey, ...] = ()
-        if load_spec.duckdb_relation in selected:
-            deps = (_dbt_key(load_spec.duckdb_relation),)
-        specs.append(
-            DataPlatformAssetSpec(
-                key=_canonical_key(load_spec.identifier),
-                kind="canonical",
-                deps=deps,
-                metadata={
-                    "identifier": load_spec.identifier,
-                    "duckdb_relation": load_spec.duckdb_relation,
-                    "required_columns": list(load_spec.required_columns),
-                    "writer": "marts",
-                    "write_group": "canonical_marts",
+    mart_deps = tuple(
+        _dbt_key(load_spec.duckdb_relation)
+        for load_spec in CANONICAL_MART_LOAD_SPECS
+    )
+    specs.append(
+        DataPlatformAssetSpec(
+            key=CANONICAL_MARTS_ASSET_KEY,
+            kind="canonical",
+            deps=mart_deps,
+            metadata={
+                "identifier": CANONICAL_MARTS_ASSET_IDENTIFIER,
+                "canonical_identifiers": [
+                    load_spec.identifier for load_spec in CANONICAL_MART_LOAD_SPECS
+                ],
+                "duckdb_relations": [
+                    load_spec.duckdb_relation for load_spec in CANONICAL_MART_LOAD_SPECS
+                ],
+                "required_columns_by_identifier": {
+                    load_spec.identifier: list(load_spec.required_columns)
+                    for load_spec in CANONICAL_MART_LOAD_SPECS
                 },
-                callable_import_path=CANONICAL_MARTS_CALLABLE,
-            )
+                "writer": "marts",
+                "write_group": "canonical_marts",
+                "serialization_required": True,
+            },
+            callable_import_path=CANONICAL_MARTS_CALLABLE,
         )
+    )
     return specs
 
 
@@ -423,6 +433,7 @@ def _to_snake_case(value: str) -> str:
 __all__ = [
     "AssetKey",
     "AssetKind",
+    "CANONICAL_MARTS_ASSET_KEY",
     "DBT_PROJECT_DIR",
     "DataPlatformAssetSpec",
     "build_assets",

--- a/src/data_platform/serving/catalog.py
+++ b/src/data_platform/serving/catalog.py
@@ -13,7 +13,7 @@ from pyiceberg.catalog.sql import SqlCatalog
 from pyiceberg.typedef import Identifier
 from sqlalchemy.exc import SQLAlchemyError
 
-from data_platform.config import get_settings
+from data_platform.config import Settings, get_settings
 
 
 DEFAULT_NAMESPACES: Final[tuple[str, str, str]] = ("canonical", "formal", "analytical")
@@ -43,10 +43,14 @@ class DataPlatformSqlCatalog(SqlCatalog):
 SQL_CATALOG_CLASS: type[SqlCatalog] = DataPlatformSqlCatalog
 
 
-def load_catalog(name: str | None = None) -> SqlCatalog:
+def load_catalog(
+    name: str | None = None,
+    *,
+    settings: Settings | None = None,
+) -> SqlCatalog:
     """Load the project PG-backed PyIceberg SQL catalog."""
 
-    pg_dsn, configured_catalog_name, warehouse_path = _catalog_config()
+    pg_dsn, configured_catalog_name, warehouse_path = _catalog_config(settings)
     catalog_name = name or configured_catalog_name
     properties = {
         "uri": _sqlalchemy_postgres_uri(pg_dsn),
@@ -77,9 +81,16 @@ def ensure_namespaces(catalog: SqlCatalog, names: Iterable[str | Identifier]) ->
             raise
 
 
-def _catalog_config() -> tuple[str, str, Path]:
+def _catalog_config(settings: Settings | None = None) -> tuple[str, str, Path]:
+    if settings is not None:
+        return (
+            str(settings.pg_dsn),
+            settings.iceberg_catalog_name,
+            settings.iceberg_warehouse_path,
+        )
+
     try:
-        settings = get_settings()
+        resolved_settings = get_settings()
     except ValidationError as exc:
         jdbc_config = _jdbc_catalog_config_from_env(exc)
         if jdbc_config is None:
@@ -87,9 +98,9 @@ def _catalog_config() -> tuple[str, str, Path]:
         return jdbc_config
 
     return (
-        str(settings.pg_dsn),
-        settings.iceberg_catalog_name,
-        settings.iceberg_warehouse_path,
+        str(resolved_settings.pg_dsn),
+        resolved_settings.iceberg_catalog_name,
+        resolved_settings.iceberg_warehouse_path,
     )
 
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -15,6 +15,7 @@ from data_platform.assets import (
 )
 from data_platform.config import Settings
 from data_platform.raw import RawReader, RawWriter
+from data_platform.serving import catalog as catalog_module
 
 
 pa = pytest.importorskip("pyarrow")
@@ -55,15 +56,40 @@ def test_build_assets_links_raw_staging_marts_and_canonical_specs() -> None:
     raw_key = ("raw", "fake", "stock_basic")
     staging_key = ("dbt", "stg_stock_basic")
     stock_basic_key = ("canonical", "stock_basic")
-    mart_dbt_key = ("dbt", "mart_dim_security")
-    mart_canonical_key = ("canonical", "dim_security")
+    canonical_marts_key = ("canonical", "canonical_marts")
+    mart_dbt_keys = {
+        ("dbt", "mart_dim_security"),
+        ("dbt", "mart_dim_index"),
+        ("dbt", "mart_fact_price_bar"),
+        ("dbt", "mart_fact_financial_indicator"),
+        ("dbt", "mart_fact_event"),
+    }
 
     assert by_key[raw_key].kind == "raw"
     assert by_key[staging_key].deps == (raw_key,)
     assert by_key[stock_basic_key].deps == (staging_key,)
-    assert by_key[mart_canonical_key].deps == (mart_dbt_key,)
-    assert by_key[mart_canonical_key].metadata["identifier"] == "canonical.dim_security"
-    assert by_key[mart_canonical_key].callable_import_path.endswith(":load_canonical_marts")
+    assert set(by_key[canonical_marts_key].deps) == mart_dbt_keys
+    assert (
+        by_key[canonical_marts_key].metadata["identifier"]
+        == "canonical.canonical_marts"
+    )
+    assert by_key[canonical_marts_key].metadata["canonical_identifiers"] == [
+        "canonical.dim_security",
+        "canonical.dim_index",
+        "canonical.fact_price_bar",
+        "canonical.fact_financial_indicator",
+        "canonical.fact_event",
+    ]
+    assert by_key[canonical_marts_key].metadata["serialization_required"] is True
+    assert by_key[canonical_marts_key].callable_import_path.endswith(
+        ":load_canonical_marts"
+    )
+    mart_group_specs = [
+        spec
+        for spec in specs
+        if spec.callable_import_path.endswith(":load_canonical_marts")
+    ]
+    assert [spec.key for spec in mart_group_specs] == [canonical_marts_key]
 
     _assert_dependency_order(specs)
     _assert_acyclic(specs)
@@ -80,7 +106,13 @@ def test_build_resources_returns_runtime_objects_from_settings(
         duckdb_path=tmp_path / "duckdb" / "data_platform.duckdb",
     )
     fake_catalog = object()
-    monkeypatch.setattr(assets_module, "load_catalog", lambda: fake_catalog)
+    captured_settings: list[Settings | None] = []
+
+    def fake_load_catalog(*, settings: Settings | None = None) -> object:
+        captured_settings.append(settings)
+        return fake_catalog
+
+    monkeypatch.setattr(assets_module, "load_catalog", fake_load_catalog)
 
     resources = build_resources(settings)
 
@@ -89,8 +121,48 @@ def test_build_resources_returns_runtime_objects_from_settings(
     assert isinstance(resources["raw_reader"], RawReader)
     assert resources["raw_reader"].raw_zone_path == settings.raw_zone_path
     assert resources["iceberg_catalog"] is fake_catalog
+    assert captured_settings == [settings]
     assert resources["duckdb_path"] == settings.duckdb_path
     assert resources["dbt_project_dir"] == assets_module.DBT_PROJECT_DIR
+
+
+def test_load_catalog_uses_injected_settings_for_uri_and_warehouse(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    injected_settings = Settings(
+        pg_dsn="postgresql://injected:pass@localhost/injected",
+        raw_zone_path=tmp_path / "raw-injected",
+        iceberg_warehouse_path=tmp_path / "warehouse-injected",
+        duckdb_path=tmp_path / "duckdb" / "injected.duckdb",
+        iceberg_catalog_name="injected_catalog",
+    )
+    monkeypatch.setenv("DP_PG_DSN", "postgresql://env:pass@localhost/env")
+    monkeypatch.setenv("DP_RAW_ZONE_PATH", str(tmp_path / "raw-env"))
+    monkeypatch.setenv("DP_ICEBERG_WAREHOUSE_PATH", str(tmp_path / "warehouse-env"))
+    monkeypatch.setenv("DP_DUCKDB_PATH", str(tmp_path / "duckdb" / "env.duckdb"))
+    monkeypatch.setenv("DP_ICEBERG_CATALOG_NAME", "env_catalog")
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    class CapturingCatalog:
+        def __init__(self, name: str, **properties: str) -> None:
+            calls.append((name, properties))
+
+    monkeypatch.setattr(catalog_module, "SQL_CATALOG_CLASS", CapturingCatalog)
+
+    catalog_module.load_catalog(settings=injected_settings)
+
+    assert calls == [
+        (
+            "injected_catalog",
+            {
+                "uri": "postgresql+psycopg://injected:pass@localhost/injected",
+                "warehouse": str(tmp_path / "warehouse-injected"),
+                "pool_pre_ping": "true",
+                "init_catalog_tables": "true",
+            },
+        )
+    ]
 
 
 def test_assets_cli_outputs_stable_json_with_canonical_marts(
@@ -100,19 +172,29 @@ def test_assets_cli_outputs_stable_json_with_canonical_marts(
 
     captured = capsys.readouterr()
     payload = assets_module.json.loads(captured.out)
-    canonical_identifiers = {
-        item["metadata"]["identifier"]
-        for item in payload
-        if item["kind"] == "canonical"
+    canonical_keys = {
+        tuple(item["key"]) for item in payload if item["kind"] == "canonical"
     }
+    canonical_marts = next(
+        item
+        for item in payload
+        if item["key"] == ["canonical", "canonical_marts"]
+    )
 
     assert exit_code == 0
     assert captured.err == ""
-    assert "canonical.dim_security" in canonical_identifiers
-    assert "canonical.dim_index" in canonical_identifiers
-    assert "canonical.fact_price_bar" in canonical_identifiers
-    assert "canonical.fact_financial_indicator" in canonical_identifiers
-    assert "canonical.fact_event" in canonical_identifiers
+    assert canonical_marts["metadata"]["canonical_identifiers"] == [
+        "canonical.dim_security",
+        "canonical.dim_index",
+        "canonical.fact_price_bar",
+        "canonical.fact_financial_indicator",
+        "canonical.fact_event",
+    ]
+    assert ("canonical", "dim_security") not in canonical_keys
+    assert ("canonical", "dim_index") not in canonical_keys
+    assert ("canonical", "fact_price_bar") not in canonical_keys
+    assert ("canonical", "fact_financial_indicator") not in canonical_keys
+    assert ("canonical", "fact_event") not in canonical_keys
 
 
 def test_assets_cli_filters_by_kind(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from data_platform import assets as assets_module
+from data_platform.adapters.base import AssetSpec, DataSourceAdapter
+from data_platform.assets import (
+    DataPlatformAssetSpec,
+    build_assets,
+    build_resources,
+    main,
+)
+from data_platform.config import Settings
+from data_platform.raw import RawReader, RawWriter
+
+
+pa = pytest.importorskip("pyarrow")
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DATA_PLATFORM = PROJECT_ROOT / "src" / "data_platform"
+
+
+class FakeAdapter(DataSourceAdapter):
+    def source_id(self) -> str:
+        return "fake"
+
+    def get_assets(self) -> list[AssetSpec]:
+        return [
+            AssetSpec(
+                name="fake_stock_basic",
+                dataset="stock_basic",
+                partition="static",
+                schema=pa.schema([("ts_code", pa.string())]),
+            )
+        ]
+
+    def get_resources(self) -> dict[str, Any]:
+        return {"source_id": self.source_id(), "token_env": "FAKE_TOKEN"}
+
+    def get_staging_dbt_models(self) -> list[str]:
+        return ["stg_stock_basic"]
+
+    def get_quota_config(self) -> dict[str, Any]:
+        return {"requests_per_minute": 1, "daily_credit_quota": None}
+
+
+def test_build_assets_links_raw_staging_marts_and_canonical_specs() -> None:
+    specs = build_assets([FakeAdapter()])
+    by_key = {spec.key: spec for spec in specs}
+
+    raw_key = ("raw", "fake", "stock_basic")
+    staging_key = ("dbt", "stg_stock_basic")
+    stock_basic_key = ("canonical", "stock_basic")
+    mart_dbt_key = ("dbt", "mart_dim_security")
+    mart_canonical_key = ("canonical", "dim_security")
+
+    assert by_key[raw_key].kind == "raw"
+    assert by_key[staging_key].deps == (raw_key,)
+    assert by_key[stock_basic_key].deps == (staging_key,)
+    assert by_key[mart_canonical_key].deps == (mart_dbt_key,)
+    assert by_key[mart_canonical_key].metadata["identifier"] == "canonical.dim_security"
+    assert by_key[mart_canonical_key].callable_import_path.endswith(":load_canonical_marts")
+
+    _assert_dependency_order(specs)
+    _assert_acyclic(specs)
+
+
+def test_build_resources_returns_runtime_objects_from_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    settings = Settings(
+        pg_dsn="postgresql://user:pass@localhost/data_platform",
+        raw_zone_path=tmp_path / "raw",
+        iceberg_warehouse_path=tmp_path / "warehouse",
+        duckdb_path=tmp_path / "duckdb" / "data_platform.duckdb",
+    )
+    fake_catalog = object()
+    monkeypatch.setattr(assets_module, "load_catalog", lambda: fake_catalog)
+
+    resources = build_resources(settings)
+
+    assert isinstance(resources["raw_writer"], RawWriter)
+    assert resources["raw_writer"].raw_zone_path == settings.raw_zone_path
+    assert isinstance(resources["raw_reader"], RawReader)
+    assert resources["raw_reader"].raw_zone_path == settings.raw_zone_path
+    assert resources["iceberg_catalog"] is fake_catalog
+    assert resources["duckdb_path"] == settings.duckdb_path
+    assert resources["dbt_project_dir"] == assets_module.DBT_PROJECT_DIR
+
+
+def test_assets_cli_outputs_stable_json_with_canonical_marts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["--json"])
+
+    captured = capsys.readouterr()
+    payload = assets_module.json.loads(captured.out)
+    canonical_identifiers = {
+        item["metadata"]["identifier"]
+        for item in payload
+        if item["kind"] == "canonical"
+    }
+
+    assert exit_code == 0
+    assert captured.err == ""
+    assert "canonical.dim_security" in canonical_identifiers
+    assert "canonical.dim_index" in canonical_identifiers
+    assert "canonical.fact_price_bar" in canonical_identifiers
+    assert "canonical.fact_financial_indicator" in canonical_identifiers
+    assert "canonical.fact_event" in canonical_identifiers
+
+
+def test_assets_cli_filters_by_kind(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["--json", "--kind", "canonical"])
+
+    payload = assets_module.json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload
+    assert {item["kind"] for item in payload} == {"canonical"}
+
+
+def test_data_platform_asset_spec_normalizes_tuple_fields() -> None:
+    spec = DataPlatformAssetSpec(
+        key=("dbt", "stg_stock_basic"),
+        kind="dbt",
+        deps=[("raw", "fake", "stock_basic")],  # type: ignore[arg-type]
+        metadata={"model": "stg_stock_basic"},
+        callable_import_path="dbt.cli.main:dbtRunner",
+    )
+
+    assert spec.key == ("dbt", "stg_stock_basic")
+    assert spec.deps == (("raw", "fake", "stock_basic"),)
+    assert spec.metadata["callable_import_path"] == "dbt.cli.main:dbtRunner"
+
+
+def test_data_platform_package_has_no_orchestrator_runtime_definitions() -> None:
+    for path in SRC_DATA_PLATFORM.rglob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        lowered = source.lower()
+
+        assert "import dagster" not in lowered, path
+        assert "from dagster" not in lowered, path
+        assert "definitions(" not in source, path
+        assert "@job" not in source, path
+        assert "@schedule" not in source, path
+        assert "@sensor" not in source, path
+
+
+def _assert_dependency_order(specs: list[DataPlatformAssetSpec]) -> None:
+    position_by_key = {spec.key: index for index, spec in enumerate(specs)}
+    for spec in specs:
+        for dep in spec.deps:
+            assert position_by_key[dep] < position_by_key[spec.key]
+
+
+def _assert_acyclic(specs: list[DataPlatformAssetSpec]) -> None:
+    deps_by_key = {spec.key: spec.deps for spec in specs}
+    visiting: set[tuple[str, ...]] = set()
+    visited: set[tuple[str, ...]] = set()
+
+    def visit(key: tuple[str, ...]) -> None:
+        if key in visited:
+            return
+        assert key not in visiting
+        visiting.add(key)
+        for dep in deps_by_key[key]:
+            visit(dep)
+        visiting.remove(key)
+        visited.add(key)
+
+    for key in deps_by_key:
+        visit(key)


### PR DESCRIPTION
Closes #25

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `docs/spike/iceberg-write-chain.md`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/dbt/macros/stg_latest_raw.sql`, `src/data_platform/dbt/models/intermediate/int_financial_reports_latest.sql`, `src/data_platform/dbt/models/marts/mart_dim_security.sql`


---
### 1. 背景与目标
项目文档 §4.1 / §14 规定 data-platform 提供 asset/resource 工厂，但不拥有 Dagster job/schedule。当前代码已经有 `DataSourceAdapter` / `AssetSpec`、`RawWriter`、`load_catalog()`、`load_canonical_*` 等可装配能力，但没有统一的 Dagster-neutral 描述。#23 会补齐 canonical marts，本 issue 输出给 orchestrator 消费的纯 Python spec 与 resources map。

### 2. 所属模块
新增 `src/data_platform/assets.py`，配套测试在 `tests/test_assets.py`。

### 3. 实现范围
- 新增 Dagster-neutral dataclass，描述 raw fetch、dbt model、canonical write 三类 asset 的 key、依赖、metadata 和 callable import path。
- 实现 `build_assets(adapters: Sequence[DataSourceAdapter] | None = None) -> list[DataPlatformAssetSpec]`，从 `TushareAdapter.get_assets()` 与 `get_staging_dbt_models()` 生成 Raw/dbt/canonical 依赖链。
- 实现 `build_resources(settings: Settings | None = None) -> dict[str, Any]`，返回 `raw_writer`、`raw_reader`、`iceberg_catalog`、`duckdb_path`、`dbt_project_dir` 等装配资源。
- 提供 `build_default_adapters() -> list[DataSourceAdapter]`，默认只包含 Tushare adapter，允许测试注入 fake adapter 避免 token 依赖。
- 新增 CLI `python -m data_platform.assets --json`，输出稳定 JSON 便于 orchestrator smoke 检查。

### 4. 不在本次范围
- 不 import Dagster，不定义 job/schedule/sensor/Definitions。
- 不执行 adapter fetch、dbt run 或 canonical write；只描述可装配 spec。
- 不新增新的数据源或业务资产。
- 不改变 `DataSourceAdapter` 公共协议。

### 5. 关键交付物
- `@dataclass(frozen=True) class DataPlatformAssetSpec`，字段包含 `key: tuple[str, ...]`、`kind: Literal['raw', 'dbt', 'canonical']`、`deps: tuple[tuple[str, ...], ...]`、`metadata: dict[str, Any]`。
- `build_assets(adapters: Sequence[DataSourceAdapter] | None = None) -> list[DataPlatformAssetSpec]`。
- `build_resources(settings: Settings | None = None) -> dict[str, Any]`，其中 `Settings` 来自 `data_platform.config.Settings`。
- `build_default_adapters() -> list[DataSourceAdapter]`。
- `main(argv: Sequence[str] | None = None) -> int`，支持 `--json` 和 `--kind raw|dbt|canonical`。
- 测试断言 `src/data_platform/assets.py` 与整个 `src/data_platform/` 不出现 `dagster` import。

### 6. 验收标准
- [ ] fake adapter 下 `build_assets(...)` 生成 Raw asset → staging dbt model → marts/can