### PR TITLE
feat(#34): Formal Serving 通过 manifest 读取（latest / by_id / by_snapshot）

### DIFF
--- a/src/data_platform/cycle/__init__.py
+++ b/src/data_platform/cycle/__init__.py
@@ -18,8 +18,10 @@ from data_platform.cycle.manifest import (
     ManifestAlreadyPublished,
     PublishManifestNotFound,
     get_latest_publish_manifest,
+    get_publish_manifest_for_snapshot,
     get_publish_manifest,
     publish_manifest,
+    validate_snapshot_id,
 )
 from data_platform.cycle.repository import (
     CycleAlreadyFrozen,
@@ -56,6 +58,8 @@ __all__ = [
     "get_cycle",
     "get_latest_publish_manifest",
     "get_publish_manifest",
+    "get_publish_manifest_for_snapshot",
     "publish_manifest",
     "transition_cycle_status",
+    "validate_snapshot_id",
 ]

--- a/src/data_platform/cycle/manifest.py
+++ b/src/data_platform/cycle/manifest.py
@@ -237,6 +237,50 @@ def get_latest_publish_manifest() -> CyclePublishManifest:
         engine.dispose()
 
 
+def get_publish_manifest_for_snapshot(
+    snapshot_id: int,
+    table_identifier: str,
+) -> CyclePublishManifest:
+    """Return the newest manifest that publishes table_identifier at snapshot_id."""
+
+    validated_snapshot_id = validate_snapshot_id(snapshot_id)
+    validated_table_identifier = _validate_formal_table_key(table_identifier)
+    engine = _create_engine()
+    try:
+        with engine.connect() as connection:
+            row = (
+                connection.execute(
+                    _text(
+                        f"""
+                    SELECT
+                        published_cycle_id,
+                        published_at,
+                        formal_table_snapshots
+                    FROM {CYCLE_PUBLISH_MANIFEST_TABLE}
+                    WHERE jsonb_extract_path_text(
+                        formal_table_snapshots,
+                        :table_identifier,
+                        'snapshot_id'
+                    ) = :snapshot_id
+                    ORDER BY published_at DESC, published_cycle_id DESC
+                    LIMIT 1
+                    """
+                    ),
+                    {
+                        "table_identifier": validated_table_identifier,
+                        "snapshot_id": str(validated_snapshot_id),
+                    },
+                )
+                .mappings()
+                .one_or_none()
+            )
+            if row is None:
+                raise PublishManifestNotFound()
+            return _manifest_from_row(row)
+    finally:
+        engine.dispose()
+
+
 def _normalize_snapshot_manifest(
     formal_table_snapshots: Mapping[str, object],
 ) -> dict[str, FormalTableSnapshot]:
@@ -295,7 +339,9 @@ def _validate_formal_table_key(table: object) -> str:
     return table
 
 
-def _validate_snapshot_id(snapshot_id: object) -> int:
+def validate_snapshot_id(snapshot_id: object) -> int:
+    """Validate a formal table snapshot id from API or manifest input."""
+
     if isinstance(snapshot_id, bool) or not isinstance(snapshot_id, int):
         msg = f"snapshot_id must be a positive integer: {snapshot_id!r}"
         raise InvalidFormalSnapshotManifest(msg)
@@ -303,6 +349,10 @@ def _validate_snapshot_id(snapshot_id: object) -> int:
         msg = f"snapshot_id must be a positive integer: {snapshot_id!r}"
         raise InvalidFormalSnapshotManifest(msg)
     return snapshot_id
+
+
+def _validate_snapshot_id(snapshot_id: object) -> int:
+    return validate_snapshot_id(snapshot_id)
 
 
 def _snapshot_payload(
@@ -347,7 +397,9 @@ __all__ = [
     "InvalidFormalSnapshotManifest",
     "ManifestAlreadyPublished",
     "PublishManifestNotFound",
+    "get_publish_manifest_for_snapshot",
     "get_latest_publish_manifest",
     "get_publish_manifest",
     "publish_manifest",
+    "validate_snapshot_id",
 ]

--- a/src/data_platform/serving/__init__.py
+++ b/src/data_platform/serving/__init__.py
@@ -1,1 +1,25 @@
 """Formal serving package."""
+
+from data_platform.serving.formal import (
+    FormalManifestNotFound,
+    FormalObject,
+    FormalObjectTypeInvalid,
+    FormalSnapshotNotPublished,
+    FormalTableSnapshotNotFound,
+    formal_table_identifier,
+    get_formal_by_id,
+    get_formal_by_snapshot,
+    get_formal_latest,
+)
+
+__all__ = [
+    "FormalManifestNotFound",
+    "FormalObject",
+    "FormalObjectTypeInvalid",
+    "FormalSnapshotNotPublished",
+    "FormalTableSnapshotNotFound",
+    "formal_table_identifier",
+    "get_formal_by_id",
+    "get_formal_by_snapshot",
+    "get_formal_latest",
+]

--- a/src/data_platform/serving/formal.py
+++ b/src/data_platform/serving/formal.py
@@ -1,0 +1,219 @@
+"""Formal serving APIs backed by publish-manifest pinned Iceberg snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import pyarrow as pa  # type: ignore[import-untyped]
+
+from data_platform.cycle.manifest import (
+    CYCLE_PUBLISH_MANIFEST_TABLE,
+    CyclePublishManifest,
+    FormalTableSnapshot,
+    PublishManifestNotFound,
+    _manifest_from_row,
+    get_latest_publish_manifest,
+    get_publish_manifest,
+)
+from data_platform.cycle.repository import _create_engine, _text
+from data_platform.serving.catalog import load_catalog
+from data_platform.serving.reader import _validate_identifier
+
+
+FORMAL_NAMESPACE: Final[str] = "formal"
+
+
+class FormalObjectTypeInvalid(ValueError):
+    """Raised when object_type cannot be used as a formal table identifier."""
+
+    def __init__(self, object_type: object) -> None:
+        self.object_type = object_type
+        super().__init__(f"invalid formal object_type: {object_type!r}")
+
+
+class FormalManifestNotFound(LookupError):
+    """Raised when the required cycle publish manifest does not exist."""
+
+    def __init__(self, cycle_id: str | None = None) -> None:
+        self.cycle_id = cycle_id
+        if cycle_id is None:
+            super().__init__("formal publish manifest not found")
+        else:
+            super().__init__(f"formal publish manifest not found: {cycle_id}")
+
+
+class FormalSnapshotNotPublished(LookupError):
+    """Raised when a requested snapshot is not present in any publish manifest."""
+
+    def __init__(self, snapshot_id: int, table_identifier: str) -> None:
+        self.snapshot_id = snapshot_id
+        self.table_identifier = table_identifier
+        super().__init__(
+            f"formal snapshot is not published: {table_identifier} snapshot_id={snapshot_id}"
+        )
+
+
+class FormalTableSnapshotNotFound(LookupError):
+    """Raised when a publish manifest does not pin the requested formal table."""
+
+    def __init__(self, cycle_id: str, table_identifier: str) -> None:
+        self.cycle_id = cycle_id
+        self.table_identifier = table_identifier
+        super().__init__(
+            "formal table snapshot not found in publish manifest: "
+            f"{cycle_id} {table_identifier}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FormalObject:
+    """A formal object materialized from one manifest-pinned Iceberg snapshot."""
+
+    cycle_id: str
+    object_type: str
+    snapshot_id: int
+    payload: pa.Table
+
+
+def get_formal_latest(object_type: str) -> FormalObject:
+    """Read the newest published formal object for object_type."""
+
+    table_identifier = formal_table_identifier(object_type)
+    try:
+        manifest = get_latest_publish_manifest()
+    except PublishManifestNotFound as exc:
+        raise FormalManifestNotFound() from exc
+    return _formal_object_from_manifest(manifest, object_type, table_identifier)
+
+
+def get_formal_by_id(cycle_id: str, object_type: str) -> FormalObject:
+    """Read the formal object pinned by one published cycle_id."""
+
+    table_identifier = formal_table_identifier(object_type)
+    try:
+        manifest = get_publish_manifest(cycle_id)
+    except PublishManifestNotFound as exc:
+        raise FormalManifestNotFound(cycle_id) from exc
+    return _formal_object_from_manifest(manifest, object_type, table_identifier)
+
+
+def get_formal_by_snapshot(snapshot_id: int, object_type: str) -> FormalObject:
+    """Read a formal object only if snapshot_id has been published in a manifest."""
+
+    table_identifier = formal_table_identifier(object_type)
+    validated_snapshot_id = _validate_snapshot_id(snapshot_id)
+    manifest = _get_publish_manifest_for_snapshot(
+        validated_snapshot_id,
+        table_identifier,
+    )
+    snapshot = _snapshot_from_manifest(manifest, table_identifier)
+    if snapshot.snapshot_id != validated_snapshot_id:
+        raise FormalSnapshotNotPublished(validated_snapshot_id, table_identifier)
+    return FormalObject(
+        cycle_id=manifest.published_cycle_id,
+        object_type=object_type,
+        snapshot_id=snapshot.snapshot_id,
+        payload=_read_formal_snapshot(table_identifier, snapshot.snapshot_id),
+    )
+
+
+def formal_table_identifier(object_type: str) -> str:
+    """Return the manifest key and Iceberg identifier for one formal object type."""
+
+    try:
+        _validate_identifier(object_type)
+    except (TypeError, ValueError) as exc:
+        raise FormalObjectTypeInvalid(object_type) from exc
+    return f"{FORMAL_NAMESPACE}.{object_type}"
+
+
+def _formal_object_from_manifest(
+    manifest: CyclePublishManifest,
+    object_type: str,
+    table_identifier: str,
+) -> FormalObject:
+    snapshot = _snapshot_from_manifest(manifest, table_identifier)
+    return FormalObject(
+        cycle_id=manifest.published_cycle_id,
+        object_type=object_type,
+        snapshot_id=snapshot.snapshot_id,
+        payload=_read_formal_snapshot(table_identifier, snapshot.snapshot_id),
+    )
+
+
+def _snapshot_from_manifest(
+    manifest: CyclePublishManifest,
+    table_identifier: str,
+) -> FormalTableSnapshot:
+    snapshot = manifest.formal_table_snapshots.get(table_identifier)
+    if snapshot is None:
+        raise FormalTableSnapshotNotFound(manifest.published_cycle_id, table_identifier)
+    return snapshot
+
+
+def _read_formal_snapshot(table_identifier: str, snapshot_id: int) -> pa.Table:
+    table = load_catalog().load_table(table_identifier)
+    payload = table.scan(snapshot_id=snapshot_id).to_arrow()
+    if isinstance(payload, pa.Table):
+        return payload
+    msg = "formal Iceberg scan did not return a PyArrow table"
+    raise TypeError(msg)
+
+
+def _get_publish_manifest_for_snapshot(
+    snapshot_id: int,
+    table_identifier: str,
+) -> CyclePublishManifest:
+    engine = _create_engine()
+    try:
+        with engine.connect() as connection:
+            rows = (
+                connection.execute(
+                    _text(
+                        f"""
+                    SELECT
+                        published_cycle_id,
+                        published_at,
+                        formal_table_snapshots
+                    FROM {CYCLE_PUBLISH_MANIFEST_TABLE}
+                    ORDER BY published_at DESC, published_cycle_id DESC
+                    """
+                    )
+                )
+                .mappings()
+                .all()
+            )
+    finally:
+        engine.dispose()
+
+    for row in rows:
+        manifest = _manifest_from_row(row)
+        snapshot = manifest.formal_table_snapshots.get(table_identifier)
+        if snapshot is not None and snapshot.snapshot_id == snapshot_id:
+            return manifest
+
+    raise FormalSnapshotNotPublished(snapshot_id, table_identifier)
+
+
+def _validate_snapshot_id(snapshot_id: int) -> int:
+    if isinstance(snapshot_id, bool) or not isinstance(snapshot_id, int):
+        msg = f"snapshot_id must be a positive integer: {snapshot_id!r}"
+        raise ValueError(msg)
+    if snapshot_id < 1:
+        msg = f"snapshot_id must be a positive integer: {snapshot_id!r}"
+        raise ValueError(msg)
+    return snapshot_id
+
+
+__all__ = [
+    "FormalManifestNotFound",
+    "FormalObject",
+    "FormalObjectTypeInvalid",
+    "FormalSnapshotNotPublished",
+    "FormalTableSnapshotNotFound",
+    "formal_table_identifier",
+    "get_formal_by_id",
+    "get_formal_by_snapshot",
+    "get_formal_latest",
+]

--- a/src/data_platform/serving/formal.py
+++ b/src/data_platform/serving/formal.py
@@ -8,15 +8,15 @@ from typing import Final
 import pyarrow as pa  # type: ignore[import-untyped]
 
 from data_platform.cycle.manifest import (
-    CYCLE_PUBLISH_MANIFEST_TABLE,
     CyclePublishManifest,
     FormalTableSnapshot,
+    InvalidFormalSnapshotManifest,
     PublishManifestNotFound,
-    _manifest_from_row,
     get_latest_publish_manifest,
+    get_publish_manifest_for_snapshot,
     get_publish_manifest,
+    validate_snapshot_id,
 )
-from data_platform.cycle.repository import _create_engine, _text
 from data_platform.serving.catalog import load_catalog
 from data_platform.serving.reader import _validate_identifier
 
@@ -102,11 +102,17 @@ def get_formal_by_snapshot(snapshot_id: int, object_type: str) -> FormalObject:
     """Read a formal object only if snapshot_id has been published in a manifest."""
 
     table_identifier = formal_table_identifier(object_type)
-    validated_snapshot_id = _validate_snapshot_id(snapshot_id)
-    manifest = _get_publish_manifest_for_snapshot(
-        validated_snapshot_id,
-        table_identifier,
-    )
+    validated_snapshot_id = _validate_formal_snapshot_id(snapshot_id)
+    try:
+        manifest = get_publish_manifest_for_snapshot(
+            validated_snapshot_id,
+            table_identifier,
+        )
+    except PublishManifestNotFound as exc:
+        raise FormalSnapshotNotPublished(
+            validated_snapshot_id,
+            table_identifier,
+        ) from exc
     snapshot = _snapshot_from_manifest(manifest, table_identifier)
     if snapshot.snapshot_id != validated_snapshot_id:
         raise FormalSnapshotNotPublished(validated_snapshot_id, table_identifier)
@@ -161,49 +167,11 @@ def _read_formal_snapshot(table_identifier: str, snapshot_id: int) -> pa.Table:
     raise TypeError(msg)
 
 
-def _get_publish_manifest_for_snapshot(
-    snapshot_id: int,
-    table_identifier: str,
-) -> CyclePublishManifest:
-    engine = _create_engine()
+def _validate_formal_snapshot_id(snapshot_id: int) -> int:
     try:
-        with engine.connect() as connection:
-            rows = (
-                connection.execute(
-                    _text(
-                        f"""
-                    SELECT
-                        published_cycle_id,
-                        published_at,
-                        formal_table_snapshots
-                    FROM {CYCLE_PUBLISH_MANIFEST_TABLE}
-                    ORDER BY published_at DESC, published_cycle_id DESC
-                    """
-                    )
-                )
-                .mappings()
-                .all()
-            )
-    finally:
-        engine.dispose()
-
-    for row in rows:
-        manifest = _manifest_from_row(row)
-        snapshot = manifest.formal_table_snapshots.get(table_identifier)
-        if snapshot is not None and snapshot.snapshot_id == snapshot_id:
-            return manifest
-
-    raise FormalSnapshotNotPublished(snapshot_id, table_identifier)
-
-
-def _validate_snapshot_id(snapshot_id: int) -> int:
-    if isinstance(snapshot_id, bool) or not isinstance(snapshot_id, int):
-        msg = f"snapshot_id must be a positive integer: {snapshot_id!r}"
-        raise ValueError(msg)
-    if snapshot_id < 1:
-        msg = f"snapshot_id must be a positive integer: {snapshot_id!r}"
-        raise ValueError(msg)
-    return snapshot_id
+        return validate_snapshot_id(snapshot_id)
+    except InvalidFormalSnapshotManifest as exc:
+        raise ValueError(str(exc)) from exc
 
 
 __all__ = [

--- a/tests/serving/test_formal.py
+++ b/tests/serving/test_formal.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import os
+from collections.abc import Generator, Mapping
 from dataclasses import FrozenInstanceError, fields, is_dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 import importlib.util
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import pytest
 
@@ -168,7 +171,7 @@ def test_by_snapshot_reads_only_published_snapshot(
     monkeypatch.setattr(formal_module, "load_catalog", lambda: catalog)
     monkeypatch.setattr(
         formal_module,
-        "_get_publish_manifest_for_snapshot",
+        "get_publish_manifest_for_snapshot",
         published_lookup,
     )
 
@@ -208,12 +211,70 @@ def test_by_snapshot_rejects_unpublished_current_head_before_reading_table(
     monkeypatch.setattr(formal_module, "load_catalog", fail_load_catalog)
     monkeypatch.setattr(
         formal_module,
-        "_get_publish_manifest_for_snapshot",
+        "get_publish_manifest_for_snapshot",
         unpublished_lookup,
     )
 
     with pytest.raises(formal_module.FormalSnapshotNotPublished):
         formal_module.get_formal_by_snapshot(unpublished_snapshot_id, "recommendation_set")
+
+
+def test_by_snapshot_uses_db_backed_manifest_lookup(
+    formal_postgres_env: str,
+    monkeypatch: pytest.MonkeyPatch,
+    formal_module: Any,
+    pa_module: Any,
+) -> None:
+    target_snapshot_id = 98123
+    unpublished_snapshot_id = 98124
+    target_cycle_id = "CYCLE_20260201"
+
+    for day in range(1, 26):
+        _publish_formal_manifest(
+            date(2026, 1, day),
+            {"formal.other_object": 70000 + day},
+        )
+    _publish_formal_manifest(
+        date(2026, 2, 1),
+        {FORMAL_IDENTIFIER: target_snapshot_id},
+    )
+    for day in range(2, 10):
+        _publish_formal_manifest(
+            date(2026, 2, day),
+            {"formal.other_object": 80000 + day},
+        )
+
+    monkeypatch.setattr(
+        formal_module,
+        "load_catalog",
+        lambda: _fake_snapshot_catalog(
+            pa_module,
+            expected_snapshot_id=target_snapshot_id,
+        ),
+    )
+
+    formal_object = formal_module.get_formal_by_snapshot(
+        target_snapshot_id,
+        "recommendation_set",
+    )
+
+    assert formal_object.cycle_id == target_cycle_id
+    assert formal_object.snapshot_id == target_snapshot_id
+    assert formal_object.payload.column("version").to_pylist() == [
+        f"snapshot-{target_snapshot_id}"
+    ]
+    assert formal_object.payload.column("score").to_pylist() == [target_snapshot_id]
+
+    monkeypatch.setattr(
+        formal_module,
+        "load_catalog",
+        lambda: pytest.fail("unpublished snapshot must not read formal table head"),
+    )
+    with pytest.raises(formal_module.FormalSnapshotNotPublished):
+        formal_module.get_formal_by_snapshot(
+            unpublished_snapshot_id,
+            "recommendation_set",
+        )
 
 
 def test_missing_manifest_raises_formal_manifest_not_found(
@@ -314,3 +375,138 @@ def make_manifest(
             )
         },
     )
+
+
+@pytest.fixture()
+def postgres_dsn() -> Generator[str]:
+    admin_dsn = os.environ.get("DATABASE_URL") or os.environ.get("DP_PG_DSN")
+    if not admin_dsn:
+        pytest.skip("PostgreSQL formal serving tests require DATABASE_URL or DP_PG_DSN")
+
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL formal serving tests require SQLAlchemy",
+    )
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL formal serving tests require the migration runner",
+    )
+    make_url = pytest.importorskip(
+        "sqlalchemy.engine",
+        reason="PostgreSQL formal serving tests require SQLAlchemy",
+    ).make_url
+    sqlalchemy_error = pytest.importorskip(
+        "sqlalchemy.exc",
+        reason="PostgreSQL formal serving tests require SQLAlchemy",
+    ).SQLAlchemyError
+
+    admin_engine = _create_engine(admin_dsn, isolation_level="AUTOCOMMIT")
+    database_name = f"dp_formal_serving_test_{uuid4().hex}"
+    try:
+        with admin_engine.connect() as connection:
+            connection.execute(sqlalchemy.text(f'CREATE DATABASE "{database_name}"'))
+    except sqlalchemy_error as exc:
+        admin_engine.dispose()
+        pytest.skip(
+            "PostgreSQL formal serving tests require permission to create "
+            f"test databases: {exc}"
+        )
+
+    test_dsn = str(
+        make_url(runner_module._sqlalchemy_postgres_uri(admin_dsn)).set(
+            database=database_name,
+        )
+    )
+    try:
+        yield test_dsn
+    finally:
+        with admin_engine.connect() as connection:
+            connection.execute(
+                sqlalchemy.text(
+                    """
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = :database_name
+                      AND pid <> pg_backend_pid()
+                    """
+                ),
+                {"database_name": database_name},
+            )
+            connection.execute(sqlalchemy.text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+        admin_engine.dispose()
+
+
+@pytest.fixture()
+def migrated_postgres_dsn(postgres_dsn: str) -> str:
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL formal serving tests require the migration runner",
+    )
+    runner_module.MigrationRunner().apply_pending(postgres_dsn)
+    assert runner_module.MigrationRunner().apply_pending(postgres_dsn) == []
+    return postgres_dsn
+
+
+@pytest.fixture()
+def formal_postgres_env(
+    migrated_postgres_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[str]:
+    monkeypatch.setenv("DP_PG_DSN", migrated_postgres_dsn)
+    yield migrated_postgres_dsn
+
+
+def _publish_formal_manifest(
+    cycle_date: date,
+    snapshots: Mapping[str, int],
+) -> None:
+    from data_platform.cycle import (
+        create_cycle,
+        publish_manifest,
+        transition_cycle_status,
+    )
+
+    cycle = create_cycle(cycle_date)
+    for status in ("phase0", "phase1", "phase2", "phase3"):
+        transition_cycle_status(cycle.cycle_id, status)
+    publish_manifest(cycle.cycle_id, snapshots)
+
+
+def _fake_snapshot_catalog(
+    pa_module: Any,
+    *,
+    expected_snapshot_id: int,
+) -> object:
+    class FakeScan:
+        def to_arrow(self) -> Any:
+            return pa_module.table(
+                {
+                    "version": [f"snapshot-{expected_snapshot_id}"],
+                    "score": [expected_snapshot_id],
+                },
+                schema=formal_schema(pa_module),
+            )
+
+    class FakeTable:
+        def scan(self, *, snapshot_id: int) -> FakeScan:
+            assert snapshot_id == expected_snapshot_id
+            return FakeScan()
+
+    class FakeCatalog:
+        def load_table(self, table_identifier: str) -> FakeTable:
+            assert table_identifier == FORMAL_IDENTIFIER
+            return FakeTable()
+
+    return FakeCatalog()
+
+
+def _create_engine(dsn: str, **kwargs: object) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="PostgreSQL formal serving tests require SQLAlchemy",
+    )
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="PostgreSQL formal serving tests require the migration runner",
+    )
+    return sqlalchemy.create_engine(runner_module._sqlalchemy_postgres_uri(dsn), **kwargs)

--- a/tests/serving/test_formal.py
+++ b/tests/serving/test_formal.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, fields, is_dataclass
+from datetime import UTC, datetime
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from data_platform.cycle.manifest import (
+    CyclePublishManifest,
+    FormalTableSnapshot,
+    PublishManifestNotFound,
+)
+
+FORMAL_DEPS_MISSING = (
+    importlib.util.find_spec("pyarrow") is None
+    or importlib.util.find_spec("pyiceberg") is None
+)
+pytestmark = pytest.mark.skipif(
+    FORMAL_DEPS_MISSING,
+    reason="formal serving tests require PyArrow and PyIceberg",
+)
+
+
+FORMAL_IDENTIFIER = "formal.recommendation_set"
+
+
+@pytest.fixture()
+def pa_module() -> Any:
+    return pytest.importorskip("pyarrow", reason="formal serving tests require PyArrow")
+
+
+@pytest.fixture()
+def memory_catalog_class() -> Any:
+    module = pytest.importorskip(
+        "pyiceberg.catalog.memory",
+        reason="formal serving tests require PyIceberg",
+    )
+    return module.InMemoryCatalog
+
+
+@pytest.fixture()
+def formal_module() -> Any:
+    from data_platform.serving import formal
+
+    return formal
+
+
+def test_formal_object_model_exposes_contract(
+    formal_module: Any,
+    pa_module: Any,
+) -> None:
+    payload = pa_module.table(
+        {"version": ["v1"], "score": [1]},
+        schema=formal_schema(pa_module),
+    )
+    formal_object = formal_module.FormalObject(
+        cycle_id="CYCLE_20260416",
+        object_type="recommendation_set",
+        snapshot_id=123,
+        payload=payload,
+    )
+
+    assert is_dataclass(formal_module.FormalObject)
+    assert [field.name for field in fields(formal_module.FormalObject)] == [
+        "cycle_id",
+        "object_type",
+        "snapshot_id",
+        "payload",
+    ]
+    assert formal_module.FormalObject.__slots__ == (
+        "cycle_id",
+        "object_type",
+        "snapshot_id",
+        "payload",
+    )
+    assert formal_object.payload == payload
+    with pytest.raises(FrozenInstanceError):
+        formal_object.snapshot_id = 456
+
+
+def test_formal_table_identifier_validates_object_type(formal_module: Any) -> None:
+    assert formal_module.formal_table_identifier("recommendation_set") == FORMAL_IDENTIFIER
+
+    for object_type in ["formal.recommendation_set", "recommendation-set", "", " raw "]:
+        with pytest.raises(formal_module.FormalObjectTypeInvalid):
+            formal_module.formal_table_identifier(object_type)
+
+
+def test_latest_and_by_id_read_manifest_snapshots_not_formal_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    formal_module: Any,
+    memory_catalog_class: Any,
+    pa_module: Any,
+) -> None:
+    catalog = create_formal_catalog(tmp_path, memory_catalog_class, pa_module)
+    old_snapshot_id = write_formal_snapshot(catalog, pa_module, version="old", score=1)
+    latest_snapshot_id = write_formal_snapshot(
+        catalog,
+        pa_module,
+        version="latest",
+        score=2,
+    )
+    unpublished_head_snapshot_id = write_formal_snapshot(
+        catalog,
+        pa_module,
+        version="unpublished-head",
+        score=3,
+    )
+    old_manifest = make_manifest("CYCLE_20260416", old_snapshot_id)
+    latest_manifest = make_manifest("CYCLE_20260417", latest_snapshot_id)
+
+    monkeypatch.setattr(formal_module, "load_catalog", lambda: catalog)
+    monkeypatch.setattr(
+        formal_module,
+        "get_latest_publish_manifest",
+        lambda: latest_manifest,
+    )
+    monkeypatch.setattr(
+        formal_module,
+        "get_publish_manifest",
+        lambda cycle_id: {
+            "CYCLE_20260416": old_manifest,
+            "CYCLE_20260417": latest_manifest,
+        }[cycle_id],
+    )
+
+    latest = formal_module.get_formal_latest("recommendation_set")
+    old = formal_module.get_formal_by_id("CYCLE_20260416", "recommendation_set")
+
+    assert latest.cycle_id == "CYCLE_20260417"
+    assert latest.snapshot_id == latest_snapshot_id
+    assert latest.snapshot_id != unpublished_head_snapshot_id
+    assert latest.payload.column("version").to_pylist() == ["latest"]
+    assert latest.payload.column("score").to_pylist() == [2]
+
+    assert old.cycle_id == "CYCLE_20260416"
+    assert old.snapshot_id == old_snapshot_id
+    assert old.payload.column("version").to_pylist() == ["old"]
+    assert old.payload.column("score").to_pylist() == [1]
+
+
+def test_by_snapshot_reads_only_published_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    formal_module: Any,
+    memory_catalog_class: Any,
+    pa_module: Any,
+) -> None:
+    catalog = create_formal_catalog(tmp_path, memory_catalog_class, pa_module)
+    published_snapshot_id = write_formal_snapshot(
+        catalog,
+        pa_module,
+        version="published",
+        score=10,
+    )
+    published_manifest = make_manifest("CYCLE_20260416", published_snapshot_id)
+
+    def published_lookup(snapshot_id: int, table_identifier: str) -> CyclePublishManifest:
+        assert table_identifier == FORMAL_IDENTIFIER
+        if snapshot_id == published_snapshot_id:
+            return published_manifest
+        raise formal_module.FormalSnapshotNotPublished(snapshot_id, table_identifier)
+
+    monkeypatch.setattr(formal_module, "load_catalog", lambda: catalog)
+    monkeypatch.setattr(
+        formal_module,
+        "_get_publish_manifest_for_snapshot",
+        published_lookup,
+    )
+
+    formal_object = formal_module.get_formal_by_snapshot(
+        published_snapshot_id,
+        "recommendation_set",
+    )
+
+    assert formal_object.cycle_id == "CYCLE_20260416"
+    assert formal_object.snapshot_id == published_snapshot_id
+    assert formal_object.payload.column("version").to_pylist() == ["published"]
+    assert formal_object.payload.column("score").to_pylist() == [10]
+
+
+def test_by_snapshot_rejects_unpublished_current_head_before_reading_table(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    formal_module: Any,
+    memory_catalog_class: Any,
+    pa_module: Any,
+) -> None:
+    catalog = create_formal_catalog(tmp_path, memory_catalog_class, pa_module)
+    unpublished_snapshot_id = write_formal_snapshot(
+        catalog,
+        pa_module,
+        version="head",
+        score=99,
+    )
+
+    def unpublished_lookup(snapshot_id: int, table_identifier: str) -> CyclePublishManifest:
+        assert snapshot_id == unpublished_snapshot_id
+        raise formal_module.FormalSnapshotNotPublished(snapshot_id, table_identifier)
+
+    def fail_load_catalog() -> object:
+        pytest.fail("unpublished snapshot must be rejected before Iceberg read")
+
+    monkeypatch.setattr(formal_module, "load_catalog", fail_load_catalog)
+    monkeypatch.setattr(
+        formal_module,
+        "_get_publish_manifest_for_snapshot",
+        unpublished_lookup,
+    )
+
+    with pytest.raises(formal_module.FormalSnapshotNotPublished):
+        formal_module.get_formal_by_snapshot(unpublished_snapshot_id, "recommendation_set")
+
+
+def test_missing_manifest_raises_formal_manifest_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+    formal_module: Any,
+) -> None:
+    def missing_latest() -> CyclePublishManifest:
+        raise PublishManifestNotFound()
+
+    def missing_cycle(cycle_id: str) -> CyclePublishManifest:
+        raise PublishManifestNotFound(cycle_id)
+
+    monkeypatch.setattr(formal_module, "get_latest_publish_manifest", missing_latest)
+    monkeypatch.setattr(formal_module, "get_publish_manifest", missing_cycle)
+
+    with pytest.raises(formal_module.FormalManifestNotFound):
+        formal_module.get_formal_latest("recommendation_set")
+    with pytest.raises(formal_module.FormalManifestNotFound):
+        formal_module.get_formal_by_id("CYCLE_20260416", "recommendation_set")
+
+
+def test_manifest_without_object_type_raises_table_snapshot_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+    formal_module: Any,
+) -> None:
+    manifest = make_manifest(
+        "CYCLE_20260416",
+        snapshot_id=123,
+        table_identifier="formal.other_object",
+    )
+
+    def fail_load_catalog() -> object:
+        pytest.fail("missing manifest entry must be rejected before Iceberg read")
+
+    monkeypatch.setattr(formal_module, "get_latest_publish_manifest", lambda: manifest)
+    monkeypatch.setattr(formal_module, "load_catalog", fail_load_catalog)
+
+    with pytest.raises(formal_module.FormalTableSnapshotNotFound):
+        formal_module.get_formal_latest("recommendation_set")
+
+
+def formal_schema(pa_module: Any) -> Any:
+    return pa_module.schema(
+        [
+            pa_module.field("version", pa_module.string()),
+            pa_module.field("score", pa_module.int64()),
+        ]
+    )
+
+
+def create_formal_catalog(
+    tmp_path: Path,
+    memory_catalog_class: Any,
+    pa_module: Any,
+) -> Any:
+    catalog = memory_catalog_class(
+        "test",
+        warehouse=f"file://{tmp_path / 'warehouse'}",
+    )
+    catalog.create_namespace_if_not_exists(("formal",))
+    catalog.create_table(FORMAL_IDENTIFIER, schema=formal_schema(pa_module))
+    return catalog
+
+
+def write_formal_snapshot(
+    catalog: Any,
+    pa_module: Any,
+    *,
+    version: str,
+    score: int,
+) -> int:
+    table = catalog.load_table(FORMAL_IDENTIFIER)
+    table.overwrite(
+        pa_module.table(
+            {"version": [version], "score": [score]},
+            schema=formal_schema(pa_module),
+        )
+    )
+    snapshot = table.refresh().current_snapshot()
+    if snapshot is None:
+        raise AssertionError("formal table overwrite did not create a snapshot")
+    return int(snapshot.snapshot_id)
+
+
+def make_manifest(
+    cycle_id: str,
+    snapshot_id: int,
+    *,
+    table_identifier: str = FORMAL_IDENTIFIER,
+) -> CyclePublishManifest:
+    return CyclePublishManifest(
+        published_cycle_id=cycle_id,
+        published_at=datetime(2026, 4, 16, 10, 30, tzinfo=UTC),
+        formal_table_snapshots={
+            table_identifier: FormalTableSnapshot(
+                table=table_identifier,
+                snapshot_id=snapshot_id,
+            )
+        },
+    )


### PR DESCRIPTION
Closes #34

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/cycle/__init__.py`


---
### 1. 背景与目标
项目文档 §11.2 要求 Formal Serving 必须先读 `cycle_publish_manifest`，解析 snapshot 后再做 Iceberg time travel，禁止直读 formal head。现有 `src/data_platform/serving/reader.py` 只提供 canonical 读取，`src/data_platform/serving/catalog.py` 提供 catalog/warehouse 配置，#33 将补齐 manifest API。本 issue 新增 formal 读取接口，覆盖 latest、by_id、by_snapshot 三种语义。

### 2. 所属模块
`src/data_platform/serving/formal.py` + `src/data_platform/serving/__init__.py`

### 3. 实现范围
- 新增 `src/data_platform/serving/formal.py`，定义 `FormalObject` 和三个 public API：`get_formal_latest()`、`get_formal_by_id()`、`get_formal_by_snapshot()`。
- `get_formal_latest(object_type)` 调用 #33 的 `get_latest_publish_manifest()`，从 manifest 中定位 `formal.<object_type>` 的 `snapshot_id`。
- `get_formal_by_id(cycle_id, object_type)` 调用 `get_publish_manifest(cycle_id)`，按同样规则定位 snapshot。
- `get_formal_by_snapshot(snapshot_id, object_type)` 必须先在 `cycle_publish_manifest` 中确认该 snapshot 已发布，才能读取 Iceberg；未发布 snapshot 抛错。
- 读取实现复用 `load_catalog()` 获取 formal 表 location，并通过 DuckDB iceberg `iceberg_scan(..., snapshot_id := ?)` 或等价 PyIceberg time-travel API 返回 `pa.Table`；任何路径都不能调用当前 head 作为 fallback。
- 新增 `tests/serving/test_formal.py`，用临时 formal Iceberg 表 + manifest fixture 验证 latest/by_id/by_snapshot、缺失 manifest、缺失 object_type、未发布 snapshot。

### 4. 不在本次范围
- 不写 formal table，也不定义 main-core 的 formal object schema。
- 不修改 canonical reader 或 canonical writer。
- 不提供不带 manifest 的 `read_formal_head()` 调试入口。
- 不实现权限、多租户或远程 serving API。

### 5. 关键交付物
- `@dataclass(frozen=True, slots=True) class FormalObject`，字段包含 `cycle_id: str`、`object_type: str`、`snapshot_id: int`、`payload: pa.Table`。
- `def get_formal_latest(object_type: str) -> FormalObject`。
- `def get_formal_by_id(cycle_id: str, object_type: str) -> FormalObject`。
- `def get_formal_by_snapshot(snapshot_id: int, object_type: str) -> FormalObject`。
- 错误类型：`FormalObjectTypeInvalid`、`FormalManifestNotFound`、`FormalSnapshotNotPublished`、`FormalTableSnapshotNotFound`。
- Helper `formal_table_identifier(object_type: str) -> str` 