### PR TITLE
feat(#69): [milestone-1 review] P0: Tracked milestone artifact is missing source and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Guard tracked repository artifacts
+        run: python scripts/check_repository_artifacts.py
+
+      - name: Install test dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Run tests
+        run: python -m pytest

--- a/scripts/check_repository_artifacts.py
+++ b/scripts/check_repository_artifacts.py
@@ -9,22 +9,82 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+REQUIRED_REPOSITORY_FILES: tuple[str, ...] = (
+    # Generated artifacts must stay ignored and checked in CI.
+    ".gitignore",
+    ".github/workflows/ci.yml",
+    # Core package and adapter surface.
+    "src/data_platform/__init__.py",
+    "src/data_platform/adapters/base.py",
+    "src/data_platform/adapters/tushare/adapter.py",
+    "src/data_platform/adapters/tushare/assets.py",
+    "src/data_platform/assets.py",
+    "src/data_platform/config/settings.py",
+    "src/data_platform/daily_refresh.py",
+    "src/data_platform/raw/health.py",
+    "src/data_platform/raw/writer.py",
+    # Canonical DDL, serving, and schema-evolution implementation.
+    "src/data_platform/ddl/iceberg_tables.py",
+    "src/data_platform/ddl/runner.py",
+    "src/data_platform/serving/canonical_writer.py",
+    "src/data_platform/serving/catalog.py",
+    "src/data_platform/serving/reader.py",
+    "src/data_platform/serving/schema_evolution.py",
+    # dbt project artifacts required for structured data reproducibility.
+    "src/data_platform/dbt/dbt_project.yml",
+    "src/data_platform/dbt/macros/stg_latest_raw.sql",
+    "src/data_platform/dbt/models/staging/_schema.yml",
+    "src/data_platform/dbt/models/staging/stg_stock_basic.sql",
+    "src/data_platform/dbt/models/intermediate/_schema.yml",
+    "src/data_platform/dbt/models/intermediate/int_price_bars_adjusted.sql",
+    "src/data_platform/dbt/models/marts/_schema.yml",
+    "src/data_platform/dbt/models/marts/mart_fact_price_bar.sql",
+    "src/data_platform/dbt/tests/assert_raw_manifest_fresh.sql",
+    # Operator scripts and CI guard.
+    "scripts/canonical_backfill.py",
+    "scripts/check_repository_artifacts.py",
+    "scripts/daily_refresh.sh",
+    "scripts/dbt.sh",
+    "scripts/init_iceberg_catalog.py",
+    # Representative tests for each restored milestone area.
+    "tests/test_assets.py",
+    "tests/test_repository_artifact_guard.py",
+    "tests/adapters/test_tushare.py",
+    "tests/dbt/test_tushare_staging_models.py",
+    "tests/dbt/test_intermediate_models.py",
+    "tests/dbt/test_marts_models.py",
+    "tests/ddl/test_iceberg_tables.py",
+    "tests/integration/test_daily_refresh.py",
+    "tests/raw/test_writer.py",
+    "tests/serving/test_canonical_writer.py",
+)
+
+
 @dataclass(frozen=True)
 class RepositoryArtifactCheck:
     tracked_paths: tuple[str, ...]
     generated_artifacts: tuple[str, ...]
+    missing_required_paths: tuple[str, ...]
     has_platform_source: bool
     has_tests: bool
 
     @property
     def ok(self) -> bool:
-        return not self.generated_artifacts and self.has_platform_source and self.has_tests
+        return (
+            not self.generated_artifacts
+            and not self.missing_required_paths
+            and self.has_platform_source
+            and self.has_tests
+        )
 
     def error_messages(self) -> list[str]:
         messages: list[str] = []
         if self.generated_artifacts:
             messages.append("generated Python artifacts are tracked:")
             messages.extend(f"  - {path}" for path in self.generated_artifacts)
+        if self.missing_required_paths:
+            messages.append("required repository files are missing:")
+            messages.extend(f"  - {path}" for path in self.missing_required_paths)
         if not self.has_platform_source:
             messages.append("no tracked Python source files found under src/data_platform/")
         if not self.has_tests:
@@ -53,13 +113,18 @@ def git_ls_files(repo_root: Path) -> tuple[str, ...]:
 
 def check_tracked_paths(paths: Sequence[str]) -> RepositoryArtifactCheck:
     normalized_paths = tuple(_normalize_path(path) for path in paths)
+    tracked_path_set = set(normalized_paths)
     generated_artifacts = tuple(
         path for path in normalized_paths if _is_generated_python_artifact(path)
+    )
+    missing_required_paths = tuple(
+        path for path in REQUIRED_REPOSITORY_FILES if path not in tracked_path_set
     )
 
     return RepositoryArtifactCheck(
         tracked_paths=normalized_paths,
         generated_artifacts=generated_artifacts,
+        missing_required_paths=missing_required_paths,
         has_platform_source=any(_is_platform_source(path) for path in normalized_paths),
         has_tests=any(_is_test_source(path) for path in normalized_paths),
     )
@@ -110,8 +175,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     check = check_tracked_paths(tracked_paths)
     if check.ok:
         print(
-            "Repository artifact guard passed: tracked source and tests are present, "
-            "and no generated Python artifacts are tracked."
+            "Repository artifact guard passed: required source, dbt, scripts, "
+            "and tests are tracked, and no generated Python artifacts are tracked."
         )
         return 0
 

--- a/scripts/check_repository_artifacts.py
+++ b/scripts/check_repository_artifacts.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RepositoryArtifactCheck:
+    tracked_paths: tuple[str, ...]
+    generated_artifacts: tuple[str, ...]
+    has_platform_source: bool
+    has_tests: bool
+
+    @property
+    def ok(self) -> bool:
+        return not self.generated_artifacts and self.has_platform_source and self.has_tests
+
+    def error_messages(self) -> list[str]:
+        messages: list[str] = []
+        if self.generated_artifacts:
+            messages.append("generated Python artifacts are tracked:")
+            messages.extend(f"  - {path}" for path in self.generated_artifacts)
+        if not self.has_platform_source:
+            messages.append("no tracked Python source files found under src/data_platform/")
+        if not self.has_tests:
+            messages.append("no tracked Python test files found under tests/")
+        return messages
+
+
+def git_ls_files(repo_root: Path) -> tuple[str, ...]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git ls-files failed: {stderr}")
+
+    return tuple(
+        path
+        for path in result.stdout.decode(errors="replace").split("\0")
+        if path
+    )
+
+
+def check_tracked_paths(paths: Sequence[str]) -> RepositoryArtifactCheck:
+    normalized_paths = tuple(_normalize_path(path) for path in paths)
+    generated_artifacts = tuple(
+        path for path in normalized_paths if _is_generated_python_artifact(path)
+    )
+
+    return RepositoryArtifactCheck(
+        tracked_paths=normalized_paths,
+        generated_artifacts=generated_artifacts,
+        has_platform_source=any(_is_platform_source(path) for path in normalized_paths),
+        has_tests=any(_is_test_source(path) for path in normalized_paths),
+    )
+
+
+def _normalize_path(path: str) -> str:
+    return path.replace("\\", "/").strip("/")
+
+
+def _is_generated_python_artifact(path: str) -> bool:
+    parts = path.split("/")
+    return (
+        path.endswith((".pyc", ".pyo"))
+        or "__pycache__" in parts
+        or any(part.endswith(".egg-info") for part in parts)
+    )
+
+
+def _is_platform_source(path: str) -> bool:
+    return path.startswith("src/data_platform/") and path.endswith(".py")
+
+
+def _is_test_source(path: str) -> bool:
+    return path.startswith("tests/") and path.endswith(".py")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail if generated Python artifacts are tracked or if required "
+            "source/test files are missing from the git index."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository root to inspect; defaults to this script's parent checkout",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        tracked_paths = git_ls_files(args.repo_root)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    check = check_tracked_paths(tracked_paths)
+    if check.ok:
+        print(
+            "Repository artifact guard passed: tracked source and tests are present, "
+            "and no generated Python artifacts are tracked."
+        )
+        return 0
+
+    print("Repository artifact guard failed:", file=sys.stderr)
+    for message in check.error_messages():
+        print(message, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repository_artifact_guard.py
+++ b/tests/test_repository_artifact_guard.py
@@ -25,17 +25,30 @@ def _load_guard_module() -> object:
 def test_guard_accepts_tracked_source_and_tests_without_generated_artifacts() -> None:
     guard = _load_guard_module()
 
+    check = guard.check_tracked_paths(guard.REQUIRED_REPOSITORY_FILES)
+
+    assert check.ok
+    assert check.generated_artifacts == ()
+    assert check.missing_required_paths == ()
+    assert check.error_messages() == []
+
+
+def test_guard_rejects_token_source_and_test_only_repository() -> None:
+    guard = _load_guard_module()
+
     check = guard.check_tracked_paths(
         [
             "src/data_platform/__init__.py",
-            "src/data_platform/dbt/models/staging/stg_stock_basic.sql",
             "tests/test_smoke.py",
         ]
     )
 
-    assert check.ok
-    assert check.generated_artifacts == ()
-    assert check.error_messages() == []
+    assert not check.ok
+    messages = check.error_messages()
+    assert "required repository files are missing:" in messages
+    assert "  - src/data_platform/adapters/tushare/adapter.py" in messages
+    assert "  - src/data_platform/dbt/dbt_project.yml" in messages
+    assert "  - scripts/dbt.sh" in messages
 
 
 def test_guard_rejects_generated_artifacts_and_missing_sources() -> None:
@@ -54,10 +67,16 @@ def test_guard_rejects_generated_artifacts_and_missing_sources() -> None:
         "src/data_platform/adapters/__pycache__/adapter.cpython-314.pyc",
         "src/project_ult_data_platform.egg-info/PKG-INFO",
     )
-    assert check.error_messages() == [
+    messages = check.error_messages()
+    assert messages[:3] == [
         "generated Python artifacts are tracked:",
         "  - src/data_platform/adapters/__pycache__/adapter.cpython-314.pyc",
         "  - src/project_ult_data_platform.egg-info/PKG-INFO",
+    ]
+    assert "required repository files are missing:" in messages
+    assert "  - src/data_platform/adapters/tushare/adapter.py" in messages
+    assert "  - src/data_platform/dbt/dbt_project.yml" in messages
+    assert messages[-2:] == [
         "no tracked Python source files found under src/data_platform/",
         "no tracked Python test files found under tests/",
     ]
@@ -69,3 +88,11 @@ def test_git_index_has_source_tests_and_no_generated_artifacts() -> None:
     check = guard.check_tracked_paths(guard.git_ls_files(PROJECT_ROOT))
 
     assert check.ok, "\n".join(check.error_messages())
+
+
+def test_gitignore_excludes_generated_python_artifacts() -> None:
+    gitignore = (PROJECT_ROOT / ".gitignore").read_text()
+
+    assert "__pycache__/" in gitignore
+    assert "*.py[cod]" in gitignore
+    assert "*.egg-info/" in gitignore

--- a/tests/test_repository_artifact_guard.py
+++ b/tests/test_repository_artifact_guard.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+GUARD_SCRIPT = PROJECT_ROOT / "scripts" / "check_repository_artifacts.py"
+
+
+def _load_guard_module() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "check_repository_artifacts", GUARD_SCRIPT
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_guard_accepts_tracked_source_and_tests_without_generated_artifacts() -> None:
+    guard = _load_guard_module()
+
+    check = guard.check_tracked_paths(
+        [
+            "src/data_platform/__init__.py",
+            "src/data_platform/dbt/models/staging/stg_stock_basic.sql",
+            "tests/test_smoke.py",
+        ]
+    )
+
+    assert check.ok
+    assert check.generated_artifacts == ()
+    assert check.error_messages() == []
+
+
+def test_guard_rejects_generated_artifacts_and_missing_sources() -> None:
+    guard = _load_guard_module()
+
+    check = guard.check_tracked_paths(
+        [
+            "src/data_platform/adapters/__pycache__/adapter.cpython-314.pyc",
+            "src/project_ult_data_platform.egg-info/PKG-INFO",
+            "README.md",
+        ]
+    )
+
+    assert not check.ok
+    assert check.generated_artifacts == (
+        "src/data_platform/adapters/__pycache__/adapter.cpython-314.pyc",
+        "src/project_ult_data_platform.egg-info/PKG-INFO",
+    )
+    assert check.error_messages() == [
+        "generated Python artifacts are tracked:",
+        "  - src/data_platform/adapters/__pycache__/adapter.cpython-314.pyc",
+        "  - src/project_ult_data_platform.egg-info/PKG-INFO",
+        "no tracked Python source files found under src/data_platform/",
+        "no tracked Python test files found under tests/",
+    ]
+
+
+def test_git_index_has_source_tests_and_no_generated_artifacts() -> None:
+    guard = _load_guard_module()
+
+    check = guard.check_tracked_paths(guard.git_ls_files(PROJECT_ROOT))
+
+    assert check.ok, "\n".join(check.error_messages())


### PR DESCRIPTION
Closes #69

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/daily_refresh.py`


---
## 背景与目标
Milestone review for milestone-1 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The workspace at the milestone head tracks generated `__pycache__/*.pyc` and egg-info artifacts but does not contain the corresponding `.py`, `.sql`, `.yml`, or test source files. Imports such as `data_platform.adapters.tushare.adapter` resolve to no module in this checkout, and `pytest` collects no tests. This makes the milestone non-reproducible and blocks any reliable validation or follow-on development.

## 实现范围
- 修改文件: `cross-cutting`
- Restore and commit the actual source, dbt, script, and test files; remove tracked `__pycache__` and egg-info outputs; restore the `.gitignore` rules that exclude generated artifacts; add a CI guard that fails if generated bytecode is tracked or if `src/data_platform/**/*.py` / `tests/**/*.py` are absent.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/data-platform/.venv/bin/python -m pytest
```
