### PR TITLE
feat(#81): fix: 3 dbt relationship test failures in CI

### DIFF
--- a/scripts/dbt.sh
+++ b/scripts/dbt.sh
@@ -18,4 +18,20 @@ fi
 # dbt 1.8+ removed --project-dir flag; use DBT_PROJECT_DIR env var instead
 # (already set above, compatible with dbt 1.5+)
 export DBT_PROJECT_DIR
-exec "${DBT_BIN}" "$@"
+
+DBT_ARGS=("$@")
+if [ "${1:-}" = "test" ]; then
+  HAS_INDIRECT_SELECTION=0
+  for arg in "$@"; do
+    if [ "${arg}" = "--indirect-selection" ]; then
+      HAS_INDIRECT_SELECTION=1
+      break
+    fi
+  done
+
+  if [ "${HAS_INDIRECT_SELECTION}" -eq 0 ]; then
+    DBT_ARGS=("test" "--indirect-selection" "cautious" "${@:2}")
+  fi
+fi
+
+exec "${DBT_BIN}" "${DBT_ARGS[@]}"

--- a/scripts/dbt.sh
+++ b/scripts/dbt.sh
@@ -19,19 +19,4 @@ fi
 # (already set above, compatible with dbt 1.5+)
 export DBT_PROJECT_DIR
 
-DBT_ARGS=("$@")
-if [ "${1:-}" = "test" ]; then
-  HAS_INDIRECT_SELECTION=0
-  for arg in "$@"; do
-    if [ "${arg}" = "--indirect-selection" ]; then
-      HAS_INDIRECT_SELECTION=1
-      break
-    fi
-  done
-
-  if [ "${HAS_INDIRECT_SELECTION}" -eq 0 ]; then
-    DBT_ARGS=("test" "--indirect-selection" "cautious" "${@:2}")
-  fi
-fi
-
-exec "${DBT_BIN}" "${DBT_ARGS[@]}"
+exec "${DBT_BIN}" "$@"

--- a/src/data_platform/dbt/models/intermediate/_schema.yml
+++ b/src/data_platform/dbt/models/intermediate/_schema.yml
@@ -112,6 +112,8 @@ models:
           - relationships:
               to: ref('stg_index_basic')
               field: ts_code
+              config:
+                severity: error
       - name: con_code
         tests:
           - not_null

--- a/src/data_platform/dbt/models/marts/_schema.yml
+++ b/src/data_platform/dbt/models/marts/_schema.yml
@@ -11,6 +11,8 @@ models:
           - relationships:
               to: ref('int_security_master')
               field: ts_code
+              config:
+                severity: error
       - name: list_date
         tests:
           - not_null

--- a/tests/dbt/test_dbt_skeleton.py
+++ b/tests/dbt/test_dbt_skeleton.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -120,3 +121,65 @@ def test_stg_stock_basic_preserves_p1a_contract() -> None:
     assert "canonical." not in lowered_model_sql
     assert "formal." not in lowered_model_sql
     assert "iceberg_scan" not in lowered_model_sql
+
+
+def test_dbt_wrapper_defaults_tests_to_cautious_indirect_selection(tmp_path: Path) -> None:
+    assert _run_dbt_wrapper_with_fake_dbt(
+        tmp_path, ["test", "--select", "intermediate"]
+    ) == [
+        "test",
+        "--indirect-selection",
+        "cautious",
+        "--select",
+        "intermediate",
+    ]
+
+
+def test_dbt_wrapper_preserves_explicit_indirect_selection(tmp_path: Path) -> None:
+    assert _run_dbt_wrapper_with_fake_dbt(
+        tmp_path,
+        [
+            "test",
+            "--indirect-selection",
+            "eager",
+            "--select",
+            "intermediate",
+        ],
+    ) == [
+        "test",
+        "--indirect-selection",
+        "eager",
+        "--select",
+        "intermediate",
+    ]
+
+
+def _run_dbt_wrapper_with_fake_dbt(tmp_path: Path, args: list[str]) -> list[str]:
+    fake_bin_dir = tmp_path / "bin"
+    fake_bin_dir.mkdir()
+    args_capture = tmp_path / "dbt_args.txt"
+    fake_dbt = fake_bin_dir / "dbt"
+    fake_dbt.write_text(
+        """
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${DBT_ARG_CAPTURE}"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    fake_dbt.chmod(0o755)
+
+    env = os.environ.copy()
+    env["DBT_ARG_CAPTURE"] = str(args_capture)
+    env["PATH"] = f"{fake_bin_dir}{os.pathsep}{env['PATH']}"
+
+    result = subprocess.run(
+        [str(PROJECT_ROOT / "scripts" / "dbt.sh"), *args],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    return args_capture.read_text(encoding="utf-8").splitlines()

--- a/tests/dbt/test_dbt_skeleton.py
+++ b/tests/dbt/test_dbt_skeleton.py
@@ -123,19 +123,17 @@ def test_stg_stock_basic_preserves_p1a_contract() -> None:
     assert "iceberg_scan" not in lowered_model_sql
 
 
-def test_dbt_wrapper_defaults_tests_to_cautious_indirect_selection(tmp_path: Path) -> None:
+def test_dbt_wrapper_does_not_mask_relationship_test_selection(tmp_path: Path) -> None:
     assert _run_dbt_wrapper_with_fake_dbt(
         tmp_path, ["test", "--select", "intermediate"]
     ) == [
         "test",
-        "--indirect-selection",
-        "cautious",
         "--select",
         "intermediate",
     ]
 
 
-def test_dbt_wrapper_preserves_explicit_indirect_selection(tmp_path: Path) -> None:
+def test_dbt_wrapper_preserves_explicit_test_selection_args(tmp_path: Path) -> None:
     assert _run_dbt_wrapper_with_fake_dbt(
         tmp_path,
         [

--- a/tests/dbt/test_intermediate_models.py
+++ b/tests/dbt/test_intermediate_models.py
@@ -189,6 +189,33 @@ def test_intermediate_models_execute_with_duckdb_raw_fixture(tmp_path: Path) -> 
     assert {"body", "content", "text"}.isdisjoint(event_columns)
 
 
+def test_index_membership_fixture_satisfies_index_basic_relationship(tmp_path: Path) -> None:
+    duckdb = pytest.importorskip("duckdb")
+
+    raw_zone_path = tmp_path / "raw"
+    _write_all_tushare_raw_fixtures(raw_zone_path, tmp_path)
+
+    connection = duckdb.connect(":memory:")
+    try:
+        _create_all_staging_views(connection, raw_zone_path)
+        _create_all_intermediate_tables(connection)
+
+        missing_index_codes = connection.execute(
+            """
+            select membership.index_code
+            from int_index_membership as membership
+            left join stg_index_basic as index_basic
+                on membership.index_code = index_basic.ts_code
+            where index_basic.ts_code is null
+            order by membership.index_code
+            """
+        ).fetchall()
+    finally:
+        connection.close()
+
+    assert missing_index_codes == []
+
+
 def test_financial_intermediate_combines_latest_metrics_by_source(tmp_path: Path) -> None:
     duckdb = pytest.importorskip("duckdb")
 

--- a/tests/dbt/test_intermediate_models.py
+++ b/tests/dbt/test_intermediate_models.py
@@ -78,6 +78,14 @@ def test_intermediate_sql_and_schema_contracts_are_present() -> None:
     financial_tests = declared_models["int_financial_reports_latest"]["tests"]
     assert any(_model_test_name(test) == "at_most_one_true_per_group" for test in financial_tests)
 
+    membership_columns = {
+        column["name"]: column for column in declared_models["int_index_membership"]["columns"]
+    }
+    index_code_relationship = _relationship_test(membership_columns["index_code"])
+    assert index_code_relationship["to"] == "ref('stg_index_basic')"
+    assert index_code_relationship["field"] == "ts_code"
+    assert index_code_relationship["config"]["severity"] == "error"
+
 
 def test_intermediate_models_execute_with_duckdb_raw_fixture(tmp_path: Path) -> None:
     duckdb = pytest.importorskip("duckdb")
@@ -325,6 +333,13 @@ def _model_test_name(test: str | dict[str, Any]) -> str:
     if isinstance(test, str):
         return test
     return next(iter(test))
+
+
+def _relationship_test(column: dict[str, Any]) -> dict[str, Any]:
+    for test in column.get("tests", []):
+        if isinstance(test, dict) and "relationships" in test:
+            return test["relationships"]
+    raise AssertionError(f"missing relationship test for column: {column['name']}")
 
 
 def _create_all_staging_views(connection: Any, raw_zone_path: Path) -> None:

--- a/tests/dbt/test_marts_models.py
+++ b/tests/dbt/test_marts_models.py
@@ -174,8 +174,8 @@ def test_marts_models_execute_with_duckdb_raw_fixture(tmp_path: Path) -> None:
     assert index_row == (
         "000300.SH",
         "index_name-fixture",
-        None,
-        None,
+        "market-fixture",
+        "category-fixture",
         date(2026, 4, 15),
         date(2026, 4, 15),
     )

--- a/tests/dbt/test_marts_models.py
+++ b/tests/dbt/test_marts_models.py
@@ -57,6 +57,12 @@ def test_marts_sql_and_schema_contracts_are_present() -> None:
     assert {"not_null", "unique"}.issubset(
         _test_names(_schema_column(declared_models["mart_dim_security"], "ts_code"))
     )
+    dim_security_relationship = _relationship_test(
+        _schema_column(declared_models["mart_dim_security"], "ts_code")
+    )
+    assert dim_security_relationship["to"] == "ref('int_security_master')"
+    assert dim_security_relationship["field"] == "ts_code"
+    assert dim_security_relationship["config"]["severity"] == "error"
     assert "not_null" in _test_names(
         _schema_column(declared_models["mart_dim_security"], "list_date")
     )
@@ -332,3 +338,10 @@ def _model_test_name(test: str | dict[str, Any]) -> str:
     if isinstance(test, str):
         return test
     return next(iter(test))
+
+
+def _relationship_test(column: dict[str, Any]) -> dict[str, Any]:
+    for test in column.get("tests", []):
+        if isinstance(test, dict) and "relationships" in test:
+            return test["relationships"]
+    raise AssertionError(f"missing relationship test for column: {column['name']}")

--- a/tests/dbt/test_tushare_staging_models.py
+++ b/tests/dbt/test_tushare_staging_models.py
@@ -516,6 +516,8 @@ def _sample_value(dataset: str, field: pa.Field) -> str | Decimal | None:
         if field.name == "f_ann_date":
             return "20260416"
         return "20260415"
+    if dataset == "index_basic" and field.name == "ts_code":
+        return "000300.SH"
     if field.name == "ts_code":
         return "000001.SZ"
     if field.name == "index_code":


### PR DESCRIPTION
Closes #81

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/cycle/__init__.py`


---
## 背景与目标
CI 中 3 个 dbt relationship test 持续失败（自 PR #70 起），本地 pytest pass 但 CI 的 dbt run+test 暴露了 schema 定义问题。

## 实现范围

### Failure 1: int_index_membership relationship
- File: `src/data_platform/dbt/models/intermediate/_schema.yml`
- Test: `relationships_int_index_membership_index_code__ts_code__ref_stg_index_basic_`
- Error: FAIL 1 — 1 row in int_index_membership.index_code 在 stg_index_basic.ts_code 中无匹配
- Fix: 检查 seed fixture 数据是否覆盖了所有 index_code，或修正 relationship 引用

### Failure 2: mart_dim_security relationship
- File: `src/data_platform/dbt/models/marts/_schema.yml`
- Test: `relationships_mart_dim_security_ts_code__ts_code__ref_int_security_master_`
- Error: Catalog Error — mart_dim_security 表在 test context 中未构建
- Fix: 确保 dbt run 在 test 前构建所有 upstream 依赖，或调整 test 执行顺序

### Failure 3: 同 #1 在 staging test context 重复

## 验收标准
- [ ] `python -m pytest tests/dbt/` 在 CI 环境下 0 failures
- [ ] relationship tests 全部 PASS

## 验证命令
```bash
./scripts/dbt.sh run && ./scripts/dbt.sh test
```

## 依赖
无