### PR TITLE
feat(#29): submit_candidate Python 接口与 payload 校验

### DIFF
--- a/src/data_platform/dbt/dbt_project.yml
+++ b/src/data_platform/dbt/dbt_project.yml
@@ -1,7 +1,7 @@
 name: data_platform
 version: "0.1.0"
 config-version: 2
-require-dbt-version: [">=1.7.0", "<2.0.0"]
+require-dbt-version: ">=1.7"
 
 profile: data_platform
 

--- a/src/data_platform/queue/__init__.py
+++ b/src/data_platform/queue/__init__.py
@@ -1,5 +1,6 @@
-"""PostgreSQL-backed Lite candidate queue types."""
+"""PostgreSQL-backed Lite candidate queue APIs and types."""
 
+from data_platform.queue.api import ExPayload, submit_candidate
 from data_platform.queue.models import (
     CANDIDATE_QUEUE_TABLE,
     INGEST_METADATA_VIEW,
@@ -8,12 +9,29 @@ from data_platform.queue.models import (
     IngestMetadataRecord,
     ValidationStatus,
 )
+from data_platform.queue.repository import CandidateQueueWriteError, CandidateRepository
+from data_platform.queue.validation import (
+    FORBIDDEN_PRODUCER_FIELDS,
+    CandidateEnvelope,
+    CandidateValidationError,
+    ForbiddenIngestMetadataError,
+    validate_candidate_envelope,
+)
 
 __all__ = [
     "CANDIDATE_QUEUE_TABLE",
+    "FORBIDDEN_PRODUCER_FIELDS",
     "INGEST_METADATA_VIEW",
+    "CandidateEnvelope",
     "CandidatePayloadType",
     "CandidateQueueItem",
+    "CandidateQueueWriteError",
+    "CandidateRepository",
+    "CandidateValidationError",
+    "ExPayload",
+    "ForbiddenIngestMetadataError",
     "IngestMetadataRecord",
     "ValidationStatus",
+    "submit_candidate",
+    "validate_candidate_envelope",
 ]

--- a/src/data_platform/queue/api.py
+++ b/src/data_platform/queue/api.py
@@ -1,0 +1,21 @@
+"""Public Python API for Lite candidate queue writes."""
+
+from __future__ import annotations
+
+from data_platform.queue.models import CandidateQueueItem
+from data_platform.queue.repository import CandidateRepository
+from data_platform.queue.validation import ExPayload, validate_candidate_envelope
+
+
+def submit_candidate(payload: ExPayload) -> CandidateQueueItem:
+    """Validate and insert one producer Ex payload into candidate_queue."""
+
+    envelope = validate_candidate_envelope(payload)
+    repository = CandidateRepository()
+    try:
+        return repository.insert_candidate(envelope)
+    finally:
+        repository.close()
+
+
+__all__ = ["ExPayload", "submit_candidate"]

--- a/src/data_platform/queue/repository.py
+++ b/src/data_platform/queue/repository.py
@@ -106,16 +106,22 @@ def _resolve_dsn() -> str:
         get_settings = getattr(config_module, "get_settings")
         return str(get_settings().pg_dsn)
     except ModuleNotFoundError as exc:
-        raise CandidateQueueWriteError("DP_PG_DSN is required for candidate queue writes", exc)
+        raise CandidateQueueWriteError(
+            "DP_PG_DSN is required for candidate queue writes", exc
+        ) from exc
     except Exception as exc:
-        raise CandidateQueueWriteError("DP_PG_DSN is required for candidate queue writes", exc)
+        raise CandidateQueueWriteError(
+            "DP_PG_DSN is required for candidate queue writes", exc
+        ) from exc
 
 
 def _create_engine(dsn: str) -> Any:
     try:
         sqlalchemy = import_module("sqlalchemy")
     except ModuleNotFoundError as exc:
-        raise CandidateQueueWriteError("candidate queue writes require SQLAlchemy", exc)
+        raise CandidateQueueWriteError(
+            "candidate queue writes require SQLAlchemy", exc
+        ) from exc
 
     create_engine = getattr(sqlalchemy, "create_engine")
     return create_engine(_sqlalchemy_postgres_uri(dsn))
@@ -125,7 +131,9 @@ def _sqlalchemy_text() -> Any:
     try:
         sqlalchemy = import_module("sqlalchemy")
     except ModuleNotFoundError as exc:
-        raise CandidateQueueWriteError("candidate queue writes require SQLAlchemy", exc)
+        raise CandidateQueueWriteError(
+            "candidate queue writes require SQLAlchemy", exc
+        ) from exc
 
     return getattr(sqlalchemy, "text")
 

--- a/src/data_platform/queue/repository.py
+++ b/src/data_platform/queue/repository.py
@@ -1,0 +1,189 @@
+"""PostgreSQL repository for Lite candidate queue writes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from importlib import import_module
+import json
+import os
+from typing import Any, Final, cast
+
+from data_platform.queue.models import (
+    CANDIDATE_QUEUE_TABLE,
+    CandidatePayloadType,
+    CandidateQueueItem,
+    ValidationStatus,
+)
+from data_platform.queue.validation import CandidateEnvelope
+
+_RETURNING_COLUMNS: Final[tuple[str, ...]] = (
+    "id",
+    "payload_type",
+    "payload",
+    "submitted_by",
+    "submitted_at",
+    "ingest_seq",
+    "validation_status",
+    "rejection_reason",
+)
+_INSERT_CANDIDATE_SQL: Final[str] = f"""
+INSERT INTO {CANDIDATE_QUEUE_TABLE} (
+    payload_type,
+    payload,
+    submitted_by
+)
+VALUES (
+    :payload_type,
+    CAST(:payload AS jsonb),
+    :submitted_by
+)
+RETURNING {", ".join(_RETURNING_COLUMNS)}
+"""
+
+
+class CandidateQueueWriteError(RuntimeError):
+    """Raised when candidate_queue insertion or returned-row mapping fails."""
+
+    def __init__(self, message: str, cause: BaseException | None = None) -> None:
+        self.cause = cause
+        detail = f": {cause}" if cause is not None else ""
+        super().__init__(f"{message}{detail}")
+
+
+class CandidateRepository:
+    """Repository for synchronous candidate_queue inserts."""
+
+    def __init__(self, dsn: str | None = None, *, engine: Any | None = None) -> None:
+        if dsn is not None and engine is not None:
+            msg = "provide either dsn or engine, not both"
+            raise ValueError(msg)
+
+        self._owns_engine = engine is None
+        self._engine = engine if engine is not None else _create_engine(dsn or _resolve_dsn())
+
+    def insert_candidate(self, envelope: CandidateEnvelope) -> CandidateQueueItem:
+        """Insert one validated candidate envelope and return the PostgreSQL row."""
+
+        try:
+            text = _sqlalchemy_text()
+            payload = json.dumps(dict(envelope.payload), allow_nan=False)
+            with self._engine.begin() as connection:
+                row = (
+                    connection.execute(
+                        text(_INSERT_CANDIDATE_SQL),
+                        {
+                            "payload_type": envelope.payload_type,
+                            "payload": payload,
+                            "submitted_by": envelope.submitted_by,
+                        },
+                    )
+                    .mappings()
+                    .one()
+                )
+        except CandidateQueueWriteError:
+            raise
+        except Exception as exc:
+            if _is_sqlalchemy_error(exc):
+                raise CandidateQueueWriteError("candidate queue insert failed", exc) from exc
+            raise
+
+        return _row_to_candidate_queue_item(row)
+
+    def close(self) -> None:
+        """Dispose an owned SQLAlchemy engine."""
+
+        if self._owns_engine:
+            self._engine.dispose()
+
+
+def _resolve_dsn() -> str:
+    dsn = os.environ.get("DP_PG_DSN")
+    if dsn:
+        return dsn
+
+    try:
+        config_module = import_module("data_platform.config")
+        get_settings = getattr(config_module, "get_settings")
+        return str(get_settings().pg_dsn)
+    except ModuleNotFoundError as exc:
+        raise CandidateQueueWriteError("DP_PG_DSN is required for candidate queue writes", exc)
+    except Exception as exc:
+        raise CandidateQueueWriteError("DP_PG_DSN is required for candidate queue writes", exc)
+
+
+def _create_engine(dsn: str) -> Any:
+    try:
+        sqlalchemy = import_module("sqlalchemy")
+    except ModuleNotFoundError as exc:
+        raise CandidateQueueWriteError("candidate queue writes require SQLAlchemy", exc)
+
+    create_engine = getattr(sqlalchemy, "create_engine")
+    return create_engine(_sqlalchemy_postgres_uri(dsn))
+
+
+def _sqlalchemy_text() -> Any:
+    try:
+        sqlalchemy = import_module("sqlalchemy")
+    except ModuleNotFoundError as exc:
+        raise CandidateQueueWriteError("candidate queue writes require SQLAlchemy", exc)
+
+    return getattr(sqlalchemy, "text")
+
+
+def _is_sqlalchemy_error(exc: BaseException) -> bool:
+    try:
+        sqlalchemy_exc = import_module("sqlalchemy.exc")
+    except ModuleNotFoundError:
+        return False
+
+    SQLAlchemyError = getattr(sqlalchemy_exc, "SQLAlchemyError")
+    return isinstance(exc, SQLAlchemyError)
+
+
+def _sqlalchemy_postgres_uri(dsn: str) -> str:
+    if dsn.startswith("postgresql://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgresql://")
+    if dsn.startswith("postgres://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgres://")
+    return dsn
+
+
+def _row_to_candidate_queue_item(row: Mapping[str, Any]) -> CandidateQueueItem:
+    try:
+        payload = _coerce_payload(row["payload"])
+        return CandidateQueueItem(
+            id=int(row["id"]),
+            payload_type=cast(CandidatePayloadType, row["payload_type"]),
+            payload=payload,
+            submitted_by=str(row["submitted_by"]),
+            submitted_at=row["submitted_at"],
+            ingest_seq=int(row["ingest_seq"]),
+            validation_status=cast(ValidationStatus, row["validation_status"]),
+            rejection_reason=(
+                None if row["rejection_reason"] is None else str(row["rejection_reason"])
+            ),
+        )
+    except KeyError as exc:
+        raise CandidateQueueWriteError(
+            f"candidate queue returning row missing field {exc.args[0]!r}", exc
+        ) from exc
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise CandidateQueueWriteError("candidate queue returning row is invalid", exc) from exc
+
+
+def _coerce_payload(payload: object) -> Mapping[str, Any]:
+    if isinstance(payload, Mapping):
+        return cast(Mapping[str, Any], payload)
+    if isinstance(payload, str):
+        decoded = json.loads(payload)
+        if isinstance(decoded, Mapping):
+            return cast(Mapping[str, Any], decoded)
+
+    msg = "candidate queue returning payload must be a JSON object mapping"
+    raise TypeError(msg)
+
+
+__all__ = [
+    "CandidateQueueWriteError",
+    "CandidateRepository",
+]

--- a/src/data_platform/queue/validation.py
+++ b/src/data_platform/queue/validation.py
@@ -1,0 +1,126 @@
+"""Producer-envelope validation for Lite candidate queue writes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import json
+from types import MappingProxyType
+from typing import Any, Final, TypeAlias, cast, get_args
+
+from data_platform.queue.models import CandidatePayloadType
+
+ExPayload: TypeAlias = Mapping[str, Any]
+FORBIDDEN_PRODUCER_FIELDS: Final[frozenset[str]] = frozenset(
+    {"submitted_at", "ingest_seq"}
+)
+_CANDIDATE_PAYLOAD_TYPES: Final[frozenset[str]] = frozenset(
+    cast(tuple[str, ...], get_args(CandidatePayloadType))
+)
+
+
+class CandidateValidationError(ValueError):
+    """Raised when a producer candidate envelope is invalid."""
+
+
+class ForbiddenIngestMetadataError(CandidateValidationError):
+    """Raised when a producer attempts to supply Layer B ingest metadata."""
+
+    def __init__(self, forbidden_fields: list[str]) -> None:
+        self.forbidden_fields = forbidden_fields
+        super().__init__(
+            "producer payload must not include PostgreSQL ingest metadata fields: "
+            f"{forbidden_fields}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateEnvelope:
+    """Validated producer envelope ready for candidate_queue insertion."""
+
+    payload_type: CandidatePayloadType
+    submitted_by: str
+    payload: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        _validate_payload_type(self.payload_type)
+        _validate_submitted_by(self.submitted_by)
+        payload = _copy_valid_payload(self.payload)
+        object.__setattr__(self, "payload", MappingProxyType(payload))
+
+
+def validate_candidate_envelope(payload: Mapping[str, Any]) -> CandidateEnvelope:
+    """Validate and normalize one producer Ex payload envelope."""
+
+    if not isinstance(payload, Mapping):
+        msg = "candidate payload must be a JSON object mapping"
+        raise CandidateValidationError(msg)
+
+    _reject_forbidden_ingest_metadata(payload)
+
+    payload_type = payload.get("payload_type")
+    submitted_by = payload.get("submitted_by")
+
+    _validate_payload_type(payload_type)
+    _validate_submitted_by(submitted_by)
+
+    return CandidateEnvelope(
+        payload_type=cast(CandidatePayloadType, payload_type),
+        submitted_by=cast(str, submitted_by),
+        payload=payload,
+    )
+
+
+def _validate_payload_type(value: object) -> None:
+    if value not in _CANDIDATE_PAYLOAD_TYPES:
+        msg = f"payload_type must be one of {sorted(_CANDIDATE_PAYLOAD_TYPES)}"
+        raise CandidateValidationError(msg)
+
+
+def _validate_submitted_by(value: object) -> None:
+    if not isinstance(value, str) or not value.strip():
+        msg = "submitted_by is required and must be a non-empty string"
+        raise CandidateValidationError(msg)
+
+
+def _copy_valid_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        msg = "candidate payload must be a JSON object mapping"
+        raise CandidateValidationError(msg)
+
+    payload_copy = dict(payload)
+    _reject_forbidden_ingest_metadata(payload_copy)
+    _validate_string_keys(payload_copy)
+    _validate_json_serializable(payload_copy)
+    return payload_copy
+
+
+def _reject_forbidden_ingest_metadata(payload: Mapping[str, Any]) -> None:
+    forbidden_fields = sorted(FORBIDDEN_PRODUCER_FIELDS.intersection(payload))
+    if forbidden_fields:
+        raise ForbiddenIngestMetadataError(forbidden_fields)
+
+
+def _validate_string_keys(payload: Mapping[Any, Any]) -> None:
+    non_string_keys = [key for key in payload if not isinstance(key, str)]
+    if non_string_keys:
+        msg = "candidate payload JSON object keys must be strings"
+        raise CandidateValidationError(msg)
+
+
+def _validate_json_serializable(payload: Mapping[str, Any]) -> None:
+    try:
+        json.dumps(payload, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        msg = f"candidate payload must be JSON serializable: {exc}"
+        raise CandidateValidationError(msg) from exc
+
+
+__all__ = [
+    "FORBIDDEN_PRODUCER_FIELDS",
+    "CandidateEnvelope",
+    "CandidateValidationError",
+    "ExPayload",
+    "ForbiddenIngestMetadataError",
+    "validate_candidate_envelope",
+]

--- a/src/data_platform/queue/validation.py
+++ b/src/data_platform/queue/validation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import json
 from types import MappingProxyType
@@ -72,7 +72,7 @@ def validate_candidate_envelope(payload: Mapping[str, Any]) -> CandidateEnvelope
 
 
 def _validate_payload_type(value: object) -> None:
-    if value not in _CANDIDATE_PAYLOAD_TYPES:
+    if not isinstance(value, str) or value not in _CANDIDATE_PAYLOAD_TYPES:
         msg = f"payload_type must be one of {sorted(_CANDIDATE_PAYLOAD_TYPES)}"
         raise CandidateValidationError(msg)
 
@@ -101,11 +101,19 @@ def _reject_forbidden_ingest_metadata(payload: Mapping[str, Any]) -> None:
         raise ForbiddenIngestMetadataError(forbidden_fields)
 
 
-def _validate_string_keys(payload: Mapping[Any, Any]) -> None:
-    non_string_keys = [key for key in payload if not isinstance(key, str)]
-    if non_string_keys:
-        msg = "candidate payload JSON object keys must be strings"
-        raise CandidateValidationError(msg)
+def _validate_string_keys(value: object) -> None:
+    if isinstance(value, Mapping):
+        non_string_keys = [key for key in value if not isinstance(key, str)]
+        if non_string_keys:
+            msg = "candidate payload JSON object keys must be strings"
+            raise CandidateValidationError(msg)
+        for nested_value in value.values():
+            _validate_string_keys(nested_value)
+        return
+
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        for nested_value in value:
+            _validate_string_keys(nested_value)
 
 
 def _validate_json_serializable(payload: Mapping[str, Any]) -> None:

--- a/tests/queue/test_submit_candidate.py
+++ b/tests/queue/test_submit_candidate.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from data_platform.queue import (
+    CandidateEnvelope,
+    CandidateQueueItem,
+    CandidateValidationError,
+    ForbiddenIngestMetadataError,
+    submit_candidate,
+    validate_candidate_envelope,
+)
+from data_platform.queue import api as queue_api
+from data_platform.queue.repository import (
+    CandidateRepository,
+    _sqlalchemy_postgres_uri,
+)
+
+
+def test_submit_candidate_validates_and_writes_with_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_envelopes: list[CandidateEnvelope] = []
+    closed = False
+
+    class FakeRepository:
+        def insert_candidate(self, envelope: CandidateEnvelope) -> CandidateQueueItem:
+            seen_envelopes.append(envelope)
+            return CandidateQueueItem(
+                id=10,
+                payload_type=envelope.payload_type,
+                payload=envelope.payload,
+                submitted_by=envelope.submitted_by,
+                submitted_at=datetime.now(UTC),
+                ingest_seq=99,
+                validation_status="pending",
+                rejection_reason=None,
+            )
+
+        def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    monkeypatch.setattr(queue_api, "CandidateRepository", FakeRepository)
+
+    payload = {
+        "payload_type": "Ex-1",
+        "submitted_by": "test-subsystem",
+        "candidate": {"id": "alpha"},
+    }
+    item = submit_candidate(payload)
+
+    assert item.id == 10
+    assert item.ingest_seq == 99
+    assert item.submitted_at is not None
+    assert item.validation_status == "pending"
+    assert item.rejection_reason is None
+    assert dict(item.payload) == payload
+    assert seen_envelopes == [
+        CandidateEnvelope(
+            payload_type="Ex-1",
+            submitted_by="test-subsystem",
+            payload=payload,
+        )
+    ]
+    assert closed is True
+
+
+def test_validate_candidate_envelope_returns_immutable_payload_copy() -> None:
+    payload = {
+        "payload_type": "Ex-2",
+        "submitted_by": "test-subsystem",
+        "candidate": "alpha",
+    }
+
+    envelope = validate_candidate_envelope(payload)
+    payload["candidate"] = "mutated"
+
+    assert envelope.payload_type == "Ex-2"
+    assert envelope.submitted_by == "test-subsystem"
+    assert dict(envelope.payload) == {
+        "payload_type": "Ex-2",
+        "submitted_by": "test-subsystem",
+        "candidate": "alpha",
+    }
+    with pytest.raises(TypeError):
+        envelope.payload["ingest_seq"] = 1  # type: ignore[index]
+    with pytest.raises(FrozenInstanceError):
+        envelope.submitted_by = "other-subsystem"
+
+
+def test_submit_candidate_rejects_invalid_payload_type() -> None:
+    with pytest.raises(CandidateValidationError, match="payload_type must be one of"):
+        submit_candidate(
+            {
+                "payload_type": "Ex-4",
+                "submitted_by": "test-subsystem",
+                "candidate": "alpha",
+            }
+        )
+
+
+def test_submit_candidate_rejects_missing_submitted_by() -> None:
+    with pytest.raises(CandidateValidationError, match="submitted_by is required"):
+        submit_candidate({"payload_type": "Ex-1", "candidate": "alpha"})
+
+
+def test_submit_candidate_rejects_ingest_metadata_before_other_fields() -> None:
+    with pytest.raises(ForbiddenIngestMetadataError, match="must not include"):
+        submit_candidate({"payload_type": "Ex-1", "ingest_seq": 123})
+
+
+@pytest.mark.parametrize("forbidden_key", ["submitted_at", "ingest_seq"])
+def test_submit_candidate_rejects_top_level_ingest_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    forbidden_key: str,
+) -> None:
+    class UnexpectedRepository:
+        def __init__(self) -> None:
+            raise AssertionError("repository must not be created for invalid payloads")
+
+    monkeypatch.setattr(queue_api, "CandidateRepository", UnexpectedRepository)
+
+    with pytest.raises(ForbiddenIngestMetadataError, match="must not include"):
+        submit_candidate(
+            {
+                "payload_type": "Ex-1",
+                "submitted_by": "test-subsystem",
+                forbidden_key: "not producer-owned",
+            }
+        )
+
+
+def test_submit_candidate_rejects_non_json_payload() -> None:
+    with pytest.raises(CandidateValidationError, match="JSON serializable"):
+        submit_candidate(
+            {
+                "payload_type": "Ex-1",
+                "submitted_by": "test-subsystem",
+                "as_of": datetime.now(UTC),
+            }
+        )
+
+
+def test_repository_rewrites_plain_postgres_dsn_to_psycopg() -> None:
+    assert _sqlalchemy_postgres_uri("postgresql://dp:dp@localhost/db") == (
+        "postgresql+psycopg://dp:dp@localhost/db"
+    )
+    assert _sqlalchemy_postgres_uri("postgres://dp:dp@localhost/db") == (
+        "postgresql+psycopg://dp:dp@localhost/db"
+    )
+    assert _sqlalchemy_postgres_uri("postgresql+psycopg://dp:dp@localhost/db") == (
+        "postgresql+psycopg://dp:dp@localhost/db"
+    )
+
+
+def test_submit_candidate_inserts_and_returns_pg_generated_fields(
+    migrated_postgres_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_settings_env(monkeypatch, migrated_postgres_dsn)
+
+    payload = {
+        "payload_type": "Ex-1",
+        "submitted_by": "test-subsystem",
+        "candidate": {"id": "alpha"},
+    }
+
+    item = submit_candidate(payload)
+
+    assert item.id is not None
+    assert item.submitted_at is not None
+    assert item.ingest_seq is not None
+    assert item.payload_type == "Ex-1"
+    assert item.submitted_by == "test-subsystem"
+    assert dict(item.payload) == payload
+    assert item.validation_status == "pending"
+    assert item.rejection_reason is None
+
+
+def test_forbidden_ingest_metadata_does_not_insert_row(
+    migrated_postgres_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_settings_env(monkeypatch, migrated_postgres_dsn)
+    engine = _create_engine(migrated_postgres_dsn)
+    try:
+        before_count = _candidate_count(engine)
+        with pytest.raises(ForbiddenIngestMetadataError):
+            submit_candidate(
+                {
+                    "payload_type": "Ex-1",
+                    "submitted_by": "test-subsystem",
+                    "ingest_seq": 123,
+                }
+            )
+        assert _candidate_count(engine) == before_count
+    finally:
+        engine.dispose()
+
+
+def test_repository_maps_pg_returning_fields(migrated_postgres_dsn: str) -> None:
+    envelope = validate_candidate_envelope(
+        {
+            "payload_type": "Ex-3",
+            "submitted_by": "test-subsystem",
+            "candidate": "beta",
+        }
+    )
+    repository = CandidateRepository(dsn=migrated_postgres_dsn)
+    try:
+        item = repository.insert_candidate(envelope)
+    finally:
+        repository.close()
+
+    assert item.id > 0
+    assert item.payload_type == "Ex-3"
+    assert item.submitted_by == "test-subsystem"
+    assert item.submitted_at is not None
+    assert item.ingest_seq > 0
+    assert item.validation_status == "pending"
+    assert item.rejection_reason is None
+
+
+@pytest.fixture()
+def migrated_postgres_dsn() -> Generator[str]:
+    admin_dsn = os.environ.get("DATABASE_URL") or os.environ.get("DP_PG_DSN")
+    if not admin_dsn:
+        pytest.skip("PostgreSQL submit_candidate tests require DATABASE_URL or DP_PG_DSN")
+
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL submit_candidate tests require SQLAlchemy",
+    )
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL submit_candidate tests require the migration runner",
+    )
+    make_url = pytest.importorskip(
+        "sqlalchemy.engine",
+        reason="PostgreSQL submit_candidate tests require SQLAlchemy",
+    ).make_url
+    sqlalchemy_error = pytest.importorskip(
+        "sqlalchemy.exc",
+        reason="PostgreSQL submit_candidate tests require SQLAlchemy",
+    ).SQLAlchemyError
+
+    admin_engine = sqlalchemy.create_engine(
+        runner_module._sqlalchemy_postgres_uri(admin_dsn),
+        isolation_level="AUTOCOMMIT",
+    )
+    database_name = f"dp_submit_candidate_test_{uuid4().hex}"
+    try:
+        with admin_engine.connect() as connection:
+            connection.execute(sqlalchemy.text(f'CREATE DATABASE "{database_name}"'))
+    except sqlalchemy_error as exc:
+        admin_engine.dispose()
+        pytest.skip(
+            "PostgreSQL submit_candidate tests require permission to create "
+            f"test databases: {exc}"
+        )
+
+    test_dsn = str(
+        make_url(runner_module._sqlalchemy_postgres_uri(admin_dsn)).set(database=database_name)
+    )
+    try:
+        runner_module.MigrationRunner().apply_pending(test_dsn)
+        yield test_dsn
+    finally:
+        with admin_engine.connect() as connection:
+            connection.execute(
+                sqlalchemy.text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )
+            connection.execute(sqlalchemy.text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+        admin_engine.dispose()
+
+
+def _set_required_settings_env(monkeypatch: pytest.MonkeyPatch, dsn: str) -> None:
+    monkeypatch.setenv("DP_PG_DSN", dsn)
+    monkeypatch.setenv("DP_RAW_ZONE_PATH", "data_platform/raw")
+    monkeypatch.setenv("DP_ICEBERG_WAREHOUSE_PATH", "data_platform/iceberg/warehouse")
+    monkeypatch.setenv("DP_DUCKDB_PATH", "data_platform/duckdb/data_platform.duckdb")
+
+
+def _create_engine(dsn: str) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL submit_candidate tests require SQLAlchemy",
+    )
+    return sqlalchemy.create_engine(_sqlalchemy_postgres_uri(dsn))
+
+
+def _candidate_count(engine: Any) -> int:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL submit_candidate tests require SQLAlchemy",
+    )
+    with engine.connect() as connection:
+        return int(
+            connection.execute(
+                sqlalchemy.text("SELECT count(*) FROM data_platform.candidate_queue")
+            ).scalar_one()
+        )

--- a/tests/queue/test_submit_candidate.py
+++ b/tests/queue/test_submit_candidate.py
@@ -107,6 +107,18 @@ def test_submit_candidate_rejects_invalid_payload_type() -> None:
         )
 
 
+@pytest.mark.parametrize("payload_type", [None, ["Ex-1"]])
+def test_submit_candidate_rejects_non_string_payload_type(payload_type: object) -> None:
+    with pytest.raises(CandidateValidationError, match="payload_type must be one of"):
+        submit_candidate(
+            {
+                "payload_type": payload_type,
+                "submitted_by": "test-subsystem",
+                "candidate": "alpha",
+            }
+        )
+
+
 def test_submit_candidate_rejects_missing_submitted_by() -> None:
     with pytest.raises(CandidateValidationError, match="submitted_by is required"):
         submit_candidate({"payload_type": "Ex-1", "candidate": "alpha"})
@@ -145,6 +157,28 @@ def test_submit_candidate_rejects_non_json_payload() -> None:
                 "payload_type": "Ex-1",
                 "submitted_by": "test-subsystem",
                 "as_of": datetime.now(UTC),
+            }
+        )
+
+
+def test_submit_candidate_rejects_nested_non_string_payload_keys() -> None:
+    with pytest.raises(CandidateValidationError, match="JSON object keys must be strings"):
+        submit_candidate(
+            {
+                "payload_type": "Ex-1",
+                "submitted_by": "test-subsystem",
+                "candidate": {"id": "alpha", "nested": {1: "not-json-object-key"}},
+            }
+        )
+
+
+def test_submit_candidate_rejects_nested_non_string_payload_keys_in_lists() -> None:
+    with pytest.raises(CandidateValidationError, match="JSON object keys must be strings"):
+        submit_candidate(
+            {
+                "payload_type": "Ex-1",
+                "submitted_by": "test-subsystem",
+                "candidate": [{"id": "alpha"}, {1: "not-json-object-key"}],
             }
         )
 


### PR DESCRIPTION
Closes #29

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/daily_refresh.py`


---
### 1. 背景与目标
项目文档 §16.1 要求公开 `submit_candidate(payload: ExPayload) -> CandidateQueueItem`，§9.3 要求摄取元数据由 Layer B 落库逻辑补写。现有 `src/data_platform/config/settings.py` 提供 `DP_PG_DSN`，#28 将提供 `candidate_queue` 表和 `CandidateQueueItem` 类型；当前 `src/data_platform/queue/` 还没有写入入口。本 issue 实现同步 Python API，只做 producer envelope 边界校验和 PG 插入，返回服务端生成的 queue item。

### 2. 所属模块
`src/data_platform/queue/`

### 3. 实现范围
- 新增 `src/data_platform/queue/api.py`，实现 `submit_candidate(payload: ExPayload) -> CandidateQueueItem`，并在 `src/data_platform/queue/__init__.py` re-export。
- 新增 `src/data_platform/queue/repository.py`，封装 SQLAlchemy engine 创建、insert + returning、row → `CandidateQueueItem` 映射。
- 新增 `src/data_platform/queue/validation.py`，实现 `validate_candidate_envelope(payload: Mapping[str, Any]) -> CandidateEnvelope`，校验 `payload_type`、`submitted_by`、JSON serializable payload，并拒绝 producer 传入 `submitted_at` / `ingest_seq`。
- 新增错误类型 `CandidateValidationError`、`ForbiddenIngestMetadataError`、`CandidateQueueWriteError`，风格保持现有代码中 `CanonicalTableNotFound(table)`、`AdapterFetchError(...)` 这类明确消息异常。
- 新增 `tests/queue/test_submit_candidate.py`，覆盖成功写入、非法 payload_type、缺失 submitted_by、payload 顶层包含 ingest metadata、PG returning 字段完整。

### 4. 不在本次范围
- 不把候选直接标记为 `accepted`；写入后的 `validation_status` 必须保持 `pending`，完整 contracts 校验由 #30 worker 完成。
- 不修改外部 `contracts` 仓库，也不在本项目内引入业务判断规则。
- 不实现批量提交或异步队列消费者。
- 不创建 cycle 或 selection 记录。

### 5. 关键交付物
- `ExPayload = Mapping[str, Any]` 作为本模块边界类型，后续可由 contracts 的具体 payload 类型替换但不改变 public API。
- `def submit_candidate(payload: ExPayload) -> CandidateQueueItem`。
- `@dataclass(frozen=True, slots=True) class CandidateEnvelope`，字段包含 `payload_type: CandidatePayloadType`、`submitted_by: str`、`payload: Mapping[str, Any]`。
- `class CandidateRepository`，方法 `insert_candidate(envelope: CandidateEnvelope) -> CandidateQueueItem`。
- `FORBIDDEN_PRODUCER_FIELDS = {'submitted_at', 'ingest_seq'}` 在 validation 层集中维护。
- 所有 DB insert 使用 `INSERT ... RETURNING id, payload_type, payload, submitted_by,