### PR TITLE
feat(#32): cycle_candidate_selection 表与 freeze_cycle_candidates 事务

### DIFF
--- a/src/data_platform/cycle/__init__.py
+++ b/src/data_platform/cycle/__init__.py
@@ -1,31 +1,41 @@
 """Cycle control package."""
 
 from data_platform.cycle.models import (
+    CYCLE_CANDIDATE_SELECTION_TABLE,
     CYCLE_ID_PATTERN,
     CYCLE_METADATA_TABLE,
+    CycleCandidateSelection,
     CycleMetadata,
     CycleStatus,
     InvalidCycleId,
 )
+from data_platform.cycle.freeze import freeze_cycle_candidates
 from data_platform.cycle.repository import (
+    CycleAlreadyFrozen,
     CycleAlreadyExists,
     CycleNotFound,
     InvalidCycleTransition,
+    NoAcceptedCandidates,
     create_cycle,
     get_cycle,
     transition_cycle_status,
 )
 
 __all__ = [
+    "CYCLE_CANDIDATE_SELECTION_TABLE",
     "CYCLE_ID_PATTERN",
     "CYCLE_METADATA_TABLE",
+    "CycleAlreadyFrozen",
     "CycleAlreadyExists",
+    "CycleCandidateSelection",
     "CycleMetadata",
     "CycleNotFound",
     "CycleStatus",
     "InvalidCycleId",
     "InvalidCycleTransition",
+    "NoAcceptedCandidates",
     "create_cycle",
+    "freeze_cycle_candidates",
     "get_cycle",
     "transition_cycle_status",
 ]

--- a/src/data_platform/cycle/freeze.py
+++ b/src/data_platform/cycle/freeze.py
@@ -1,0 +1,21 @@
+"""Public API for Lite candidate selection freeze."""
+
+from __future__ import annotations
+
+from data_platform.cycle.models import CycleMetadata, _cycle_date_from_id
+from data_platform.cycle.repository import CycleRepository
+
+
+def freeze_cycle_candidates(cycle_id: str) -> CycleMetadata:
+    """Freeze accepted candidate_queue rows for one cycle."""
+
+    _cycle_date_from_id(cycle_id)
+    repository = CycleRepository()
+    try:
+        with repository.begin() as connection:
+            return repository.freeze_selection(cycle_id, connection)
+    finally:
+        repository.close()
+
+
+__all__ = ["freeze_cycle_candidates"]

--- a/src/data_platform/cycle/models.py
+++ b/src/data_platform/cycle/models.py
@@ -19,6 +19,9 @@ CycleStatus: TypeAlias = Literal[
 
 CYCLE_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^CYCLE_(?P<cycle_date>\d{8})$")
 CYCLE_METADATA_TABLE: Final[str] = "data_platform.cycle_metadata"
+CYCLE_CANDIDATE_SELECTION_TABLE: Final[str] = (
+    "data_platform.cycle_candidate_selection"
+)
 
 _CYCLE_STATUSES: Final[frozenset[str]] = frozenset(get_args(CycleStatus))
 
@@ -52,6 +55,21 @@ class CycleMetadata:
         _validate_cycle_status(self.status)
         if self.candidate_count < 0:
             msg = "candidate_count must be non-negative"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class CycleCandidateSelection:
+    """A row from data_platform.cycle_candidate_selection."""
+
+    cycle_id: str
+    candidate_id: int
+    selected_at: datetime
+
+    def __post_init__(self) -> None:
+        _cycle_date_from_id(self.cycle_id)
+        if self.candidate_id < 1:
+            msg = "candidate_id must be positive"
             raise ValueError(msg)
 
 

--- a/src/data_platform/cycle/repository.py
+++ b/src/data_platform/cycle/repository.py
@@ -58,7 +58,7 @@ class CycleAlreadyFrozen(RuntimeError):
 
 
 class NoAcceptedCandidates(RuntimeError):
-    """Raised by strict freeze flows when no accepted candidates are available."""
+    """Available for strict callers; the default freeze path allows empty selection."""
 
     def __init__(self, cycle_id: str) -> None:
         self.cycle_id = cycle_id
@@ -95,7 +95,14 @@ class CycleRepository:
         return self._engine.begin()
 
     def freeze_selection(self, cycle_id: str, connection: Any) -> CycleMetadata:
-        """Freeze accepted queue candidates for one cycle in the caller transaction."""
+        """Freeze accepted queue candidates for one cycle in the caller transaction.
+
+        Under PostgreSQL READ COMMITTED, the freeze boundary is the
+        INSERT...SELECT statement start. Candidates accepted before that statement's
+        snapshot are eligible; candidates accepted later wait for a future cycle.
+        Metadata is derived from the same inserted CTE so cutoffs and counts always
+        describe the actual selected rows.
+        """
 
         _cycle_date_from_id(cycle_id)
         current = connection.execute(

--- a/src/data_platform/cycle/repository.py
+++ b/src/data_platform/cycle/repository.py
@@ -8,6 +8,7 @@ from datetime import date
 from typing import Any, Final
 
 from data_platform.cycle.models import (
+    CYCLE_CANDIDATE_SELECTION_TABLE,
     CYCLE_METADATA_TABLE,
     CycleMetadata,
     CycleStatus,
@@ -16,6 +17,7 @@ from data_platform.cycle.models import (
     _validate_cycle_status,
     cycle_id_for_date,
 )
+from data_platform.queue.models import CANDIDATE_QUEUE_TABLE
 
 _FORWARD_TRANSITIONS: Final[dict[CycleStatus, CycleStatus]] = {
     "pending": "phase0",
@@ -43,6 +45,26 @@ class CycleNotFound(LookupError):
         super().__init__(f"cycle not found: {cycle_id}")
 
 
+class CycleAlreadyFrozen(RuntimeError):
+    """Raised when candidate selection for a cycle has already been frozen."""
+
+    def __init__(self, cycle_id: str, current_status: str) -> None:
+        self.cycle_id = cycle_id
+        self.current_status = current_status
+        super().__init__(
+            f"cycle candidate selection already frozen: {cycle_id} "
+            f"status={current_status!r}"
+        )
+
+
+class NoAcceptedCandidates(RuntimeError):
+    """Raised by strict freeze flows when no accepted candidates are available."""
+
+    def __init__(self, cycle_id: str) -> None:
+        self.cycle_id = cycle_id
+        super().__init__(f"cycle has no accepted candidates to freeze: {cycle_id}")
+
+
 class InvalidCycleTransition(ValueError):
     """Raised when a requested cycle status transition is not allowed."""
 
@@ -54,6 +76,111 @@ class InvalidCycleTransition(ValueError):
             "invalid cycle status transition: "
             f"{cycle_id} {current_status!r} -> {target_status!r}"
         )
+
+
+class CycleRepository:
+    """Repository for PostgreSQL-backed cycle operations."""
+
+    def __init__(self, dsn: str | None = None, *, engine: Any | None = None) -> None:
+        if dsn is not None and engine is not None:
+            msg = "provide either dsn or engine, not both"
+            raise ValueError(msg)
+
+        self._owns_engine = engine is None
+        self._engine = engine if engine is not None else _create_engine(dsn or _resolve_dsn())
+
+    def begin(self) -> Any:
+        """Begin a PostgreSQL transaction for cycle operations."""
+
+        return self._engine.begin()
+
+    def freeze_selection(self, cycle_id: str, connection: Any) -> CycleMetadata:
+        """Freeze accepted queue candidates for one cycle in the caller transaction."""
+
+        _cycle_date_from_id(cycle_id)
+        current = connection.execute(
+            _text(
+                f"""
+                SELECT
+                    cycle_id,
+                    status,
+                    selection_frozen_at
+                FROM {CYCLE_METADATA_TABLE}
+                WHERE cycle_id = :cycle_id
+                FOR UPDATE
+                """
+            ),
+            {"cycle_id": cycle_id},
+        ).mappings().one_or_none()
+        if current is None:
+            raise CycleNotFound(cycle_id)
+
+        current_status = _validate_cycle_status(str(current["status"]))
+        if current_status != "pending" or current["selection_frozen_at"] is not None:
+            raise CycleAlreadyFrozen(cycle_id, current_status)
+
+        row = connection.execute(
+            _text(
+                f"""
+                WITH inserted AS (
+                    INSERT INTO {CYCLE_CANDIDATE_SELECTION_TABLE} (
+                        cycle_id,
+                        candidate_id
+                    )
+                    SELECT
+                        :cycle_id,
+                        candidate_queue.id
+                    FROM {CANDIDATE_QUEUE_TABLE} AS candidate_queue
+                    WHERE candidate_queue.validation_status = 'accepted'
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM {CYCLE_CANDIDATE_SELECTION_TABLE} AS selection
+                          WHERE selection.cycle_id = :cycle_id
+                            AND selection.candidate_id = candidate_queue.id
+                      )
+                    ORDER BY candidate_queue.ingest_seq ASC
+                    RETURNING candidate_id
+                ),
+                stats AS (
+                    SELECT
+                        max(candidate_queue.submitted_at) AS cutoff_submitted_at,
+                        max(candidate_queue.ingest_seq) AS cutoff_ingest_seq,
+                        count(*) AS candidate_count
+                    FROM inserted
+                    JOIN {CANDIDATE_QUEUE_TABLE} AS candidate_queue
+                      ON candidate_queue.id = inserted.candidate_id
+                )
+                UPDATE {CYCLE_METADATA_TABLE} AS cycle_metadata
+                SET
+                    cutoff_submitted_at = stats.cutoff_submitted_at,
+                    cutoff_ingest_seq = stats.cutoff_ingest_seq,
+                    candidate_count = CAST(stats.candidate_count AS integer),
+                    selection_frozen_at = now(),
+                    status = CAST('phase0' AS data_platform.cycle_status),
+                    updated_at = now()
+                FROM stats
+                WHERE cycle_metadata.cycle_id = :cycle_id
+                RETURNING
+                    cycle_metadata.cycle_id,
+                    cycle_metadata.cycle_date,
+                    cycle_metadata.status,
+                    cycle_metadata.cutoff_submitted_at,
+                    cycle_metadata.cutoff_ingest_seq,
+                    cycle_metadata.candidate_count,
+                    cycle_metadata.selection_frozen_at,
+                    cycle_metadata.created_at,
+                    cycle_metadata.updated_at
+                """
+            ),
+            {"cycle_id": cycle_id},
+        ).mappings().one()
+        return _metadata_from_row(row)
+
+    def close(self) -> None:
+        """Dispose an owned SQLAlchemy engine."""
+
+        if self._owns_engine:
+            self._engine.dispose()
 
 
 def create_cycle(cycle_date: date) -> CycleMetadata:
@@ -182,10 +309,10 @@ def transition_cycle_status(cycle_id: str, status: CycleStatus) -> CycleMetadata
         engine.dispose()
 
 
-def _create_engine() -> Any:
+def _create_engine(dsn: str | None = None) -> Any:
     from sqlalchemy import create_engine
 
-    return create_engine(_sqlalchemy_postgres_uri(_resolve_dsn()))
+    return create_engine(_sqlalchemy_postgres_uri(dsn or _resolve_dsn()))
 
 
 def _text(sql: str) -> Any:
@@ -245,10 +372,13 @@ def _metadata_from_row(row: Mapping[str, Any]) -> CycleMetadata:
 
 
 __all__ = [
+    "CycleAlreadyFrozen",
     "CycleAlreadyExists",
+    "CycleRepository",
     "CycleNotFound",
     "InvalidCycleId",
     "InvalidCycleTransition",
+    "NoAcceptedCandidates",
     "create_cycle",
     "get_cycle",
     "transition_cycle_status",

--- a/src/data_platform/ddl/migrations/0004_cycle_candidate_selection.sql
+++ b/src/data_platform/ddl/migrations/0004_cycle_candidate_selection.sql
@@ -1,0 +1,8 @@
+CREATE SCHEMA IF NOT EXISTS data_platform;
+
+CREATE TABLE IF NOT EXISTS data_platform.cycle_candidate_selection (
+    cycle_id TEXT NOT NULL REFERENCES data_platform.cycle_metadata(cycle_id),
+    candidate_id BIGINT NOT NULL REFERENCES data_platform.candidate_queue(id),
+    selected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (cycle_id, candidate_id)
+);

--- a/tests/cycle/test_cycle_metadata.py
+++ b/tests/cycle/test_cycle_metadata.py
@@ -110,7 +110,7 @@ def migrated_postgres_dsn(postgres_dsn: str) -> str:
         reason="PostgreSQL cycle metadata tests require the migration runner",
     )
     applied_versions = runner_module.MigrationRunner().apply_pending(postgres_dsn)
-    assert applied_versions == ["0001", "0002", "0003"]
+    assert applied_versions == ["0001", "0002", "0003", "0004"]
     assert runner_module.MigrationRunner().apply_pending(postgres_dsn) == []
     return postgres_dsn
 

--- a/tests/cycle/test_freeze_cycle_candidates.py
+++ b/tests/cycle/test_freeze_cycle_candidates.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Generator, Mapping
+from dataclasses import FrozenInstanceError, fields, is_dataclass
+from datetime import UTC, date, datetime
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from data_platform.cycle import (
+    CYCLE_CANDIDATE_SELECTION_TABLE,
+    CycleAlreadyFrozen,
+    CycleCandidateSelection,
+    CycleNotFound,
+    InvalidCycleId,
+    create_cycle,
+    freeze_cycle_candidates,
+    get_cycle,
+)
+
+
+EXPECTED_SELECTION_COLUMNS = ["cycle_id", "candidate_id", "selected_at"]
+EXPECTED_MIGRATIONS = ["0001", "0002", "0003", "0004"]
+
+
+def test_cycle_candidate_selection_model_exposes_contract() -> None:
+    assert CYCLE_CANDIDATE_SELECTION_TABLE == "data_platform.cycle_candidate_selection"
+    assert is_dataclass(CycleCandidateSelection)
+    assert [field.name for field in fields(CycleCandidateSelection)] == (
+        EXPECTED_SELECTION_COLUMNS
+    )
+    assert CycleCandidateSelection.__slots__ == tuple(EXPECTED_SELECTION_COLUMNS)
+
+    selection = CycleCandidateSelection(
+        cycle_id="CYCLE_20260416",
+        candidate_id=1,
+        selected_at=datetime.now(UTC),
+    )
+    with pytest.raises(FrozenInstanceError):
+        selection.candidate_id = 2
+
+    with pytest.raises(InvalidCycleId):
+        CycleCandidateSelection(
+            cycle_id="bad",
+            candidate_id=1,
+            selected_at=datetime.now(UTC),
+        )
+    with pytest.raises(ValueError, match="candidate_id must be positive"):
+        CycleCandidateSelection(
+            cycle_id="CYCLE_20260416",
+            candidate_id=0,
+            selected_at=datetime.now(UTC),
+        )
+
+
+def test_freeze_rejects_invalid_cycle_id_before_database() -> None:
+    with pytest.raises(InvalidCycleId):
+        freeze_cycle_candidates("bad")
+
+
+def test_migration_creates_cycle_candidate_selection_schema(
+    migrated_postgres_dsn: str,
+) -> None:
+    engine = _create_engine(migrated_postgres_dsn)
+    try:
+        with engine.connect() as connection:
+            assert (
+                connection.execute(
+                    _text("SELECT to_regclass('data_platform.cycle_candidate_selection')")
+                ).scalar_one()
+                == "data_platform.cycle_candidate_selection"
+            )
+
+            table_columns = connection.execute(
+                _text(
+                    """
+                    SELECT column_name, data_type, is_nullable, column_default
+                    FROM information_schema.columns
+                    WHERE table_schema = 'data_platform'
+                      AND table_name = 'cycle_candidate_selection'
+                    ORDER BY ordinal_position
+                    """
+                )
+            ).mappings()
+            columns = {str(row["column_name"]): row for row in table_columns}
+            assert list(columns) == EXPECTED_SELECTION_COLUMNS
+            assert columns["cycle_id"]["data_type"] == "text"
+            assert columns["candidate_id"]["data_type"] == "bigint"
+            assert columns["selected_at"]["data_type"] == "timestamp with time zone"
+            assert columns["selected_at"]["column_default"] == "now()"
+            for column_name in EXPECTED_SELECTION_COLUMNS:
+                assert columns[column_name]["is_nullable"] == "NO"
+
+            assert {
+                str(row[0])
+                for row in connection.execute(
+                    _text(
+                        """
+                        SELECT constraint_name
+                        FROM information_schema.table_constraints
+                        WHERE table_schema = 'data_platform'
+                          AND table_name = 'cycle_candidate_selection'
+                        """
+                    )
+                )
+            } >= {
+                "cycle_candidate_selection_pkey",
+                "cycle_candidate_selection_cycle_id_fkey",
+                "cycle_candidate_selection_candidate_id_fkey",
+            }
+    finally:
+        engine.dispose()
+
+
+def test_freeze_allows_empty_queue_with_zero_count(
+    cycle_repository_env: str,
+    cycle_engine: Any,
+) -> None:
+    create_cycle(date(2026, 4, 16))
+
+    metadata = freeze_cycle_candidates("CYCLE_20260416")
+
+    assert metadata.status == "phase0"
+    assert metadata.cutoff_submitted_at is None
+    assert metadata.cutoff_ingest_seq is None
+    assert metadata.candidate_count == 0
+    assert metadata.selection_frozen_at is not None
+    assert _selection_ids(cycle_engine, "CYCLE_20260416") == []
+
+
+def test_freeze_selects_only_accepted_candidates_and_sets_cutoffs(
+    cycle_repository_env: str,
+    cycle_engine: Any,
+) -> None:
+    create_cycle(date(2026, 4, 16))
+    accepted: list[Mapping[str, Any]] = []
+    with cycle_engine.begin() as connection:
+        for index in range(5):
+            accepted.append(
+                _insert_candidate(
+                    connection,
+                    validation_status="accepted",
+                    candidate=f"accepted-{index}",
+                )
+            )
+        for index in range(2):
+            _insert_candidate(
+                connection,
+                validation_status="rejected",
+                candidate=f"rejected-{index}",
+            )
+
+    metadata = freeze_cycle_candidates("CYCLE_20260416")
+
+    assert _selection_ids(cycle_engine, "CYCLE_20260416") == [
+        int(row["id"]) for row in accepted
+    ]
+    assert metadata.status == "phase0"
+    assert metadata.candidate_count == 5
+    assert metadata.cutoff_ingest_seq == max(int(row["ingest_seq"]) for row in accepted)
+    selected_submitted_at = [row["submitted_at"] for row in accepted]
+    assert metadata.cutoff_submitted_at == max(selected_submitted_at)
+    assert all(metadata.cutoff_submitted_at >= submitted_at for submitted_at in selected_submitted_at)
+
+
+def test_freeze_missing_cycle_raises_not_found(
+    cycle_repository_env: str,
+) -> None:
+    with pytest.raises(CycleNotFound):
+        freeze_cycle_candidates("CYCLE_20260416")
+
+
+def test_repeated_freeze_raises_and_late_candidates_are_not_selected(
+    cycle_repository_env: str,
+    cycle_engine: Any,
+) -> None:
+    create_cycle(date(2026, 4, 16))
+    with cycle_engine.begin() as connection:
+        first = _insert_candidate(
+            connection,
+            validation_status="accepted",
+            candidate="before-freeze",
+        )
+
+    first_metadata = freeze_cycle_candidates("CYCLE_20260416")
+
+    with cycle_engine.begin() as connection:
+        _insert_candidate(
+            connection,
+            validation_status="accepted",
+            candidate="after-freeze",
+        )
+
+    with pytest.raises(CycleAlreadyFrozen):
+        freeze_cycle_candidates("CYCLE_20260416")
+
+    assert _selection_ids(cycle_engine, "CYCLE_20260416") == [int(first["id"])]
+    assert get_cycle("CYCLE_20260416") == first_metadata
+
+
+def test_selection_insert_failure_rolls_back_whole_freeze_transaction(
+    cycle_repository_env: str,
+    cycle_engine: Any,
+) -> None:
+    create_cycle(date(2026, 4, 16))
+    with cycle_engine.begin() as connection:
+        _insert_candidate(
+            connection,
+            validation_status="accepted",
+            candidate="will-roll-back",
+        )
+        connection.exec_driver_sql(
+            """
+            CREATE OR REPLACE FUNCTION data_platform.raise_selection_insert_failure()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                RAISE EXCEPTION 'forced selection insert failure';
+            END;
+            $$;
+
+            CREATE TRIGGER force_selection_insert_failure
+            BEFORE INSERT ON data_platform.cycle_candidate_selection
+            FOR EACH ROW
+            EXECUTE FUNCTION data_platform.raise_selection_insert_failure();
+            """
+        )
+
+    sqlalchemy_error = pytest.importorskip(
+        "sqlalchemy.exc",
+        reason="PostgreSQL freeze tests require SQLAlchemy",
+    ).SQLAlchemyError
+    with pytest.raises(sqlalchemy_error):
+        freeze_cycle_candidates("CYCLE_20260416")
+
+    metadata = get_cycle("CYCLE_20260416")
+    assert _selection_ids(cycle_engine, "CYCLE_20260416") == []
+    assert metadata.status == "pending"
+    assert metadata.cutoff_submitted_at is None
+    assert metadata.cutoff_ingest_seq is None
+    assert metadata.candidate_count == 0
+    assert metadata.selection_frozen_at is None
+
+
+@pytest.fixture()
+def postgres_dsn() -> Generator[str]:
+    admin_dsn = os.environ.get("DATABASE_URL") or os.environ.get("DP_PG_DSN")
+    if not admin_dsn:
+        pytest.skip("PostgreSQL freeze tests require DATABASE_URL or DP_PG_DSN")
+
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL freeze tests require SQLAlchemy",
+    )
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL freeze tests require the migration runner",
+    )
+    make_url = pytest.importorskip(
+        "sqlalchemy.engine",
+        reason="PostgreSQL freeze tests require SQLAlchemy",
+    ).make_url
+    sqlalchemy_error = pytest.importorskip(
+        "sqlalchemy.exc",
+        reason="PostgreSQL freeze tests require SQLAlchemy",
+    ).SQLAlchemyError
+
+    admin_engine = _create_engine(admin_dsn, isolation_level="AUTOCOMMIT")
+    database_name = f"dp_freeze_candidates_test_{uuid4().hex}"
+    try:
+        with admin_engine.connect() as connection:
+            connection.execute(sqlalchemy.text(f'CREATE DATABASE "{database_name}"'))
+    except sqlalchemy_error as exc:
+        admin_engine.dispose()
+        pytest.skip(
+            "PostgreSQL freeze tests require permission to create test databases: "
+            f"{exc}"
+        )
+
+    test_dsn = str(
+        make_url(runner_module._sqlalchemy_postgres_uri(admin_dsn)).set(
+            database=database_name,
+        )
+    )
+    try:
+        yield test_dsn
+    finally:
+        with admin_engine.connect() as connection:
+            connection.execute(
+                sqlalchemy.text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )
+            connection.execute(sqlalchemy.text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+        admin_engine.dispose()
+
+
+@pytest.fixture()
+def migrated_postgres_dsn(postgres_dsn: str) -> str:
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL freeze tests require the migration runner",
+    )
+    applied_versions = runner_module.MigrationRunner().apply_pending(postgres_dsn)
+    assert applied_versions == EXPECTED_MIGRATIONS
+    assert runner_module.MigrationRunner().apply_pending(postgres_dsn) == []
+    return postgres_dsn
+
+
+@pytest.fixture()
+def cycle_repository_env(
+    migrated_postgres_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[str]:
+    monkeypatch.setenv("DP_PG_DSN", migrated_postgres_dsn)
+    yield migrated_postgres_dsn
+
+
+@pytest.fixture()
+def cycle_engine(migrated_postgres_dsn: str) -> Generator[Any]:
+    engine = _create_engine(migrated_postgres_dsn)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def _insert_candidate(
+    connection: Any,
+    *,
+    validation_status: str,
+    candidate: str,
+) -> Mapping[str, Any]:
+    payload = {
+        "payload_type": "Ex-1",
+        "submitted_by": "freeze-test",
+        "candidate": candidate,
+    }
+    return connection.execute(
+        _text(
+            """
+            INSERT INTO data_platform.candidate_queue (
+                payload_type,
+                payload,
+                submitted_by,
+                validation_status,
+                rejection_reason
+            )
+            VALUES (
+                'Ex-1',
+                CAST(:payload AS jsonb),
+                'freeze-test',
+                CAST(:validation_status AS data_platform.validation_status),
+                :rejection_reason
+            )
+            RETURNING id, submitted_at, ingest_seq, validation_status
+            """
+        ),
+        {
+            "payload": json.dumps(payload, allow_nan=False),
+            "validation_status": validation_status,
+            "rejection_reason": (
+                "rejected by freeze test" if validation_status == "rejected" else None
+            ),
+        },
+    ).mappings().one()
+
+
+def _selection_ids(engine: Any, cycle_id: str) -> list[int]:
+    with engine.connect() as connection:
+        rows = connection.execute(
+            _text(
+                """
+                SELECT candidate_id
+                FROM data_platform.cycle_candidate_selection
+                WHERE cycle_id = :cycle_id
+                ORDER BY candidate_id ASC
+                """
+            ),
+            {"cycle_id": cycle_id},
+        ).scalars()
+        return [int(row) for row in rows]
+
+
+def _create_engine(dsn: str, **kwargs: object) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL freeze tests require SQLAlchemy",
+    )
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL freeze tests require the migration runner",
+    )
+    return sqlalchemy.create_engine(runner_module._sqlalchemy_postgres_uri(dsn), **kwargs)
+
+
+def _text(sql: str) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL freeze tests require SQLAlchemy",
+    )
+    return sqlalchemy.text(sql)

--- a/tests/cycle/test_freeze_cycle_candidates.py
+++ b/tests/cycle/test_freeze_cycle_candidates.py
@@ -166,6 +166,34 @@ def test_freeze_selects_only_accepted_candidates_and_sets_cutoffs(
     assert all(metadata.cutoff_submitted_at >= submitted_at for submitted_at in selected_submitted_at)
 
 
+def test_freeze_metadata_matches_actual_selection_rows(
+    cycle_repository_env: str,
+    cycle_engine: Any,
+) -> None:
+    create_cycle(date(2026, 4, 16))
+    with cycle_engine.begin() as connection:
+        for index in range(3):
+            _insert_candidate(
+                connection,
+                validation_status="accepted",
+                candidate=f"accepted-{index}",
+            )
+        _insert_candidate(
+            connection,
+            validation_status="rejected",
+            candidate="rejected",
+        )
+
+    metadata = freeze_cycle_candidates("CYCLE_20260416")
+    stats = _selection_stats(cycle_engine, "CYCLE_20260416")
+
+    assert stats == {
+        "candidate_count": metadata.candidate_count,
+        "cutoff_ingest_seq": metadata.cutoff_ingest_seq,
+        "cutoff_submitted_at": metadata.cutoff_submitted_at,
+    }
+
+
 def test_freeze_missing_cycle_raises_not_found(
     cycle_repository_env: str,
 ) -> None:
@@ -390,6 +418,26 @@ def _selection_ids(engine: Any, cycle_id: str) -> list[int]:
             {"cycle_id": cycle_id},
         ).scalars()
         return [int(row) for row in rows]
+
+
+def _selection_stats(engine: Any, cycle_id: str) -> dict[str, object]:
+    with engine.connect() as connection:
+        row = connection.execute(
+            _text(
+                """
+                SELECT
+                    count(*)::integer AS candidate_count,
+                    max(candidate_queue.ingest_seq) AS cutoff_ingest_seq,
+                    max(candidate_queue.submitted_at) AS cutoff_submitted_at
+                FROM data_platform.cycle_candidate_selection AS selection
+                JOIN data_platform.candidate_queue AS candidate_queue
+                  ON candidate_queue.id = selection.candidate_id
+                WHERE selection.cycle_id = :cycle_id
+                """
+            ),
+            {"cycle_id": cycle_id},
+        ).mappings().one()
+    return dict(row)
 
 
 def _create_engine(dsn: str, **kwargs: object) -> Any:

--- a/tests/ddl/test_runner.py
+++ b/tests/ddl/test_runner.py
@@ -7,12 +7,22 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import create_engine, text
-from sqlalchemy.engine import make_url
-from sqlalchemy.exc import SQLAlchemyError
 
-from data_platform.ddl import runner as runner_module
-from data_platform.ddl.runner import MigrationError, MigrationRunner
+sqlalchemy = pytest.importorskip(
+    "sqlalchemy",
+    reason="PostgreSQL migration tests require SQLAlchemy",
+)
+make_url = pytest.importorskip(
+    "sqlalchemy.engine",
+    reason="PostgreSQL migration tests require SQLAlchemy",
+).make_url
+SQLAlchemyError = pytest.importorskip(
+    "sqlalchemy.exc",
+    reason="PostgreSQL migration tests require SQLAlchemy",
+).SQLAlchemyError
+
+from data_platform.ddl import runner as runner_module  # noqa: E402
+from data_platform.ddl.runner import MigrationError, MigrationRunner  # noqa: E402
 
 
 def write_migration(migrations_path: Path, filename: str, sql: str) -> None:
@@ -26,11 +36,14 @@ def postgres_dsn() -> Generator[str]:
     if not admin_dsn:
         pytest.skip("PostgreSQL migration tests require DATABASE_URL or DP_PG_DSN")
 
-    admin_engine = create_engine(admin_dsn, isolation_level="AUTOCOMMIT")
+    admin_engine = sqlalchemy.create_engine(
+        runner_module._sqlalchemy_postgres_uri(admin_dsn),
+        isolation_level="AUTOCOMMIT",
+    )
     database_name = f"dp_migrations_test_{uuid4().hex}"
     try:
         with admin_engine.connect() as connection:
-            connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+            connection.execute(sqlalchemy.text(f'CREATE DATABASE "{database_name}"'))
     except SQLAlchemyError as exc:
         admin_engine.dispose()
         pytest.skip(
@@ -38,13 +51,17 @@ def postgres_dsn() -> Generator[str]:
             f"{exc}"
         )
 
-    test_dsn = str(make_url(admin_dsn).set(database=database_name))
+    test_dsn = str(
+        make_url(runner_module._sqlalchemy_postgres_uri(admin_dsn)).set(
+            database=database_name,
+        )
+    )
     try:
         yield test_dsn
     finally:
         with admin_engine.connect() as connection:
             connection.execute(
-                text(
+                sqlalchemy.text(
                     """
                     SELECT pg_terminate_backend(pid)
                     FROM pg_stat_activity
@@ -54,25 +71,25 @@ def postgres_dsn() -> Generator[str]:
                 ),
                 {"database_name": database_name},
             )
-            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+            connection.execute(sqlalchemy.text(f'DROP DATABASE IF EXISTS "{database_name}"'))
         admin_engine.dispose()
 
 
 def fetch_scalar(dsn: str, sql: str) -> object:
-    engine = create_engine(dsn)
+    engine = sqlalchemy.create_engine(runner_module._sqlalchemy_postgres_uri(dsn))
     try:
         with engine.connect() as connection:
-            return connection.execute(text(sql)).scalar_one()
+            return connection.execute(sqlalchemy.text(sql)).scalar_one()
     finally:
         engine.dispose()
 
 
 def fetch_versions(dsn: str) -> list[str]:
-    engine = create_engine(dsn)
+    engine = sqlalchemy.create_engine(runner_module._sqlalchemy_postgres_uri(dsn))
     try:
         with engine.connect() as connection:
             rows = connection.execute(
-                text("SELECT version FROM dp_schema_migrations ORDER BY version")
+                sqlalchemy.text("SELECT version FROM dp_schema_migrations ORDER BY version")
             ).scalars()
             return [str(row) for row in rows]
     finally:
@@ -115,9 +132,9 @@ def test_create_engine_rewrites_plain_postgres_dsn_to_psycopg(
 def test_apply_pending_is_idempotent_and_creates_schema(postgres_dsn: str) -> None:
     runner = MigrationRunner()
 
-    assert runner.apply_pending(postgres_dsn) == ["0001", "0002", "0003"]
+    assert runner.apply_pending(postgres_dsn) == ["0001", "0002", "0003", "0004"]
     assert runner.apply_pending(postgres_dsn) == []
-    assert fetch_versions(postgres_dsn) == ["0001", "0002", "0003"]
+    assert fetch_versions(postgres_dsn) == ["0001", "0002", "0003", "0004"]
     assert fetch_scalar(postgres_dsn, "SELECT to_regclass('public.dp_schema_migrations')")
     assert (
         fetch_scalar(

--- a/tests/queue/test_candidate_queue_schema.py
+++ b/tests/queue/test_candidate_queue_schema.py
@@ -104,7 +104,7 @@ def migrated_postgres_dsn(postgres_dsn: str) -> str:
         reason="PostgreSQL candidate queue schema tests require the migration runner",
     )
     applied_versions = runner_module.MigrationRunner().apply_pending(postgres_dsn)
-    assert applied_versions == ["0001", "0002", "0003"]
+    assert applied_versions == ["0001", "0002", "0003", "0004"]
     assert runner_module.MigrationRunner().apply_pending(postgres_dsn) == []
     return postgres_dsn
 


### PR DESCRIPTION
Closes #32

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/daily_refresh.py`


---
### 1. 背景与目标
项目文档 §11.1 明确 Lite 候选冻结必须在单个 PostgreSQL 事务内完成：读取 accepted 候选、写 `cycle_candidate_selection`、更新 `cycle_metadata` cutoff 字段后提交。#30 将队列状态推进到 accepted/rejected，#31 提供 cycle 元数据；当前代码还没有 selection 表和冻结事务。本 issue 实现 `freeze_cycle_candidates(cycle_id: str) -> CycleMetadata`，这是 P1c 的核心一致性边界。

### 2. 所属模块
`src/data_platform/cycle/` + `src/data_platform/ddl/migrations/`

### 3. 实现范围
- 新增 `src/data_platform/ddl/migrations/0004_cycle_candidate_selection.sql`，创建 `data_platform.cycle_candidate_selection` 表。
- 表字段包含 `cycle_id TEXT NOT NULL REFERENCES data_platform.cycle_metadata(cycle_id)`、`candidate_id BIGINT NOT NULL REFERENCES data_platform.candidate_queue(id)`、`selected_at TIMESTAMPTZ DEFAULT now()`，主键为 `(cycle_id, candidate_id)`。
- 新增 `src/data_platform/cycle/freeze.py`，实现 public API `freeze_cycle_candidates(cycle_id: str) -> CycleMetadata`，并在 `src/data_platform/cycle/__init__.py` re-export。
- 冻结事务内对 `cycle_metadata` 对应行 `FOR UPDATE`，仅读取 `candidate_queue.validation_status='accepted'` 且尚未被该 cycle 选择的候选，按当前事务快照写入 selection。
- 同一事务更新 `cutoff_submitted_at`、`cutoff_ingest_seq`、`candidate_count`、`selection_frozen_at`，并把 cycle 状态推进到 `phase0`。
- 新增 `tests/cycle/test_freeze_cycle_candidates.py`，覆盖空队列、有 accepted/rejected 混合、重复冻结、回滚和 cutoff 字段。

### 4. 不在本次范围
- 不创建或校验 pending 候选，依赖 #29/#30。
- 不发布 formal manifest，留给 #33。
- 不实现 Phase1/Phase2/Phase3 业务处理。
- 不删除或修改原始 `candidate_queue.payload`。

### 5. 关键交付物
- `@dataclass(frozen=True, slots=True) class CycleCandidateSelection`，字段包含 `cycle_id: str`、`candidate_id: int`、`selected_at: datetime`。
- `def freeze_cycle_candidates(cycle_id: str) -> CycleMetadata`，签名与项目文档 §16.1 保持一致。
- 错误类型：`CycleAlreadyFrozen`、`NoAcceptedCandidates`（如实现选择允许空冻结，则测试必须明确 `candidate_count == 0` 语义）、`CycleNotFound` 复用 #31。
- `CycleRepository.freeze_selection(...)` 私有/内部方法必须接收现有 SQLAlchemy `Connection`，确保所有写入共享同一事务。
- `cycle_metadata.cutoff_ingest_seq` 等于本轮 selection 中最大 `candidate_queue.ingest_seq`；空集合时为 `NULL`。
- `cycle_metadata.candidate_count` 等于本轮写入 `cycle_