### PR TITLE
feat(#31): cycle_metadata 表与 cycle 创建接口

### DIFF
--- a/src/data_platform/cycle/__init__.py
+++ b/src/data_platform/cycle/__init__.py
@@ -1,1 +1,31 @@
 """Cycle control package."""
+
+from data_platform.cycle.models import (
+    CYCLE_ID_PATTERN,
+    CYCLE_METADATA_TABLE,
+    CycleAlreadyExists,
+    CycleMetadata,
+    CycleNotFound,
+    CycleStatus,
+    InvalidCycleId,
+    InvalidCycleTransition,
+)
+from data_platform.cycle.repository import (
+    create_cycle,
+    get_cycle,
+    transition_cycle_status,
+)
+
+__all__ = [
+    "CYCLE_ID_PATTERN",
+    "CYCLE_METADATA_TABLE",
+    "CycleAlreadyExists",
+    "CycleMetadata",
+    "CycleNotFound",
+    "CycleStatus",
+    "InvalidCycleId",
+    "InvalidCycleTransition",
+    "create_cycle",
+    "get_cycle",
+    "transition_cycle_status",
+]

--- a/src/data_platform/cycle/models.py
+++ b/src/data_platform/cycle/models.py
@@ -1,0 +1,83 @@
+"""Types for PostgreSQL-backed cycle control metadata."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Final, Literal, Pattern, TypeAlias
+
+CycleStatus: TypeAlias = Literal[
+    "pending",
+    "phase0",
+    "phase1",
+    "phase2",
+    "phase3",
+    "published",
+    "failed",
+]
+
+CYCLE_ID_PATTERN: Final[Pattern[str]] = re.compile(r"^CYCLE_[0-9]{8}$")
+CYCLE_METADATA_TABLE: Final[str] = "data_platform.cycle_metadata"
+
+_CYCLE_STATUSES: Final[frozenset[str]] = frozenset(
+    ("pending", "phase0", "phase1", "phase2", "phase3", "published", "failed")
+)
+
+
+class CycleError(RuntimeError):
+    """Base class for cycle metadata errors."""
+
+
+class CycleAlreadyExists(CycleError):
+    """Raised when a cycle already exists for the requested cycle date."""
+
+
+class CycleNotFound(CycleError):
+    """Raised when a cycle id does not exist."""
+
+
+class InvalidCycleId(CycleError):
+    """Raised when a cycle id does not match CYCLE_YYYYMMDD."""
+
+
+class InvalidCycleTransition(CycleError):
+    """Raised when a requested cycle status transition is not allowed."""
+
+
+@dataclass(frozen=True, slots=True)
+class CycleMetadata:
+    """A row from data_platform.cycle_metadata."""
+
+    cycle_id: str
+    cycle_date: date
+    status: CycleStatus
+    cutoff_submitted_at: datetime | None
+    cutoff_ingest_seq: int | None
+    candidate_count: int
+    selection_frozen_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+    def __post_init__(self) -> None:
+        validate_cycle_id(self.cycle_id)
+        validate_cycle_status(self.status)
+        if self.candidate_count < 0:
+            msg = "candidate_count must be greater than or equal to 0"
+            raise ValueError(msg)
+
+
+def validate_cycle_id(cycle_id: str) -> None:
+    """Validate the public cycle id contract."""
+
+    if CYCLE_ID_PATTERN.fullmatch(cycle_id) is None:
+        msg = f"cycle_id must match CYCLE_YYYYMMDD: {cycle_id!r}"
+        raise InvalidCycleId(msg)
+
+
+def validate_cycle_status(status: str) -> None:
+    """Validate the cycle status enum contract."""
+
+    if status not in _CYCLE_STATUSES:
+        msg = f"cycle status must be one of {sorted(_CYCLE_STATUSES)}: {status!r}"
+        raise InvalidCycleTransition(msg)

--- a/src/data_platform/cycle/models.py
+++ b/src/data_platform/cycle/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Final, Literal, Pattern, TypeAlias
+from typing import Final, Literal, TypeAlias
 
 CycleStatus: TypeAlias = Literal[
     "pending",
@@ -17,7 +17,7 @@ CycleStatus: TypeAlias = Literal[
     "failed",
 ]
 
-CYCLE_ID_PATTERN: Final[Pattern[str]] = re.compile(r"^CYCLE_[0-9]{8}$")
+CYCLE_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^CYCLE_[0-9]{8}$")
 CYCLE_METADATA_TABLE: Final[str] = "data_platform.cycle_metadata"
 
 _CYCLE_STATUSES: Final[frozenset[str]] = frozenset(

--- a/src/data_platform/cycle/repository.py
+++ b/src/data_platform/cycle/repository.py
@@ -1,0 +1,180 @@
+"""Repository helpers for PostgreSQL-backed cycle metadata."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import cast
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine, RowMapping
+from sqlalchemy.exc import IntegrityError
+
+from data_platform.config import get_settings
+from data_platform.cycle.models import (
+    CYCLE_METADATA_TABLE,
+    CycleAlreadyExists,
+    CycleMetadata,
+    CycleNotFound,
+    CycleStatus,
+    InvalidCycleTransition,
+    validate_cycle_id,
+    validate_cycle_status,
+)
+from data_platform.ddl.runner import _sqlalchemy_postgres_uri
+
+_ORDERED_TRANSITIONS: dict[str, str] = {
+    "pending": "phase0",
+    "phase0": "phase1",
+    "phase1": "phase2",
+    "phase2": "phase3",
+    "phase3": "published",
+}
+
+
+def create_cycle(cycle_date: date) -> CycleMetadata:
+    """Create a pending cycle for one cycle date."""
+
+    cycle_id = f"CYCLE_{cycle_date:%Y%m%d}"
+    engine = _create_engine()
+    try:
+        try:
+            with engine.begin() as connection:
+                row = connection.execute(
+                    text(
+                        f"""
+                        INSERT INTO {CYCLE_METADATA_TABLE} (cycle_id, cycle_date)
+                        VALUES (:cycle_id, :cycle_date)
+                        RETURNING
+                            cycle_id,
+                            cycle_date,
+                            status,
+                            cutoff_submitted_at,
+                            cutoff_ingest_seq,
+                            candidate_count,
+                            selection_frozen_at,
+                            created_at,
+                            updated_at
+                        """
+                    ),
+                    {"cycle_id": cycle_id, "cycle_date": cycle_date},
+                ).mappings().one()
+        except IntegrityError as exc:
+            msg = f"cycle already exists for cycle_date {cycle_date.isoformat()}"
+            raise CycleAlreadyExists(msg) from exc
+        return _row_to_cycle(row)
+    finally:
+        engine.dispose()
+
+
+def get_cycle(cycle_id: str) -> CycleMetadata:
+    """Read one cycle by id."""
+
+    validate_cycle_id(cycle_id)
+    engine = _create_engine()
+    try:
+        with engine.connect() as connection:
+            row = connection.execute(
+                text(
+                    f"""
+                    SELECT
+                        cycle_id,
+                        cycle_date,
+                        status,
+                        cutoff_submitted_at,
+                        cutoff_ingest_seq,
+                        candidate_count,
+                        selection_frozen_at,
+                        created_at,
+                        updated_at
+                    FROM {CYCLE_METADATA_TABLE}
+                    WHERE cycle_id = :cycle_id
+                    """
+                ),
+                {"cycle_id": cycle_id},
+            ).mappings().one_or_none()
+        if row is None:
+            msg = f"cycle not found: {cycle_id}"
+            raise CycleNotFound(msg)
+        return _row_to_cycle(row)
+    finally:
+        engine.dispose()
+
+
+def transition_cycle_status(cycle_id: str, status: CycleStatus) -> CycleMetadata:
+    """Move a cycle through the allowed status state machine."""
+
+    validate_cycle_id(cycle_id)
+    validate_cycle_status(status)
+    engine = _create_engine()
+    try:
+        with engine.begin() as connection:
+            current_row = connection.execute(
+                text(
+                    f"""
+                    SELECT status
+                    FROM {CYCLE_METADATA_TABLE}
+                    WHERE cycle_id = :cycle_id
+                    FOR UPDATE
+                    """
+                ),
+                {"cycle_id": cycle_id},
+            ).mappings().one_or_none()
+            if current_row is None:
+                msg = f"cycle not found: {cycle_id}"
+                raise CycleNotFound(msg)
+
+            current_status = str(current_row["status"])
+            if not _is_transition_allowed(current_status, status):
+                msg = f"cannot transition cycle {cycle_id} from {current_status!r} to {status!r}"
+                raise InvalidCycleTransition(msg)
+
+            updated_row = connection.execute(
+                text(
+                    f"""
+                    UPDATE {CYCLE_METADATA_TABLE}
+                    SET status = :status,
+                        updated_at = now()
+                    WHERE cycle_id = :cycle_id
+                    RETURNING
+                        cycle_id,
+                        cycle_date,
+                        status,
+                        cutoff_submitted_at,
+                        cutoff_ingest_seq,
+                        candidate_count,
+                        selection_frozen_at,
+                        created_at,
+                        updated_at
+                    """
+                ),
+                {"cycle_id": cycle_id, "status": status},
+            ).mappings().one()
+        return _row_to_cycle(updated_row)
+    finally:
+        engine.dispose()
+
+
+def _create_engine() -> Engine:
+    return create_engine(_sqlalchemy_postgres_uri(str(get_settings().pg_dsn)))
+
+
+def _is_transition_allowed(current_status: str, next_status: str) -> bool:
+    if next_status == "failed":
+        return current_status in _ORDERED_TRANSITIONS
+    return _ORDERED_TRANSITIONS.get(current_status) == next_status
+
+
+def _row_to_cycle(row: RowMapping) -> CycleMetadata:
+    return CycleMetadata(
+        cycle_id=str(row["cycle_id"]),
+        cycle_date=cast(date, row["cycle_date"]),
+        status=cast(CycleStatus, str(row["status"])),
+        cutoff_submitted_at=row["cutoff_submitted_at"],
+        cutoff_ingest_seq=(
+            None if row["cutoff_ingest_seq"] is None else int(row["cutoff_ingest_seq"])
+        ),
+        candidate_count=int(row["candidate_count"]),
+        selection_frozen_at=row["selection_frozen_at"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )

--- a/src/data_platform/dbt/dbt_project.yml
+++ b/src/data_platform/dbt/dbt_project.yml
@@ -1,7 +1,7 @@
 name: data_platform
 version: "0.1.0"
 config-version: 2
-require-dbt-version: [">=1.7.0", "<2.0.0"]
+require-dbt-version: ">=1.7"
 
 profile: data_platform
 

--- a/src/data_platform/ddl/migrations/0003_cycle_metadata.sql
+++ b/src/data_platform/ddl/migrations/0003_cycle_metadata.sql
@@ -31,5 +31,6 @@ CREATE TABLE IF NOT EXISTS data_platform.cycle_metadata (
     candidate_count INTEGER NOT NULL DEFAULT 0,
     selection_frozen_at TIMESTAMPTZ NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT cycle_metadata_candidate_count_nonnegative CHECK (candidate_count >= 0)
 );

--- a/src/data_platform/ddl/migrations/0003_cycle_metadata.sql
+++ b/src/data_platform/ddl/migrations/0003_cycle_metadata.sql
@@ -1,0 +1,35 @@
+CREATE SCHEMA IF NOT EXISTS data_platform;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_type
+        JOIN pg_namespace ON pg_namespace.oid = pg_type.typnamespace
+        WHERE pg_namespace.nspname = 'data_platform'
+          AND pg_type.typname = 'cycle_status'
+    ) THEN
+        CREATE TYPE data_platform.cycle_status AS ENUM (
+            'pending',
+            'phase0',
+            'phase1',
+            'phase2',
+            'phase3',
+            'published',
+            'failed'
+        );
+    END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS data_platform.cycle_metadata (
+    cycle_id TEXT PRIMARY KEY,
+    cycle_date DATE UNIQUE NOT NULL,
+    status data_platform.cycle_status NOT NULL DEFAULT 'pending',
+    cutoff_submitted_at TIMESTAMPTZ NULL,
+    cutoff_ingest_seq BIGINT NULL,
+    candidate_count INTEGER NOT NULL DEFAULT 0,
+    selection_frozen_at TIMESTAMPTZ NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/tests/cycle/test_cycle_metadata.py
+++ b/tests/cycle/test_cycle_metadata.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from dataclasses import fields, is_dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, cast, get_args
+from uuid import uuid4
+
+import pytest
+
+from data_platform.config import reset_settings_cache
+from data_platform.cycle import (
+    CYCLE_ID_PATTERN,
+    CYCLE_METADATA_TABLE,
+    CycleAlreadyExists,
+    CycleMetadata,
+    CycleNotFound,
+    CycleStatus,
+    InvalidCycleId,
+    InvalidCycleTransition,
+    create_cycle,
+    get_cycle,
+    transition_cycle_status,
+)
+
+EXPECTED_CYCLE_COLUMNS = [
+    "cycle_id",
+    "cycle_date",
+    "status",
+    "cutoff_submitted_at",
+    "cutoff_ingest_seq",
+    "candidate_count",
+    "selection_frozen_at",
+    "created_at",
+    "updated_at",
+]
+ORDERED_STATUSES: list[CycleStatus] = [
+    "phase0",
+    "phase1",
+    "phase2",
+    "phase3",
+    "published",
+]
+
+
+@pytest.fixture()
+def postgres_dsn() -> Generator[str]:
+    admin_dsn = os.environ.get("DATABASE_URL") or os.environ.get("DP_PG_DSN")
+    if not admin_dsn:
+        pytest.skip("PostgreSQL cycle metadata tests require DATABASE_URL or DP_PG_DSN")
+
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL cycle metadata tests require SQLAlchemy",
+    )
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL cycle metadata tests require the migration runner",
+    )
+    make_url = pytest.importorskip(
+        "sqlalchemy.engine",
+        reason="PostgreSQL cycle metadata tests require SQLAlchemy",
+    ).make_url
+    sqlalchemy_error = pytest.importorskip(
+        "sqlalchemy.exc",
+        reason="PostgreSQL cycle metadata tests require SQLAlchemy",
+    ).SQLAlchemyError
+
+    admin_engine = sqlalchemy.create_engine(
+        runner_module._sqlalchemy_postgres_uri(admin_dsn),
+        isolation_level="AUTOCOMMIT",
+    )
+    database_name = f"dp_cycle_metadata_test_{uuid4().hex}"
+    try:
+        with admin_engine.connect() as connection:
+            connection.execute(sqlalchemy.text(f'CREATE DATABASE "{database_name}"'))
+    except sqlalchemy_error as exc:
+        admin_engine.dispose()
+        pytest.skip(
+            "PostgreSQL cycle metadata tests require permission to create "
+            f"test databases: {exc}"
+        )
+
+    test_dsn = str(
+        make_url(runner_module._sqlalchemy_postgres_uri(admin_dsn)).set(database=database_name)
+    )
+    try:
+        yield test_dsn
+    finally:
+        with admin_engine.connect() as connection:
+            connection.execute(
+                sqlalchemy.text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )
+            connection.execute(sqlalchemy.text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+        admin_engine.dispose()
+
+
+@pytest.fixture()
+def migrated_cycle_dsn(
+    postgres_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Generator[str]:
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL cycle metadata tests require the migration runner",
+    )
+    monkeypatch.setenv("DP_PG_DSN", postgres_dsn)
+    monkeypatch.setenv("DP_RAW_ZONE_PATH", str(tmp_path / "raw"))
+    monkeypatch.setenv("DP_ICEBERG_WAREHOUSE_PATH", str(tmp_path / "iceberg" / "warehouse"))
+    monkeypatch.setenv("DP_DUCKDB_PATH", str(tmp_path / "duckdb" / "data_platform.duckdb"))
+    reset_settings_cache()
+
+    applied_versions = runner_module.MigrationRunner().apply_pending(postgres_dsn)
+    assert applied_versions == ["0001", "0002", "0003"]
+    assert runner_module.MigrationRunner().apply_pending(postgres_dsn) == []
+    try:
+        yield postgres_dsn
+    finally:
+        reset_settings_cache()
+
+
+def test_cycle_metadata_model_exposes_contract_types_and_constants() -> None:
+    assert CYCLE_METADATA_TABLE == "data_platform.cycle_metadata"
+    assert CYCLE_ID_PATTERN.fullmatch("CYCLE_20260416") is not None
+    assert CYCLE_ID_PATTERN.fullmatch("20260416") is None
+    assert get_args(CycleStatus) == (
+        "pending",
+        "phase0",
+        "phase1",
+        "phase2",
+        "phase3",
+        "published",
+        "failed",
+    )
+
+    assert is_dataclass(CycleMetadata)
+    assert [field.name for field in fields(CycleMetadata)] == EXPECTED_CYCLE_COLUMNS
+    assert CycleMetadata.__slots__ == tuple(EXPECTED_CYCLE_COLUMNS)
+
+    now = datetime.now(UTC)
+    cycle = CycleMetadata(
+        cycle_id="CYCLE_20260416",
+        cycle_date=date(2026, 4, 16),
+        status="pending",
+        cutoff_submitted_at=None,
+        cutoff_ingest_seq=None,
+        candidate_count=0,
+        selection_frozen_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    assert cycle.cycle_id == "CYCLE_20260416"
+    assert cycle.status == "pending"
+
+
+@pytest.mark.parametrize(
+    "cycle_id",
+    ["", "20260416", "CYCLE_2026-04-16", "CYCLE_2026041", "CYCLE_202604160"],
+)
+def test_repository_rejects_invalid_cycle_id_before_db_access(cycle_id: str) -> None:
+    with pytest.raises(InvalidCycleId, match="CYCLE_YYYYMMDD"):
+        get_cycle(cycle_id)
+
+    with pytest.raises(InvalidCycleId, match="CYCLE_YYYYMMDD"):
+        transition_cycle_status(cycle_id, "phase0")
+
+
+def test_repository_rejects_invalid_target_status_before_db_access() -> None:
+    with pytest.raises(InvalidCycleTransition, match="cycle status must be one of"):
+        transition_cycle_status("CYCLE_20260416", cast(CycleStatus, "done"))
+
+
+def test_migration_creates_cycle_metadata_schema(migrated_cycle_dsn: str) -> None:
+    engine = _create_engine(migrated_cycle_dsn)
+    try:
+        with engine.connect() as connection:
+            assert (
+                connection.execute(
+                    _text("SELECT to_regclass('data_platform.cycle_metadata')")
+                ).scalar_one()
+                == "data_platform.cycle_metadata"
+            )
+            assert _enum_labels(connection, "cycle_status") == [
+                "pending",
+                "phase0",
+                "phase1",
+                "phase2",
+                "phase3",
+                "published",
+                "failed",
+            ]
+
+            table_columns = connection.execute(
+                _text(
+                    """
+                    SELECT column_name, data_type, udt_schema, udt_name, is_nullable,
+                           column_default
+                    FROM information_schema.columns
+                    WHERE table_schema = 'data_platform'
+                      AND table_name = 'cycle_metadata'
+                    ORDER BY ordinal_position
+                    """
+                )
+            ).mappings()
+            columns = {str(row["column_name"]): row for row in table_columns}
+            assert list(columns) == EXPECTED_CYCLE_COLUMNS
+            assert columns["cycle_id"]["data_type"] == "text"
+            assert columns["cycle_date"]["data_type"] == "date"
+            assert columns["status"]["udt_name"] == "cycle_status"
+            assert columns["status"]["column_default"] == (
+                "'pending'::data_platform.cycle_status"
+            )
+            assert columns["cutoff_submitted_at"]["data_type"] == "timestamp with time zone"
+            assert columns["cutoff_ingest_seq"]["data_type"] == "bigint"
+            assert columns["candidate_count"]["data_type"] == "integer"
+            assert columns["candidate_count"]["column_default"] == "0"
+            assert columns["selection_frozen_at"]["data_type"] == "timestamp with time zone"
+            assert columns["created_at"]["column_default"] == "now()"
+            assert columns["updated_at"]["column_default"] == "now()"
+            for column_name in EXPECTED_CYCLE_COLUMNS:
+                expected_nullable = (
+                    "YES"
+                    if column_name
+                    in {"cutoff_submitted_at", "cutoff_ingest_seq", "selection_frozen_at"}
+                    else "NO"
+                )
+                assert columns[column_name]["is_nullable"] == expected_nullable
+
+            assert {
+                str(row[0])
+                for row in connection.execute(
+                    _text(
+                        """
+                        SELECT constraint_name
+                        FROM information_schema.table_constraints
+                        WHERE table_schema = 'data_platform'
+                          AND table_name = 'cycle_metadata'
+                        """
+                    )
+                )
+            } >= {"cycle_metadata_pkey", "cycle_metadata_cycle_date_key"}
+    finally:
+        engine.dispose()
+
+
+def test_create_cycle_returns_pending_metadata(migrated_cycle_dsn: str) -> None:
+    cycle = create_cycle(date(2026, 4, 16))
+
+    assert cycle.cycle_id == "CYCLE_20260416"
+    assert cycle.cycle_date == date(2026, 4, 16)
+    assert cycle.status == "pending"
+    assert cycle.cutoff_submitted_at is None
+    assert cycle.cutoff_ingest_seq is None
+    assert cycle.candidate_count == 0
+    assert cycle.selection_frozen_at is None
+    assert cycle.created_at is not None
+    assert cycle.updated_at is not None
+    assert get_cycle("CYCLE_20260416") == cycle
+
+
+def test_create_cycle_rejects_duplicate_cycle_date(migrated_cycle_dsn: str) -> None:
+    create_cycle(date(2026, 4, 16))
+
+    with pytest.raises(CycleAlreadyExists, match="2026-04-16"):
+        create_cycle(date(2026, 4, 16))
+
+    assert _fetch_scalar(
+        migrated_cycle_dsn,
+        "SELECT count(*) FROM data_platform.cycle_metadata",
+    ) == 1
+
+
+def test_get_cycle_raises_for_missing_cycle(migrated_cycle_dsn: str) -> None:
+    with pytest.raises(CycleNotFound, match="CYCLE_20990101"):
+        get_cycle("CYCLE_20990101")
+
+
+def test_transition_cycle_status_allows_ordered_path(migrated_cycle_dsn: str) -> None:
+    cycle = create_cycle(date(2026, 4, 16))
+
+    for status in ORDERED_STATUSES:
+        cycle = transition_cycle_status(cycle.cycle_id, status)
+        assert cycle.status == status
+
+    assert get_cycle("CYCLE_20260416").status == "published"
+
+
+def test_transition_cycle_status_rejects_direct_publish(migrated_cycle_dsn: str) -> None:
+    create_cycle(date(2026, 4, 16))
+
+    with pytest.raises(InvalidCycleTransition, match="from 'pending' to 'published'"):
+        transition_cycle_status("CYCLE_20260416", "published")
+
+    assert get_cycle("CYCLE_20260416").status == "pending"
+
+
+def test_transition_cycle_status_allows_failed_from_nonterminal_states(
+    migrated_cycle_dsn: str,
+) -> None:
+    source_paths: list[list[CycleStatus]] = [
+        [],
+        ["phase0"],
+        ["phase0", "phase1"],
+        ["phase0", "phase1", "phase2"],
+        ["phase0", "phase1", "phase2", "phase3"],
+    ]
+
+    for index, source_path in enumerate(source_paths, start=16):
+        cycle = create_cycle(date(2026, 4, index))
+        for status in source_path:
+            cycle = transition_cycle_status(cycle.cycle_id, status)
+
+        failed_cycle = transition_cycle_status(cycle.cycle_id, "failed")
+
+        assert failed_cycle.status == "failed"
+        with pytest.raises(InvalidCycleTransition):
+            transition_cycle_status(cycle.cycle_id, "phase0")
+
+
+def test_transition_cycle_status_rejects_changes_after_published(
+    migrated_cycle_dsn: str,
+) -> None:
+    cycle = create_cycle(date(2026, 4, 16))
+    for status in ORDERED_STATUSES:
+        cycle = transition_cycle_status(cycle.cycle_id, status)
+
+    with pytest.raises(InvalidCycleTransition, match="from 'published' to 'failed'"):
+        transition_cycle_status(cycle.cycle_id, "failed")
+
+
+def test_transition_cycle_status_raises_for_missing_cycle(migrated_cycle_dsn: str) -> None:
+    with pytest.raises(CycleNotFound, match="CYCLE_20990101"):
+        transition_cycle_status("CYCLE_20990101", "phase0")
+
+
+def _create_engine(dsn: str, **kwargs: object) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL cycle metadata tests require SQLAlchemy",
+    )
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL cycle metadata tests require the migration runner",
+    )
+    return sqlalchemy.create_engine(runner_module._sqlalchemy_postgres_uri(dsn), **kwargs)
+
+
+def _text(sql: str) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL cycle metadata tests require SQLAlchemy",
+    )
+    return sqlalchemy.text(sql)
+
+
+def _enum_labels(connection: Any, type_name: str) -> list[str]:
+    rows = connection.execute(
+        _text(
+            """
+            SELECT pg_enum.enumlabel
+            FROM pg_enum
+            JOIN pg_type ON pg_type.oid = pg_enum.enumtypid
+            JOIN pg_namespace ON pg_namespace.oid = pg_type.typnamespace
+            WHERE pg_namespace.nspname = 'data_platform'
+              AND pg_type.typname = :type_name
+            ORDER BY pg_enum.enumsortorder
+            """
+        ),
+        {"type_name": type_name},
+    ).scalars()
+    return [str(row) for row in rows]
+
+
+def _fetch_scalar(dsn: str, sql: str) -> object:
+    engine = _create_engine(dsn)
+    try:
+        with engine.connect() as connection:
+            return connection.execute(_text(sql)).scalar_one()
+    finally:
+        engine.dispose()

--- a/tests/cycle/test_cycle_metadata.py
+++ b/tests/cycle/test_cycle_metadata.py
@@ -249,7 +249,58 @@ def test_migration_creates_cycle_metadata_schema(migrated_cycle_dsn: str) -> Non
                         """
                     )
                 )
-            } >= {"cycle_metadata_pkey", "cycle_metadata_cycle_date_key"}
+            } >= {
+                "cycle_metadata_pkey",
+                "cycle_metadata_cycle_date_key",
+                "cycle_metadata_candidate_count_nonnegative",
+            }
+    finally:
+        engine.dispose()
+
+
+def test_cycle_metadata_rejects_negative_candidate_count(migrated_cycle_dsn: str) -> None:
+    sqlalchemy_exc = pytest.importorskip(
+        "sqlalchemy.exc",
+        reason="PostgreSQL cycle metadata tests require SQLAlchemy",
+    ).IntegrityError
+    engine = _create_engine(migrated_cycle_dsn)
+    try:
+        with pytest.raises(sqlalchemy_exc):
+            with engine.begin() as connection:
+                connection.execute(
+                    _text(
+                        """
+                        INSERT INTO data_platform.cycle_metadata (
+                            cycle_id,
+                            cycle_date,
+                            candidate_count
+                        )
+                        VALUES ('CYCLE_20260416', DATE '2026-04-16', -1)
+                        """
+                    )
+                )
+
+        with engine.begin() as connection:
+            connection.execute(
+                _text(
+                    """
+                    INSERT INTO data_platform.cycle_metadata (cycle_id, cycle_date)
+                    VALUES ('CYCLE_20260416', DATE '2026-04-16')
+                    """
+                )
+            )
+
+        with pytest.raises(sqlalchemy_exc):
+            with engine.begin() as connection:
+                connection.execute(
+                    _text(
+                        """
+                        UPDATE data_platform.cycle_metadata
+                        SET candidate_count = -1
+                        WHERE cycle_id = 'CYCLE_20260416'
+                        """
+                    )
+                )
     finally:
         engine.dispose()
 

--- a/tests/ddl/test_runner.py
+++ b/tests/ddl/test_runner.py
@@ -115,9 +115,9 @@ def test_create_engine_rewrites_plain_postgres_dsn_to_psycopg(
 def test_apply_pending_is_idempotent_and_creates_schema(postgres_dsn: str) -> None:
     runner = MigrationRunner()
 
-    assert runner.apply_pending(postgres_dsn) == ["0001", "0002"]
+    assert runner.apply_pending(postgres_dsn) == ["0001", "0002", "0003"]
     assert runner.apply_pending(postgres_dsn) == []
-    assert fetch_versions(postgres_dsn) == ["0001", "0002"]
+    assert fetch_versions(postgres_dsn) == ["0001", "0002", "0003"]
     assert fetch_scalar(postgres_dsn, "SELECT to_regclass('public.dp_schema_migrations')")
     assert (
         fetch_scalar(

--- a/tests/queue/test_candidate_queue_schema.py
+++ b/tests/queue/test_candidate_queue_schema.py
@@ -104,7 +104,7 @@ def migrated_postgres_dsn(postgres_dsn: str) -> str:
         reason="PostgreSQL candidate queue schema tests require the migration runner",
     )
     applied_versions = runner_module.MigrationRunner().apply_pending(postgres_dsn)
-    assert applied_versions == ["0001", "0002"]
+    assert applied_versions == ["0001", "0002", "0003"]
     assert runner_module.MigrationRunner().apply_pending(postgres_dsn) == []
     return postgres_dsn
 


### PR DESCRIPTION
Closes #31

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/daily_refresh.py`


---
### 1. 背景与目标
项目文档 §9.3 和 §11.1 要求 `CycleMetadata` 记录每个日频 cycle 的状态、cutoff 和冻结时间。现有代码有通用 migration runner，但 `src/data_platform/cycle/` 尚无表、dataclass 或状态迁移 API。本 issue 先建立 cycle 元数据表和创建/状态迁移辅助，为 #32 的冻结事务和 #33 的 manifest 发布提供稳定控制面。

### 2. 所属模块
`src/data_platform/cycle/` + `src/data_platform/ddl/migrations/`

### 3. 实现范围
- 新增 `src/data_platform/ddl/migrations/0003_cycle_metadata.sql`，创建 `data_platform.cycle_status` enum 和 `data_platform.cycle_metadata` 表。
- `cycle_metadata` 字段包含 `cycle_id TEXT PRIMARY KEY`、`cycle_date DATE UNIQUE NOT NULL`、`status`、`cutoff_submitted_at TIMESTAMPTZ NULL`、`cutoff_ingest_seq BIGINT NULL`、`candidate_count INTEGER NOT NULL DEFAULT 0`、`selection_frozen_at TIMESTAMPTZ NULL`、`created_at TIMESTAMPTZ DEFAULT now()`、`updated_at TIMESTAMPTZ DEFAULT now()`。
- 新增 `src/data_platform/cycle/models.py`，定义 `CycleMetadata`、`CycleStatus`、`CYCLE_ID_PATTERN`。
- 新增 `src/data_platform/cycle/repository.py`，实现 cycle 创建、读取、状态迁移，并在 `src/data_platform/cycle/__init__.py` re-export。
- 状态迁移只允许 `pending -> phase0 -> phase1 -> phase2 -> phase3 -> published`，`failed` 可从任一非终态进入；非法迁移抛 `InvalidCycleTransition`。
- 新增 `tests/cycle/test_cycle_metadata.py`，覆盖 ID 格式、唯一性、状态迁移和非法状态。

### 4. 不在本次范围
- 不读取或冻结候选队列，留给 #32。
- 不写 `cycle_candidate_selection` 或 `cycle_publish_manifest`。
- 不实现交易日历、节假日判断或调度策略。
- 不在 data-platform 内定义 Dagster schedule/job。

### 5. 关键交付物
- `CycleStatus = Literal['pending', 'phase0', 'phase1', 'phase2', 'phase3', 'published', 'failed']`。
- `@dataclass(frozen=True, slots=True) class CycleMetadata`，字段与表结构一致。
- `def create_cycle(cycle_date: date) -> CycleMetadata`，生成 `cycle_id = f'CYCLE_{cycle_date:%Y%m%d}'`。
- `def get_cycle(cycle_id: str) -> CycleMetadata`。
- `def transition_cycle_status(cycle_id: str, status: CycleStatus) -> CycleMetadata`。
- 错误类型：`CycleAlreadyExists`、`CycleNotFound`、`InvalidCycleId`、`InvalidCycleTransition`。

### 6. 验收标准
- [ ] `create_cycle(date(2026, 4, 16))` 返回 `cycle_id == 'CYCLE_20260416'` 且初始 `status == 'pending'`。
- [ ] 同一 `cycle_date` 重