### PR TITLE
feat(#30): 队列校验 worker（pending → accepted/rejected）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,23 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: dp
+          POSTGRES_USER: postgres
+        ports:
+          - 55432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:dp@localhost:55432/postgres
+      DP_PG_DSN: postgresql://postgres:dp@localhost:55432/postgres
     steps:
       - uses: actions/checkout@v4
 

--- a/src/data_platform/queue/__init__.py
+++ b/src/data_platform/queue/__init__.py
@@ -14,6 +14,8 @@ from data_platform.queue.validation import (
     FORBIDDEN_PRODUCER_FIELDS,
     CandidateEnvelope,
     CandidateValidationError,
+    CandidateValidator,
+    EnvelopeCandidateValidator,
     ForbiddenIngestMetadataError,
     validate_candidate_envelope,
 )
@@ -28,6 +30,8 @@ __all__ = [
     "CandidateQueueWriteError",
     "CandidateRepository",
     "CandidateValidationError",
+    "CandidateValidator",
+    "EnvelopeCandidateValidator",
     "ExPayload",
     "ForbiddenIngestMetadataError",
     "IngestMetadataRecord",

--- a/src/data_platform/queue/repository.py
+++ b/src/data_platform/queue/repository.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from importlib import import_module
 import json
 import os
-from typing import Any, Final, cast
+from typing import Any, Final, Literal, TypeAlias, cast
 
 from data_platform.queue.models import (
     CANDIDATE_QUEUE_TABLE,
@@ -15,6 +15,8 @@ from data_platform.queue.models import (
     ValidationStatus,
 )
 from data_platform.queue.validation import CandidateEnvelope
+
+Connection: TypeAlias = Any
 
 _RETURNING_COLUMNS: Final[tuple[str, ...]] = (
     "id",
@@ -38,6 +40,22 @@ VALUES (
     :submitted_by
 )
 RETURNING {", ".join(_RETURNING_COLUMNS)}
+"""
+_FETCH_PENDING_FOR_UPDATE_SQL: Final[str] = f"""
+SELECT {", ".join(_RETURNING_COLUMNS)}
+FROM {CANDIDATE_QUEUE_TABLE}
+WHERE validation_status = 'pending'
+ORDER BY ingest_seq ASC
+LIMIT :limit
+FOR UPDATE SKIP LOCKED
+"""
+_MARK_VALIDATION_RESULT_SQL: Final[str] = f"""
+UPDATE {CANDIDATE_QUEUE_TABLE}
+SET
+    validation_status = CAST(:status AS data_platform.validation_status),
+    rejection_reason = :rejection_reason
+WHERE id = :candidate_id
+  AND validation_status = 'pending'
 """
 
 
@@ -88,6 +106,73 @@ class CandidateRepository:
             raise
 
         return _row_to_candidate_queue_item(row)
+
+    def fetch_pending_for_update(
+        self,
+        limit: int,
+        connection: Connection,
+    ) -> list[CandidateQueueItem]:
+        """Fetch pending candidates locked for validation in the caller transaction."""
+
+        if limit < 1:
+            msg = "limit must be a positive integer"
+            raise ValueError(msg)
+
+        try:
+            text = _sqlalchemy_text()
+            rows = (
+                connection.execute(text(_FETCH_PENDING_FOR_UPDATE_SQL), {"limit": limit})
+                .mappings()
+                .all()
+            )
+        except CandidateQueueWriteError:
+            raise
+        except Exception as exc:
+            if _is_sqlalchemy_error(exc):
+                raise CandidateQueueWriteError(
+                    "candidate queue pending fetch failed", exc
+                ) from exc
+            raise
+
+        return [_row_to_candidate_queue_item(row) for row in rows]
+
+    def mark_validation_result(
+        self,
+        candidate_id: int,
+        status: Literal["accepted", "rejected"],
+        rejection_reason: str | None,
+        connection: Connection,
+    ) -> None:
+        """Mark a locked pending candidate as accepted or rejected."""
+
+        if status not in {"accepted", "rejected"}:
+            msg = "status must be 'accepted' or 'rejected'"
+            raise ValueError(msg)
+        if status == "accepted" and rejection_reason is not None:
+            msg = "accepted candidates must not have a rejection_reason"
+            raise ValueError(msg)
+        if status == "rejected" and rejection_reason is None:
+            msg = "rejected candidates must have a rejection_reason"
+            raise ValueError(msg)
+
+        try:
+            text = _sqlalchemy_text()
+            connection.execute(
+                text(_MARK_VALIDATION_RESULT_SQL),
+                {
+                    "candidate_id": candidate_id,
+                    "status": status,
+                    "rejection_reason": rejection_reason,
+                },
+            )
+        except CandidateQueueWriteError:
+            raise
+        except Exception as exc:
+            if _is_sqlalchemy_error(exc):
+                raise CandidateQueueWriteError(
+                    "candidate queue validation status update failed", exc
+                ) from exc
+            raise
 
     def close(self) -> None:
         """Dispose an owned SQLAlchemy engine."""

--- a/src/data_platform/queue/repository.py
+++ b/src/data_platform/queue/repository.py
@@ -107,6 +107,11 @@ class CandidateRepository:
 
         return _row_to_candidate_queue_item(row)
 
+    def begin(self) -> Any:
+        """Begin a PostgreSQL transaction for queue operations."""
+
+        return self._engine.begin()
+
     def fetch_pending_for_update(
         self,
         limit: int,

--- a/src/data_platform/queue/validation.py
+++ b/src/data_platform/queue/validation.py
@@ -6,9 +6,9 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import json
 from types import MappingProxyType
-from typing import Any, Final, TypeAlias, cast, get_args
+from typing import Any, Final, Protocol, TypeAlias, cast, get_args
 
-from data_platform.queue.models import CandidatePayloadType
+from data_platform.queue.models import CandidatePayloadType, CandidateQueueItem
 
 ExPayload: TypeAlias = Mapping[str, Any]
 FORBIDDEN_PRODUCER_FIELDS: Final[frozenset[str]] = frozenset(
@@ -32,6 +32,32 @@ class ForbiddenIngestMetadataError(CandidateValidationError):
             "producer payload must not include PostgreSQL ingest metadata fields: "
             f"{forbidden_fields}"
         )
+
+
+class CandidateValidator(Protocol):
+    """Validation hook for queue worker candidate checks."""
+
+    def validate(self, item: CandidateQueueItem) -> None:
+        """Raise CandidateValidationError when a candidate must be rejected."""
+
+
+class EnvelopeCandidateValidator:
+    """Default worker validator for producer-owned Ex payload envelope fields."""
+
+    def validate(self, item: CandidateQueueItem) -> None:
+        envelope = validate_candidate_envelope(item.payload)
+        if envelope.payload_type != item.payload_type:
+            msg = (
+                "candidate payload_type does not match candidate_queue payload_type: "
+                f"{envelope.payload_type} != {item.payload_type}"
+            )
+            raise CandidateValidationError(msg)
+        if envelope.submitted_by != item.submitted_by:
+            msg = (
+                "candidate submitted_by does not match candidate_queue submitted_by: "
+                f"{envelope.submitted_by} != {item.submitted_by}"
+            )
+            raise CandidateValidationError(msg)
 
 
 @dataclass(frozen=True, slots=True)
@@ -128,6 +154,8 @@ __all__ = [
     "FORBIDDEN_PRODUCER_FIELDS",
     "CandidateEnvelope",
     "CandidateValidationError",
+    "CandidateValidator",
+    "EnvelopeCandidateValidator",
     "ExPayload",
     "ForbiddenIngestMetadataError",
     "validate_candidate_envelope",

--- a/src/data_platform/queue/worker.py
+++ b/src/data_platform/queue/worker.py
@@ -6,14 +6,20 @@ import argparse
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 import json
+import logging
 import sys
 from time import perf_counter_ns
 from typing import Never
 
 from data_platform.queue.repository import CandidateRepository
-from data_platform.queue.validation import CandidateValidator, EnvelopeCandidateValidator
+from data_platform.queue.validation import (
+    CandidateValidationError,
+    CandidateValidator,
+    EnvelopeCandidateValidator,
+)
 
 _REJECTION_REASON_MAX_CHARS = 1000
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,14 +51,14 @@ def validate_pending_candidates(
     scanned = 0
 
     try:
-        with repository._engine.begin() as connection:
+        with repository.begin() as connection:
             candidates = repository.fetch_pending_for_update(limit, connection)
             scanned = len(candidates)
 
             for candidate in candidates:
                 try:
                     candidate_validator.validate(candidate)
-                except Exception as exc:
+                except CandidateValidationError as exc:
                     rejected += 1
                     repository.mark_validation_result(
                         candidate.id,
@@ -60,6 +66,14 @@ def validate_pending_candidates(
                         _format_rejection_reason(exc),
                         connection,
                     )
+                except Exception:
+                    _LOGGER.warning(
+                        "unexpected candidate validator failure; transaction will "
+                        "roll back and candidate will remain pending",
+                        extra={"candidate_id": candidate.id},
+                        exc_info=True,
+                    )
+                    raise
                 else:
                     accepted += 1
                     repository.mark_validation_result(

--- a/src/data_platform/queue/worker.py
+++ b/src/data_platform/queue/worker.py
@@ -1,0 +1,160 @@
+"""Synchronous worker for validating pending Lite queue candidates."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+import json
+import sys
+from time import perf_counter_ns
+from typing import Never
+
+from data_platform.queue.repository import CandidateRepository
+from data_platform.queue.validation import CandidateValidator, EnvelopeCandidateValidator
+
+_REJECTION_REASON_MAX_CHARS = 1000
+
+
+@dataclass(frozen=True, slots=True)
+class QueueValidationSummary:
+    """Counts for one synchronous pending-candidate validation pass."""
+
+    scanned: int
+    accepted: int
+    rejected: int
+    duration_ms: int
+
+
+def validate_pending_candidates(
+    limit: int = 100,
+    *,
+    validator: CandidateValidator | None = None,
+) -> QueueValidationSummary:
+    """Validate up to ``limit`` pending candidates in one PostgreSQL transaction."""
+
+    if limit < 1:
+        msg = "limit must be a positive integer"
+        raise ValueError(msg)
+
+    start_ns = perf_counter_ns()
+    candidate_validator = validator if validator is not None else EnvelopeCandidateValidator()
+    repository = CandidateRepository()
+    accepted = 0
+    rejected = 0
+    scanned = 0
+
+    try:
+        with repository._engine.begin() as connection:
+            candidates = repository.fetch_pending_for_update(limit, connection)
+            scanned = len(candidates)
+
+            for candidate in candidates:
+                try:
+                    candidate_validator.validate(candidate)
+                except Exception as exc:
+                    rejected += 1
+                    repository.mark_validation_result(
+                        candidate.id,
+                        "rejected",
+                        _format_rejection_reason(exc),
+                        connection,
+                    )
+                else:
+                    accepted += 1
+                    repository.mark_validation_result(
+                        candidate.id,
+                        "accepted",
+                        None,
+                        connection,
+                    )
+    finally:
+        repository.close()
+
+    duration_ms = int((perf_counter_ns() - start_ns) / 1_000_000)
+    return QueueValidationSummary(
+        scanned=scanned,
+        accepted=accepted,
+        rejected=rejected,
+        duration_ms=duration_ms,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one synchronous validation pass and print a JSON summary."""
+
+    parser = _JsonErrorArgumentParser(
+        prog="python3 -m data_platform.queue.worker",
+        description="Validate pending data_platform.candidate_queue rows once.",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="run one validation pass",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="maximum pending candidates to lock and validate",
+    )
+
+    try:
+        args = parser.parse_args(argv)
+        if not args.once:
+            msg = "--once is required; daemon mode is not implemented"
+            raise _CliUsageError(msg)
+        if args.limit < 1:
+            msg = "--limit must be a positive integer"
+            raise _CliUsageError(msg)
+
+        summary = validate_pending_candidates(limit=args.limit)
+    except _CliUsageError as exc:
+        _print_json_error(exc)
+        return 2
+    except Exception as exc:
+        _print_json_error(exc)
+        return 1
+
+    print(json.dumps(asdict(summary), sort_keys=True))
+    return 0
+
+
+def _format_rejection_reason(exc: Exception) -> str:
+    reason = str(exc).strip() or exc.__class__.__name__
+    if len(reason) <= _REJECTION_REASON_MAX_CHARS:
+        return reason
+    return reason[:_REJECTION_REASON_MAX_CHARS]
+
+
+class _CliUsageError(ValueError):
+    """Raised for CLI argument errors that must be reported as JSON."""
+
+
+class _JsonErrorArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> Never:
+        raise _CliUsageError(message)
+
+
+def _print_json_error(exc: Exception) -> None:
+    print(
+        json.dumps(
+            {
+                "error": str(exc),
+                "error_type": exc.__class__.__name__,
+            },
+            sort_keys=True,
+        ),
+        file=sys.stderr,
+    )
+
+
+__all__ = [
+    "QueueValidationSummary",
+    "main",
+    "validate_pending_candidates",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/queue/test_worker.py
+++ b/tests/queue/test_worker.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import threading
-from typing import Any
+from typing import Any, NoReturn
 from uuid import uuid4
 
 import pytest
@@ -230,7 +230,9 @@ def queue_engine(migrated_postgres_dsn: str) -> Generator[Any]:
 def migrated_postgres_dsn() -> Generator[str]:
     admin_dsn = os.environ.get("DATABASE_URL") or os.environ.get("DP_PG_DSN")
     if not admin_dsn:
-        pytest.skip("PostgreSQL queue worker tests require DATABASE_URL or DP_PG_DSN")
+        _skip_or_fail_worker_db(
+            "PostgreSQL queue worker tests require DATABASE_URL or DP_PG_DSN",
+        )
 
     sqlalchemy = pytest.importorskip(
         "sqlalchemy",
@@ -256,13 +258,15 @@ def migrated_postgres_dsn() -> Generator[str]:
             connection.execute(sqlalchemy.text(f'CREATE DATABASE "{database_name}"'))
     except sqlalchemy_error as exc:
         admin_engine.dispose()
-        pytest.skip(
+        _skip_or_fail_worker_db(
             "PostgreSQL queue worker tests require permission to create "
             f"test databases: {exc}"
         )
 
     test_dsn = str(
-        make_url(runner_module._sqlalchemy_postgres_uri(admin_dsn)).set(database=database_name)
+        make_url(runner_module._sqlalchemy_postgres_uri(admin_dsn)).set(
+            database=database_name,
+        )
     )
     try:
         runner_module.MigrationRunner().apply_pending(test_dsn)
@@ -280,8 +284,16 @@ def migrated_postgres_dsn() -> Generator[str]:
                 ),
                 {"database_name": database_name},
             )
-            connection.execute(sqlalchemy.text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+            connection.execute(
+                sqlalchemy.text(f'DROP DATABASE IF EXISTS "{database_name}"')
+            )
         admin_engine.dispose()
+
+
+def _skip_or_fail_worker_db(message: str) -> NoReturn:
+    if os.environ.get("CI", "").strip().lower() in {"1", "true", "yes", "on"}:
+        pytest.fail(message)
+    pytest.skip(message)
 
 
 class _BarrierValidator:

--- a/tests/queue/test_worker.py
+++ b/tests/queue/test_worker.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+from collections.abc import Generator, Mapping
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+import json
+import os
+import threading
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from data_platform.queue.models import CandidateQueueItem
+from data_platform.queue.validation import (
+    CandidateValidationError,
+    EnvelopeCandidateValidator,
+)
+from data_platform.queue import worker as worker_module
+from data_platform.queue.worker import (
+    QueueValidationSummary,
+    main,
+    validate_pending_candidates,
+)
+
+
+def test_envelope_candidate_validator_accepts_ex_payload_envelope() -> None:
+    item = _candidate_item(
+        payload_type="Ex-1",
+        submitted_by="worker-test",
+        payload={
+            "payload_type": "Ex-1",
+            "submitted_by": "worker-test",
+            "candidate": {"id": "alpha"},
+        },
+    )
+
+    EnvelopeCandidateValidator().validate(item)
+
+
+def test_envelope_candidate_validator_rejects_payload_type_drift() -> None:
+    item = _candidate_item(
+        payload_type="Ex-1",
+        submitted_by="worker-test",
+        payload={
+            "payload_type": "Ex-2",
+            "submitted_by": "worker-test",
+            "candidate": {"id": "alpha"},
+        },
+    )
+
+    with pytest.raises(CandidateValidationError, match="payload_type does not match"):
+        EnvelopeCandidateValidator().validate(item)
+
+
+def test_cli_prints_json_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_validate_pending_candidates(
+        limit: int = 100,
+        *,
+        validator: object | None = None,
+    ) -> QueueValidationSummary:
+        assert limit == 5
+        assert validator is None
+        return QueueValidationSummary(scanned=0, accepted=0, rejected=0, duration_ms=1)
+
+    monkeypatch.setattr(
+        worker_module,
+        "validate_pending_candidates",
+        fake_validate_pending_candidates,
+    )
+
+    assert main(["--once", "--limit", "5"]) == 0
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "accepted": 0,
+        "duration_ms": 1,
+        "rejected": 0,
+        "scanned": 0,
+    }
+    assert captured.err == ""
+
+
+def test_worker_accepts_and_rejects_pending_candidates(
+    queue_worker_env: str,
+    queue_engine: Any,
+) -> None:
+    with queue_engine.begin() as connection:
+        accepted_first = _insert_candidate(connection, "Ex-1", _payload("Ex-1", "alpha"))
+        rejected = _insert_candidate(connection, "Ex-2", _payload("Ex-2", "reject"))
+        accepted_second = _insert_candidate(connection, "Ex-3", _payload("Ex-3", "beta"))
+
+    class FakeValidator:
+        def validate(self, item: CandidateQueueItem) -> None:
+            if item.payload["candidate"] == "reject":
+                raise CandidateValidationError("fake validator rejected candidate")
+
+    summary = validate_pending_candidates(validator=FakeValidator())
+
+    assert summary.scanned == 3
+    assert summary.accepted == 2
+    assert summary.rejected == 1
+
+    rows = _queue_rows(queue_engine)
+    assert rows[accepted_first]["validation_status"] == "accepted"
+    assert rows[accepted_first]["rejection_reason"] is None
+    assert rows[rejected]["validation_status"] == "rejected"
+    assert rows[rejected]["rejection_reason"] == "fake validator rejected candidate"
+    assert rows[accepted_second]["validation_status"] == "accepted"
+    assert rows[accepted_second]["rejection_reason"] is None
+    assert "submitted_at" not in rows[accepted_first]["payload"]
+    assert "ingest_seq" not in rows[accepted_first]["payload"]
+
+    second_summary = validate_pending_candidates(validator=FakeValidator())
+    assert second_summary.scanned == 0
+    assert second_summary.accepted == 0
+    assert second_summary.rejected == 0
+
+
+def test_worker_respects_limit(
+    queue_worker_env: str,
+    queue_engine: Any,
+) -> None:
+    with queue_engine.begin() as connection:
+        for index in range(12):
+            _insert_candidate(connection, "Ex-1", _payload("Ex-1", f"candidate-{index}"))
+
+    summary = validate_pending_candidates(limit=10)
+
+    assert summary.scanned == 10
+    assert summary.accepted == 10
+    assert summary.rejected == 0
+    assert _status_counts(queue_engine) == {"accepted": 10, "pending": 2}
+
+
+def test_concurrent_workers_do_not_process_same_candidate_twice(
+    queue_worker_env: str,
+    queue_engine: Any,
+) -> None:
+    with queue_engine.begin() as connection:
+        for index in range(20):
+            _insert_candidate(connection, "Ex-1", _payload("Ex-1", f"candidate-{index}"))
+
+    validator = _BarrierValidator(threading.Barrier(2))
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(validate_pending_candidates, 10, validator=validator),
+            executor.submit(validate_pending_candidates, 10, validator=validator),
+        ]
+        summaries = [future.result(timeout=20) for future in futures]
+
+    assert sum(summary.scanned for summary in summaries) == 20
+    assert sum(summary.accepted for summary in summaries) == 20
+    assert sum(summary.rejected for summary in summaries) == 0
+    assert len(validator.seen_candidate_ids) == 20
+    assert len(set(validator.seen_candidate_ids)) == 20
+    assert _status_counts(queue_engine) == {"accepted": 20}
+
+
+def test_cli_succeeds_on_empty_queue(
+    queue_worker_env: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["--once", "--limit", "5"]) == 0
+
+    captured = capsys.readouterr()
+    summary = json.loads(captured.out)
+    assert summary["accepted"] == 0
+    assert summary["rejected"] == 0
+    assert summary["scanned"] == 0
+    assert isinstance(summary["duration_ms"], int)
+    assert summary["duration_ms"] >= 0
+    assert captured.err == ""
+
+
+@pytest.fixture()
+def queue_worker_env(
+    migrated_postgres_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[str]:
+    monkeypatch.setenv("DP_PG_DSN", migrated_postgres_dsn)
+    yield migrated_postgres_dsn
+
+
+@pytest.fixture()
+def queue_engine(migrated_postgres_dsn: str) -> Generator[Any]:
+    engine = _create_engine(migrated_postgres_dsn)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture()
+def migrated_postgres_dsn() -> Generator[str]:
+    admin_dsn = os.environ.get("DATABASE_URL") or os.environ.get("DP_PG_DSN")
+    if not admin_dsn:
+        pytest.skip("PostgreSQL queue worker tests require DATABASE_URL or DP_PG_DSN")
+
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL queue worker tests require SQLAlchemy",
+    )
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL queue worker tests require the migration runner",
+    )
+    make_url = pytest.importorskip(
+        "sqlalchemy.engine",
+        reason="PostgreSQL queue worker tests require SQLAlchemy",
+    ).make_url
+    sqlalchemy_error = pytest.importorskip(
+        "sqlalchemy.exc",
+        reason="PostgreSQL queue worker tests require SQLAlchemy",
+    ).SQLAlchemyError
+
+    admin_engine = _create_engine(admin_dsn, isolation_level="AUTOCOMMIT")
+    database_name = f"dp_queue_worker_test_{uuid4().hex}"
+    try:
+        with admin_engine.connect() as connection:
+            connection.execute(sqlalchemy.text(f'CREATE DATABASE "{database_name}"'))
+    except sqlalchemy_error as exc:
+        admin_engine.dispose()
+        pytest.skip(
+            "PostgreSQL queue worker tests require permission to create "
+            f"test databases: {exc}"
+        )
+
+    test_dsn = str(
+        make_url(runner_module._sqlalchemy_postgres_uri(admin_dsn)).set(database=database_name)
+    )
+    try:
+        runner_module.MigrationRunner().apply_pending(test_dsn)
+        yield test_dsn
+    finally:
+        with admin_engine.connect() as connection:
+            connection.execute(
+                sqlalchemy.text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )
+            connection.execute(sqlalchemy.text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+        admin_engine.dispose()
+
+
+class _BarrierValidator:
+    def __init__(self, barrier: threading.Barrier) -> None:
+        self._barrier = barrier
+        self._local = threading.local()
+        self._lock = threading.Lock()
+        self.seen_candidate_ids: list[int] = []
+
+    def validate(self, item: CandidateQueueItem) -> None:
+        with self._lock:
+            self.seen_candidate_ids.append(item.id)
+        if getattr(self._local, "waited", False):
+            return
+
+        self._local.waited = True
+        self._barrier.wait(timeout=10)
+
+
+def _candidate_item(
+    *,
+    payload_type: str,
+    submitted_by: str,
+    payload: Mapping[str, Any],
+) -> CandidateQueueItem:
+    return CandidateQueueItem(
+        id=1,
+        payload_type=payload_type,  # type: ignore[arg-type]
+        payload=payload,
+        submitted_by=submitted_by,
+        submitted_at=datetime.now(UTC),
+        ingest_seq=1,
+        validation_status="pending",
+        rejection_reason=None,
+    )
+
+
+def _payload(payload_type: str, candidate: str) -> dict[str, Any]:
+    return {
+        "payload_type": payload_type,
+        "submitted_by": "worker-test",
+        "candidate": candidate,
+    }
+
+
+def _insert_candidate(
+    connection: Any,
+    payload_type: str,
+    payload: Mapping[str, Any],
+) -> int:
+    return int(
+        connection.execute(
+            _text(
+                """
+                INSERT INTO data_platform.candidate_queue (
+                    payload_type,
+                    payload,
+                    submitted_by
+                )
+                VALUES (:payload_type, CAST(:payload AS jsonb), :submitted_by)
+                RETURNING id
+                """
+            ),
+            {
+                "payload_type": payload_type,
+                "payload": json.dumps(dict(payload), allow_nan=False),
+                "submitted_by": payload["submitted_by"],
+            },
+        ).scalar_one()
+    )
+
+
+def _queue_rows(queue_engine: Any) -> dict[int, Mapping[str, Any]]:
+    with queue_engine.connect() as connection:
+        rows = (
+            connection.execute(
+                _text(
+                    """
+                    SELECT id, payload, validation_status, rejection_reason
+                    FROM data_platform.candidate_queue
+                    ORDER BY ingest_seq ASC
+                    """
+                )
+            )
+            .mappings()
+            .all()
+        )
+    return {int(row["id"]): row for row in rows}
+
+
+def _status_counts(queue_engine: Any) -> dict[str, int]:
+    with queue_engine.connect() as connection:
+        rows = connection.execute(
+            _text(
+                """
+                SELECT validation_status, count(*) AS row_count
+                FROM data_platform.candidate_queue
+                GROUP BY validation_status
+                ORDER BY validation_status
+                """
+            )
+        )
+    return {str(row[0]): int(row[1]) for row in rows}
+
+
+def _create_engine(dsn: str, **kwargs: object) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL queue worker tests require SQLAlchemy",
+    )
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL queue worker tests require the migration runner",
+    )
+    return sqlalchemy.create_engine(runner_module._sqlalchemy_postgres_uri(dsn), **kwargs)
+
+
+def _text(sql: str) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL queue worker tests require SQLAlchemy",
+    )
+    return sqlalchemy.text(sql)

--- a/tests/queue/test_worker.py
+++ b/tests/queue/test_worker.py
@@ -4,6 +4,7 @@ from collections.abc import Generator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 import json
+import logging
 import os
 import threading
 from typing import Any
@@ -134,6 +135,37 @@ def test_worker_respects_limit(
     assert summary.accepted == 10
     assert summary.rejected == 0
     assert _status_counts(queue_engine) == {"accepted": 10, "pending": 2}
+
+
+def test_worker_rolls_back_unexpected_validator_exceptions(
+    queue_worker_env: str,
+    queue_engine: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with queue_engine.begin() as connection:
+        first = _insert_candidate(connection, "Ex-1", _payload("Ex-1", "first"))
+        second = _insert_candidate(connection, "Ex-1", _payload("Ex-1", "crash"))
+
+    class CrashingValidator:
+        def validate(self, item: CandidateQueueItem) -> None:
+            if item.payload["candidate"] == "crash":
+                raise RuntimeError("validator backend unavailable")
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError, match="validator backend unavailable"):
+            validate_pending_candidates(validator=CrashingValidator())
+
+    rows = _queue_rows(queue_engine)
+
+    assert rows[first]["validation_status"] == "pending"
+    assert rows[first]["rejection_reason"] is None
+    assert rows[second]["validation_status"] == "pending"
+    assert rows[second]["rejection_reason"] is None
+    assert _status_counts(queue_engine) == {"pending": 2}
+    assert any(
+        "unexpected candidate validator failure" in record.message
+        for record in caplog.records
+    )
 
 
 def test_concurrent_workers_do_not_process_same_candidate_twice(


### PR DESCRIPTION
Closes #30

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/daily_refresh.py`


---
### 1. 背景与目标
项目文档 §18.1 要求 `queue/` 校验逻辑有单元测试，§9.3 定义 `validation_status` 的 `pending / accepted / rejected` 生命周期。#29 只负责 producer 边界校验和 pending 写入；当前代码没有同步 worker 去消费 `candidate_queue`。本 issue 实现可由本地 Lite 流程或外部 orchestrator 调用的同步校验 worker，并保持 data-platform 不拥有业务判断。

### 2. 所属模块
`src/data_platform/queue/worker.py` + `src/data_platform/queue/validation.py`

### 3. 实现范围
- 新增 `src/data_platform/queue/worker.py`，实现 `validate_pending_candidates(limit: int = 100, *, validator: CandidateValidator | None = None) -> QueueValidationSummary`。
- 在 `validation.py` 中补充 `CandidateValidator` protocol 和默认 `EnvelopeCandidateValidator`，只校验 Ex payload envelope、payload_type、JSON shape、禁止 ingest metadata；业务 schema 可通过注入 validator 接入 contracts。
- worker 使用单个 PG 事务按 `validation_status='pending'`、`ingest_seq ASC` 拉取，SQL 使用 `FOR UPDATE SKIP LOCKED`，避免多个 worker 重复处理同一行。
- 对通过校验的行更新为 `accepted`；对失败行更新为 `rejected` 并写入截断后的 `rejection_reason`。
- 提供 CLI：`python3 -m data_platform.queue.worker --once --limit 100`，stdout 输出 JSON summary，失败时 stderr 输出 JSON error。
- 新增 `tests/queue/test_worker.py`，覆盖 accepted、rejected、limit、重复运行幂等、两个 worker 并发不重复处理。

### 4. 不在本次范围
- 不实现常驻 daemon、sleep loop 或 Dagster job/schedule。
- 不修改外部 contracts schema；只提供 validator 注入点。
- 不冻结 cycle，也不写 `cycle_candidate_selection`。
- 不把 rejected payload 从队列表删除，保留审计记录。

### 5. 关键交付物
- `class CandidateValidator(Protocol): validate(self, item: CandidateQueueItem) -> None`。
- `@dataclass(frozen=True, slots=True) class QueueValidationSummary`，字段包含 `scanned: int`、`accepted: int`、`rejected: int`、`duration_ms: int`。
- `def validate_pending_candidates(limit: int = 100, *, validator: CandidateValidator | None = None) -> QueueValidationSummary`。
- `def main(argv: Sequence[str] | None = None) -> int` 支持 `--once` 和 `--limit`。
- `CandidateRepository.fetch_pending_for_update(limit: int, connection: Connection) -> list[CandidateQueueItem]`。
- `CandidateRepository.mark_validation_result(candidate_id: int, status: Literal['accepted', 'rejected'], rejec