### PR TITLE
feat(#37): P1c 端到端 cycle 演练 smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: smoke-p1a
+.PHONY: smoke-p1a smoke-p1c
 
 smoke-p1a:
 	@scripts/smoke_p1a.sh
+
+smoke-p1c:
+	@./scripts/smoke_p1c.sh

--- a/scripts/smoke_p1c.sh
+++ b/scripts/smoke_p1c.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -d "${ROOT_DIR}/.venv/bin" ]]; then
+  export PATH="${ROOT_DIR}/.venv/bin:${PATH}"
+fi
+
+if [[ -z "${PYTHON:-}" ]]; then
+  if [[ -x "${ROOT_DIR}/.venv/bin/python" ]]; then
+    PYTHON="${ROOT_DIR}/.venv/bin/python"
+  else
+    PYTHON="python3"
+  fi
+fi
+
+if [[ -z "${DP_PG_DSN:-}" ]]; then
+  echo "P1c smoke failed: DP_PG_DSN is required" >&2
+  exit 2
+fi
+
+SMOKE_WORK_DIR="${DP_SMOKE_WORK_DIR:-${TMPDIR:-/tmp}/data-platform-p1c-smoke}"
+LOG_DIR="${DP_SMOKE_LOG_DIR:-${SMOKE_WORK_DIR}/logs}"
+
+export PYTHONPATH="${ROOT_DIR}/src:${PYTHONPATH:-}"
+export DP_SMOKE_WORK_DIR="${SMOKE_WORK_DIR}"
+export DP_RAW_ZONE_PATH="${DP_RAW_ZONE_PATH:-${SMOKE_WORK_DIR}/raw}"
+export DP_ICEBERG_WAREHOUSE_PATH="${DP_ICEBERG_WAREHOUSE_PATH:-${SMOKE_WORK_DIR}/warehouse}"
+export DP_DUCKDB_PATH="${DP_DUCKDB_PATH:-${SMOKE_WORK_DIR}/data_platform.duckdb}"
+export DP_ICEBERG_CATALOG_NAME="${DP_ICEBERG_CATALOG_NAME:-data_platform_p1c_smoke}"
+
+mkdir -p \
+  "${DP_RAW_ZONE_PATH}" \
+  "${DP_ICEBERG_WAREHOUSE_PATH}" \
+  "$(dirname "${DP_DUCKDB_PATH}")" \
+  "${LOG_DIR}"
+
+step_index=0
+
+run_step() {
+  local name="$1"
+  shift
+  step_index=$((step_index + 1))
+  local log_file="${LOG_DIR}/step_${step_index}.log"
+
+  printf '[smoke-p1c] step %d: %s\n' "${step_index}" "${name}"
+  if "$@" >"${log_file}" 2>&1; then
+    if [[ "${name}" == "runner" ]]; then
+      cat "${log_file}"
+    fi
+    return 0
+  fi
+
+  local exit_code=$?
+  {
+    printf '\n[smoke-p1c] step failed: %s (exit %d)\n' "${name}" "${exit_code}"
+    printf '[smoke-p1c] last 80 log lines from %s:\n' "${log_file}"
+    tail -n 80 "${log_file}" || true
+  } >&2
+  exit "${exit_code}"
+}
+
+run_step "migrate" "${PYTHON}" -m data_platform.ddl.runner --upgrade
+run_step "init catalog" "${PYTHON}" "${ROOT_DIR}/scripts/init_iceberg_catalog.py"
+run_step "runner" "${PYTHON}" -m data_platform.smoke.p1c

--- a/src/data_platform/cycle/repository.py
+++ b/src/data_platform/cycle/repository.py
@@ -142,8 +142,7 @@ class CycleRepository:
                       AND NOT EXISTS (
                           SELECT 1
                           FROM {CYCLE_CANDIDATE_SELECTION_TABLE} AS selection
-                          WHERE selection.cycle_id = :cycle_id
-                            AND selection.candidate_id = candidate_queue.id
+                          WHERE selection.candidate_id = candidate_queue.id
                       )
                     ORDER BY candidate_queue.ingest_seq ASC
                     RETURNING candidate_id

--- a/src/data_platform/cycle/repository.py
+++ b/src/data_platform/cycle/repository.py
@@ -100,6 +100,8 @@ class CycleRepository:
         Under PostgreSQL READ COMMITTED, the freeze boundary is the
         INSERT...SELECT statement start. Candidates accepted before that statement's
         snapshot are eligible; candidates accepted later wait for a future cycle.
+        Eligible candidate rows are locked with SKIP LOCKED so concurrent freezes
+        cannot select the same candidate into multiple cycles.
         Metadata is derived from the same inserted CTE so cutoffs and counts always
         describe the actual selected rows.
         """
@@ -129,14 +131,8 @@ class CycleRepository:
         row = connection.execute(
             _text(
                 f"""
-                WITH inserted AS (
-                    INSERT INTO {CYCLE_CANDIDATE_SELECTION_TABLE} (
-                        cycle_id,
-                        candidate_id
-                    )
-                    SELECT
-                        :cycle_id,
-                        candidate_queue.id
+                WITH locked_candidates AS (
+                    SELECT candidate_queue.id AS candidate_id
                     FROM {CANDIDATE_QUEUE_TABLE} AS candidate_queue
                     WHERE candidate_queue.validation_status = 'accepted'
                       AND NOT EXISTS (
@@ -145,6 +141,17 @@ class CycleRepository:
                           WHERE selection.candidate_id = candidate_queue.id
                       )
                     ORDER BY candidate_queue.ingest_seq ASC
+                    FOR UPDATE OF candidate_queue SKIP LOCKED
+                ),
+                inserted AS (
+                    INSERT INTO {CYCLE_CANDIDATE_SELECTION_TABLE} (
+                        cycle_id,
+                        candidate_id
+                    )
+                    SELECT
+                        :cycle_id,
+                        locked_candidates.candidate_id
+                    FROM locked_candidates
                     RETURNING candidate_id
                 ),
                 stats AS (

--- a/src/data_platform/smoke/__init__.py
+++ b/src/data_platform/smoke/__init__.py
@@ -1,0 +1,13 @@
+"""Smoke runners for milestone acceptance checks."""
+
+from data_platform.smoke.p1c import (
+    P1C_FORMAL_OBJECT_TYPE,
+    P1cSmokeResult,
+    run_p1c_smoke,
+)
+
+__all__ = [
+    "P1C_FORMAL_OBJECT_TYPE",
+    "P1cSmokeResult",
+    "run_p1c_smoke",
+]

--- a/src/data_platform/smoke/p1c.py
+++ b/src/data_platform/smoke/p1c.py
@@ -1,0 +1,480 @@
+"""P1c end-to-end smoke runner for queue, cycle, manifest, and formal serving."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+import json
+import sys
+from time import perf_counter_ns
+from types import MappingProxyType
+from typing import Any, Final, TypeVar
+from uuid import uuid4
+
+from data_platform.cycle import (
+    CycleAlreadyExists,
+    CycleMetadata,
+    create_cycle,
+    freeze_cycle_candidates,
+    publish_manifest,
+    transition_cycle_status,
+)
+from data_platform.queue import CandidateQueueItem, submit_candidate
+from data_platform.queue.worker import validate_pending_candidates
+
+
+P1C_FORMAL_OBJECT_TYPE: Final[str] = "p1c_smoke_object"
+P1C_FORMAL_TABLE_IDENTIFIER: Final[str] = f"formal.{P1C_FORMAL_OBJECT_TYPE}"
+P1C_SUBMITTED_BY: Final[str] = "p1c-smoke"
+P1C_CANDIDATE_COUNT: Final[int] = 3
+_REQUIRED_DURATION_STEPS: Final[tuple[str, ...]] = (
+    "submit",
+    "validate",
+    "freeze",
+    "publish_manifest",
+    "formal_latest",
+)
+_MAX_CYCLE_DATE_ATTEMPTS: Final[int] = 3660
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True, slots=True)
+class P1cSmokeResult:
+    """Result summary for one P1c smoke run."""
+
+    cycle_id: str
+    candidate_count: int
+    manifest_snapshot_id: int
+    duration_ms: Mapping[str, int]
+
+    def __post_init__(self) -> None:
+        if self.candidate_count < P1C_CANDIDATE_COUNT:
+            msg = f"candidate_count must be at least {P1C_CANDIDATE_COUNT}"
+            raise ValueError(msg)
+        if self.manifest_snapshot_id < 1:
+            msg = "manifest_snapshot_id must be a positive integer"
+            raise ValueError(msg)
+
+        durations = {str(step): int(duration) for step, duration in self.duration_ms.items()}
+        missing_steps = sorted(set(_REQUIRED_DURATION_STEPS).difference(durations))
+        if missing_steps:
+            msg = "duration_ms missing required smoke steps: " + ", ".join(missing_steps)
+            raise ValueError(msg)
+        object.__setattr__(self, "duration_ms", MappingProxyType(durations))
+
+    def to_json_payload(self) -> dict[str, object]:
+        """Return a JSON-serializable result payload."""
+
+        return {
+            "cycle_id": self.cycle_id,
+            "candidate_count": self.candidate_count,
+            "manifest_snapshot_id": self.manifest_snapshot_id,
+            "duration_ms": dict(self.duration_ms),
+        }
+
+
+def run_p1c_smoke(partition_date: date | None = None) -> P1cSmokeResult:
+    """Run the P1c submit, freeze, manifest, and formal-serving smoke."""
+
+    from data_platform.config import reset_settings_cache
+
+    if partition_date is not None and not isinstance(partition_date, date):
+        msg = "partition_date must be a datetime.date or None"
+        raise TypeError(msg)
+
+    reset_settings_cache()
+    started_ns = perf_counter_ns()
+    durations: dict[str, int] = {}
+    smoke_run_id = str(uuid4())
+    start_date = partition_date or date.today()
+
+    submitted = _measure_step(
+        durations,
+        "submit",
+        lambda: _submit_smoke_candidates(smoke_run_id),
+    )
+    _measure_step(
+        durations,
+        "validate",
+        lambda: validate_pending_candidates(limit=max(P1C_CANDIDATE_COUNT, 100)),
+    )
+    _assert_candidates_accepted(submitted)
+
+    cycle = _measure_step(
+        durations,
+        "create_cycle",
+        lambda: _create_next_available_cycle(start_date),
+    )
+    metadata = _measure_step(
+        durations,
+        "freeze",
+        lambda: freeze_cycle_candidates(cycle.cycle_id),
+    )
+    _assert_selection_matches_metadata(metadata, submitted)
+
+    _measure_step(
+        durations,
+        "transition",
+        lambda: _transition_to_phase3(cycle.cycle_id),
+    )
+    manifest = _measure_step(
+        durations,
+        "publish_manifest",
+        lambda: _write_formal_snapshot_and_publish(
+            cycle.cycle_id,
+            metadata.candidate_count,
+            smoke_run_id,
+        ),
+    )
+    manifest_snapshot_id = (
+        manifest.formal_table_snapshots[P1C_FORMAL_TABLE_IDENTIFIER].snapshot_id
+    )
+
+    latest = _measure_step(
+        durations,
+        "formal_latest",
+        lambda: _get_formal_latest(P1C_FORMAL_OBJECT_TYPE),
+    )
+    by_id = _measure_step(
+        durations,
+        "formal_by_id",
+        lambda: _get_formal_by_id(cycle.cycle_id, P1C_FORMAL_OBJECT_TYPE),
+    )
+    _assert_formal_serving_result(
+        cycle_id=cycle.cycle_id,
+        smoke_run_id=smoke_run_id,
+        snapshot_id=manifest_snapshot_id,
+        latest=latest,
+        by_id=by_id,
+    )
+
+    durations["total"] = int((perf_counter_ns() - started_ns) / 1_000_000)
+    return P1cSmokeResult(
+        cycle_id=cycle.cycle_id,
+        candidate_count=metadata.candidate_count,
+        manifest_snapshot_id=manifest_snapshot_id,
+        duration_ms=durations,
+    )
+
+
+def _submit_smoke_candidates(smoke_run_id: str) -> list[CandidateQueueItem]:
+    return [
+        submit_candidate(
+            {
+                "payload_type": "Ex-1",
+                "submitted_by": P1C_SUBMITTED_BY,
+                "smoke_run_id": smoke_run_id,
+                "candidate_index": index,
+                "object_type": P1C_FORMAL_OBJECT_TYPE,
+            }
+        )
+        for index in range(P1C_CANDIDATE_COUNT)
+    ]
+
+
+def _create_next_available_cycle(start_date: date) -> CycleMetadata:
+    cycle_date = start_date
+    for _attempt in range(_MAX_CYCLE_DATE_ATTEMPTS):
+        try:
+            return create_cycle(cycle_date)
+        except CycleAlreadyExists:
+            cycle_date += timedelta(days=1)
+
+    msg = (
+        "could not create an available smoke cycle within "
+        f"{_MAX_CYCLE_DATE_ATTEMPTS} days from {start_date.isoformat()}"
+    )
+    raise RuntimeError(msg)
+
+
+def _transition_to_phase3(cycle_id: str) -> CycleMetadata:
+    transition_cycle_status(cycle_id, "phase1")
+    transition_cycle_status(cycle_id, "phase2")
+    return transition_cycle_status(cycle_id, "phase3")
+
+
+def _write_formal_snapshot_and_publish(
+    cycle_id: str,
+    candidate_count: int,
+    smoke_run_id: str,
+) -> Any:
+    snapshot_id = _write_formal_fixture_snapshot(
+        cycle_id=cycle_id,
+        candidate_count=candidate_count,
+        smoke_run_id=smoke_run_id,
+    )
+    return publish_manifest(cycle_id, {P1C_FORMAL_TABLE_IDENTIFIER: snapshot_id})
+
+
+def _write_formal_fixture_snapshot(
+    *,
+    cycle_id: str,
+    candidate_count: int,
+    smoke_run_id: str,
+) -> int:
+    import pyarrow as pa  # type: ignore[import-untyped]
+
+    from data_platform.serving.catalog import ensure_namespaces, load_catalog
+
+    schema = _formal_fixture_schema(pa)
+    catalog = load_catalog()
+    ensure_namespaces(catalog, [("formal",)])
+    table = catalog.create_table_if_not_exists(
+        P1C_FORMAL_TABLE_IDENTIFIER,
+        schema=schema,
+    )
+    table.overwrite(
+        pa.table(
+            {
+                "cycle_id": [cycle_id],
+                "smoke_run_id": [smoke_run_id],
+                "candidate_count": [candidate_count],
+                "object_type": [P1C_FORMAL_OBJECT_TYPE],
+            },
+            schema=schema,
+        )
+    )
+    snapshot = table.refresh().current_snapshot()
+    if snapshot is None:
+        msg = "formal fixture overwrite did not create an Iceberg snapshot"
+        raise RuntimeError(msg)
+    return int(snapshot.snapshot_id)
+
+
+def _formal_fixture_schema(pa_module: Any) -> Any:
+    return pa_module.schema(
+        [
+            pa_module.field("cycle_id", pa_module.string()),
+            pa_module.field("smoke_run_id", pa_module.string()),
+            pa_module.field("candidate_count", pa_module.int64()),
+            pa_module.field("object_type", pa_module.string()),
+        ]
+    )
+
+
+def _get_formal_latest(object_type: str) -> Any:
+    from data_platform.serving.formal import get_formal_latest
+
+    return get_formal_latest(object_type)
+
+
+def _get_formal_by_id(cycle_id: str, object_type: str) -> Any:
+    from data_platform.serving.formal import get_formal_by_id
+
+    return get_formal_by_id(cycle_id, object_type)
+
+
+def _assert_candidates_accepted(submitted: Sequence[CandidateQueueItem]) -> None:
+    submitted_ids = [candidate.id for candidate in submitted]
+    statuses = _candidate_validation_statuses(submitted_ids)
+    missing_candidate_ids = sorted(set(submitted_ids).difference(statuses))
+    if missing_candidate_ids:
+        msg = "P1c smoke candidates were not found after validation: " + json.dumps(
+            missing_candidate_ids
+        )
+        raise RuntimeError(msg)
+
+    not_accepted = {
+        candidate_id: status
+        for candidate_id, status in statuses.items()
+        if status != "accepted"
+    }
+    if not_accepted:
+        msg = "P1c smoke candidates were not all accepted: " + json.dumps(
+            not_accepted,
+            sort_keys=True,
+        )
+        raise RuntimeError(msg)
+
+
+def _assert_selection_matches_metadata(
+    metadata: CycleMetadata,
+    submitted: Sequence[CandidateQueueItem],
+) -> None:
+    selection_ids = _selection_candidate_ids(metadata.cycle_id)
+    if len(selection_ids) != metadata.candidate_count:
+        msg = (
+            "cycle candidate_count does not match selection rows: "
+            f"{metadata.candidate_count} != {len(selection_ids)}"
+        )
+        raise RuntimeError(msg)
+
+    submitted_ids = {candidate.id for candidate in submitted}
+    missing_submitted_ids = sorted(submitted_ids.difference(selection_ids))
+    if missing_submitted_ids:
+        msg = "smoke candidates missing from frozen selection: " + json.dumps(
+            missing_submitted_ids
+        )
+        raise RuntimeError(msg)
+
+
+def _assert_formal_serving_result(
+    *,
+    cycle_id: str,
+    smoke_run_id: str,
+    snapshot_id: int,
+    latest: Any,
+    by_id: Any,
+) -> None:
+    if latest.snapshot_id != snapshot_id or by_id.snapshot_id != snapshot_id:
+        msg = (
+            "formal serving snapshot mismatch: "
+            f"manifest={snapshot_id} latest={latest.snapshot_id} by_id={by_id.snapshot_id}"
+        )
+        raise RuntimeError(msg)
+    if latest.cycle_id != cycle_id or by_id.cycle_id != cycle_id:
+        msg = (
+            "formal serving cycle mismatch: "
+            f"cycle={cycle_id} latest={latest.cycle_id} by_id={by_id.cycle_id}"
+        )
+        raise RuntimeError(msg)
+
+    for name, formal_object in (("latest", latest), ("by_id", by_id)):
+        payload = formal_object.payload
+        if payload.num_rows != 1:
+            msg = f"formal {name} payload should contain one row, got {payload.num_rows}"
+            raise RuntimeError(msg)
+        if payload.column("cycle_id").to_pylist() != [cycle_id]:
+            msg = f"formal {name} payload cycle_id does not match {cycle_id}"
+            raise RuntimeError(msg)
+        if payload.column("smoke_run_id").to_pylist() != [smoke_run_id]:
+            msg = f"formal {name} payload smoke_run_id does not match current run"
+            raise RuntimeError(msg)
+
+
+def _candidate_validation_statuses(candidate_ids: Sequence[int]) -> dict[int, str]:
+    if not candidate_ids:
+        return {}
+
+    engine = _create_engine()
+    try:
+        with engine.connect() as connection:
+            rows = list(
+                connection.execute(
+                    _text(
+                        """
+                        SELECT id, validation_status
+                        FROM data_platform.candidate_queue
+                        WHERE id = ANY(:candidate_ids)
+                        """
+                    ),
+                    {"candidate_ids": list(candidate_ids)},
+                )
+            )
+    finally:
+        engine.dispose()
+
+    return {int(row[0]): str(row[1]) for row in rows}
+
+
+def _selection_candidate_ids(cycle_id: str) -> list[int]:
+    engine = _create_engine()
+    try:
+        with engine.connect() as connection:
+            rows = list(
+                connection.execute(
+                    _text(
+                        """
+                        SELECT candidate_id
+                        FROM data_platform.cycle_candidate_selection
+                        WHERE cycle_id = :cycle_id
+                        ORDER BY candidate_id ASC
+                        """
+                    ),
+                    {"cycle_id": cycle_id},
+                )
+            )
+    finally:
+        engine.dispose()
+
+    return [int(row[0]) for row in rows]
+
+
+def _create_engine() -> Any:
+    from sqlalchemy import create_engine
+
+    from data_platform.config import get_settings
+
+    return create_engine(_sqlalchemy_postgres_uri(str(get_settings().pg_dsn)))
+
+
+def _text(sql: str) -> Any:
+    from sqlalchemy import text
+
+    return text(sql)
+
+
+def _sqlalchemy_postgres_uri(dsn: str) -> str:
+    if dsn.startswith("jdbc:postgresql://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("jdbc:postgresql://")
+    if dsn.startswith("postgresql://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgresql://")
+    if dsn.startswith("postgres://"):
+        return "postgresql+psycopg://" + dsn.removeprefix("postgres://")
+    return dsn
+
+
+def _measure_step(
+    durations: dict[str, int],
+    name: str,
+    action: Callable[[], _T],
+) -> _T:
+    started_ns = perf_counter_ns()
+    try:
+        return action()
+    finally:
+        durations[name] = int((perf_counter_ns() - started_ns) / 1_000_000)
+
+
+def _parse_partition_date(raw_value: str) -> date:
+    try:
+        return date.fromisoformat(raw_value)
+    except ValueError as exc:
+        msg = f"invalid ISO partition date: {raw_value!r}"
+        raise argparse.ArgumentTypeError(msg) from exc
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the P1c smoke and print JSON duration telemetry."""
+
+    parser = argparse.ArgumentParser(description="Run the P1c data-platform smoke.")
+    parser.add_argument(
+        "--partition-date",
+        type=_parse_partition_date,
+        default=None,
+        help="first cycle date to try, in YYYY-MM-DD form",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        result = run_p1c_smoke(partition_date=args.partition_date)
+    except Exception as exc:
+        print(
+            json.dumps(
+                {
+                    "error": str(exc),
+                    "error_type": exc.__class__.__name__,
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(result.to_json_payload(), sort_keys=True))
+    print("P1c smoke OK")
+    return 0
+
+
+__all__ = [
+    "P1C_FORMAL_OBJECT_TYPE",
+    "P1cSmokeResult",
+    "main",
+    "run_p1c_smoke",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/cycle/test_freeze_cycle_candidates.py
+++ b/tests/cycle/test_freeze_cycle_candidates.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import Generator, Mapping
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import FrozenInstanceError, fields, is_dataclass
 from datetime import UTC, date, datetime
+from threading import Barrier
 from typing import Any
 from uuid import uuid4
 
@@ -272,6 +274,64 @@ def test_selection_insert_failure_rolls_back_whole_freeze_transaction(
     assert metadata.cutoff_ingest_seq is None
     assert metadata.candidate_count == 0
     assert metadata.selection_frozen_at is None
+
+
+def test_concurrent_freezes_do_not_select_candidate_twice(
+    cycle_repository_env: str,
+    cycle_engine: Any,
+) -> None:
+    assert cycle_repository_env
+    create_cycle(date(2026, 4, 16))
+    create_cycle(date(2026, 4, 17))
+    with cycle_engine.begin() as connection:
+        accepted_ids = [
+            int(
+                _insert_candidate(
+                    connection,
+                    validation_status="accepted",
+                    candidate=f"concurrent-freeze-{index}",
+                )["id"]
+            )
+            for index in range(8)
+        ]
+        connection.exec_driver_sql(
+            """
+            CREATE OR REPLACE FUNCTION data_platform.slow_selection_insert()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                PERFORM pg_sleep(0.1);
+                RETURN NEW;
+            END;
+            $$;
+
+            CREATE TRIGGER slow_selection_insert
+            BEFORE INSERT ON data_platform.cycle_candidate_selection
+            FOR EACH ROW
+            EXECUTE FUNCTION data_platform.slow_selection_insert();
+            """
+        )
+
+    barrier = Barrier(2)
+
+    def freeze(cycle_id: str) -> Any:
+        barrier.wait(timeout=15)
+        return freeze_cycle_candidates(cycle_id)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_16 = executor.submit(freeze, "CYCLE_20260416")
+        future_17 = executor.submit(freeze, "CYCLE_20260417")
+        metadata_16 = future_16.result(timeout=30)
+        metadata_17 = future_17.result(timeout=30)
+
+    selection_16 = _selection_ids(cycle_engine, "CYCLE_20260416")
+    selection_17 = _selection_ids(cycle_engine, "CYCLE_20260417")
+
+    assert not set(selection_16).intersection(selection_17)
+    assert set(selection_16).union(selection_17).issubset(accepted_ids)
+    assert metadata_16.candidate_count == len(selection_16)
+    assert metadata_17.candidate_count == len(selection_17)
 
 
 @pytest.fixture()

--- a/tests/integration/test_p1c_smoke.py
+++ b/tests/integration/test_p1c_smoke.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from dataclasses import dataclass
+from datetime import date
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from data_platform.smoke.p1c import (
+    P1C_CANDIDATE_COUNT,
+    P1C_FORMAL_OBJECT_TYPE,
+    P1C_FORMAL_TABLE_IDENTIFIER,
+    P1cSmokeResult,
+    run_p1c_smoke,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+REQUIRED_DURATION_STEPS = {
+    "submit",
+    "validate",
+    "freeze",
+    "publish_manifest",
+    "formal_latest",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class P1cTestContext:
+    dsn: str
+    engine: Any
+
+
+def test_p1c_smoke_end_to_end(p1c_context: P1cTestContext) -> None:
+    first = run_p1c_smoke(partition_date=date(2026, 4, 16))
+    second = run_p1c_smoke(partition_date=date(2026, 4, 16))
+
+    _assert_smoke_result(first, "CYCLE_20260416", p1c_context.engine)
+    _assert_smoke_result(second, "CYCLE_20260417", p1c_context.engine)
+    assert first.cycle_id != second.cycle_id
+    assert first.manifest_snapshot_id != second.manifest_snapshot_id
+
+    from data_platform.cycle import get_publish_manifest
+    from data_platform.serving.formal import get_formal_by_id, get_formal_latest
+
+    first_manifest = get_publish_manifest(first.cycle_id)
+    second_manifest = get_publish_manifest(second.cycle_id)
+    assert (
+        first_manifest.formal_table_snapshots[P1C_FORMAL_TABLE_IDENTIFIER].snapshot_id
+        == first.manifest_snapshot_id
+    )
+    assert (
+        second_manifest.formal_table_snapshots[P1C_FORMAL_TABLE_IDENTIFIER].snapshot_id
+        == second.manifest_snapshot_id
+    )
+
+    latest = get_formal_latest(P1C_FORMAL_OBJECT_TYPE)
+    first_by_id = get_formal_by_id(first.cycle_id, P1C_FORMAL_OBJECT_TYPE)
+    second_by_id = get_formal_by_id(second.cycle_id, P1C_FORMAL_OBJECT_TYPE)
+
+    assert latest.snapshot_id == second.manifest_snapshot_id
+    assert latest.snapshot_id == second_by_id.snapshot_id
+    assert first_by_id.snapshot_id == first.manifest_snapshot_id
+    assert latest.payload.column("cycle_id").to_pylist() == [second.cycle_id]
+    assert first_by_id.payload.column("cycle_id").to_pylist() == [first.cycle_id]
+
+
+def test_smoke_p1c_script_requires_dp_pg_dsn(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env.pop("DP_PG_DSN", None)
+    env["DP_SMOKE_WORK_DIR"] = str(tmp_path / "p1c-smoke")
+    env["PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+
+    result = subprocess.run(
+        ["bash", str(PROJECT_ROOT / "scripts" / "smoke_p1c.sh")],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+    assert result.returncode == 2
+    assert "DP_PG_DSN is required" in result.stderr
+
+
+@pytest.fixture()
+def p1c_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[P1cTestContext]:
+    _require_p1c_dependencies()
+
+    admin_dsn = os.environ.get("DATABASE_URL") or os.environ.get("DP_PG_DSN")
+    if not admin_dsn:
+        pytest.skip("P1c smoke integration requires DATABASE_URL or DP_PG_DSN")
+
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="P1c smoke integration requires SQLAlchemy",
+    )
+    sqlalchemy_error = pytest.importorskip(
+        "sqlalchemy.exc",
+        reason="P1c smoke integration requires SQLAlchemy",
+    ).SQLAlchemyError
+    runner_module = pytest.importorskip(
+        "data_platform.ddl.runner",
+        reason="P1c smoke integration requires the migration runner",
+    )
+
+    database_name = f"dp_p1c_smoke_test_{uuid4().hex}"
+    admin_engine = _create_engine(admin_dsn, isolation_level="AUTOCOMMIT")
+    database_created = False
+    try:
+        try:
+            with admin_engine.connect() as connection:
+                connection.execute(sqlalchemy.text(f'CREATE DATABASE "{database_name}"'))
+            database_created = True
+        except sqlalchemy_error as exc:
+            pytest.skip(
+                "P1c smoke integration requires permission to create a test database: "
+                f"{exc}"
+            )
+
+        test_dsn = _database_dsn(admin_dsn, database_name)
+        runner_module.MigrationRunner().apply_pending(test_dsn)
+
+        monkeypatch.setenv("DP_PG_DSN", test_dsn)
+        monkeypatch.setenv("DP_RAW_ZONE_PATH", str(tmp_path / "raw"))
+        monkeypatch.setenv("DP_ICEBERG_WAREHOUSE_PATH", str(tmp_path / "warehouse"))
+        monkeypatch.setenv("DP_DUCKDB_PATH", str(tmp_path / "p1c.duckdb"))
+        monkeypatch.setenv("DP_ICEBERG_CATALOG_NAME", f"p1c_smoke_{uuid4().hex}")
+        _reset_settings_cache()
+        _initialize_catalog()
+
+        engine = _create_engine(test_dsn)
+        try:
+            yield P1cTestContext(dsn=test_dsn, engine=engine)
+        finally:
+            engine.dispose()
+            _reset_settings_cache()
+    finally:
+        if database_created:
+            with admin_engine.connect() as connection:
+                connection.execute(
+                    sqlalchemy.text(
+                        """
+                        SELECT pg_terminate_backend(pid)
+                        FROM pg_stat_activity
+                        WHERE datname = :database_name
+                          AND pid <> pg_backend_pid()
+                        """
+                    ),
+                    {"database_name": database_name},
+                )
+                connection.execute(
+                    sqlalchemy.text(f'DROP DATABASE IF EXISTS "{database_name}"')
+                )
+        admin_engine.dispose()
+
+
+def _assert_smoke_result(
+    result: P1cSmokeResult,
+    expected_cycle_id: str,
+    engine: Any,
+) -> None:
+    assert result.cycle_id == expected_cycle_id
+    assert result.candidate_count == P1C_CANDIDATE_COUNT
+    assert result.manifest_snapshot_id > 0
+    assert REQUIRED_DURATION_STEPS.issubset(result.duration_ms)
+    assert _selection_count(engine, result.cycle_id) == result.candidate_count
+
+
+def _selection_count(engine: Any, cycle_id: str) -> int:
+    with engine.connect() as connection:
+        return int(
+            connection.execute(
+                _text(
+                    """
+                    SELECT count(*)::integer
+                    FROM data_platform.cycle_candidate_selection
+                    WHERE cycle_id = :cycle_id
+                    """
+                ),
+                {"cycle_id": cycle_id},
+            ).scalar_one()
+        )
+
+
+def _initialize_catalog() -> None:
+    from data_platform.serving.catalog import DEFAULT_NAMESPACES, ensure_namespaces, load_catalog
+
+    catalog = load_catalog()
+    ensure_namespaces(catalog, DEFAULT_NAMESPACES)
+
+
+def _require_p1c_dependencies() -> None:
+    for module_name in ("pyarrow", "pyiceberg", "sqlalchemy", "pydantic_settings"):
+        pytest.importorskip(module_name, reason=f"P1c smoke integration requires {module_name}")
+
+
+def _create_engine(dsn: str, **kwargs: object) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="P1c smoke integration requires SQLAlchemy",
+    )
+    from data_platform.serving.catalog import _sqlalchemy_postgres_uri
+
+    return sqlalchemy.create_engine(_sqlalchemy_postgres_uri(dsn), **kwargs)
+
+
+def _database_dsn(admin_dsn: str, database_name: str) -> str:
+    make_url = pytest.importorskip(
+        "sqlalchemy.engine",
+        reason="P1c smoke integration requires SQLAlchemy",
+    ).make_url
+    return (
+        make_url(_plain_postgres_uri(admin_dsn))
+        .set(database=database_name)
+        .render_as_string(hide_password=False)
+    )
+
+
+def _plain_postgres_uri(dsn: str) -> str:
+    if dsn.startswith("jdbc:postgresql://"):
+        return "postgresql://" + dsn.removeprefix("jdbc:postgresql://")
+    if dsn.startswith("postgresql+psycopg://"):
+        return "postgresql://" + dsn.removeprefix("postgresql+psycopg://")
+    if dsn.startswith("postgres://"):
+        return "postgresql://" + dsn.removeprefix("postgres://")
+    return dsn
+
+
+def _text(sql: str) -> Any:
+    sqlalchemy = pytest.importorskip(
+        "sqlalchemy",
+        reason="P1c smoke integration requires SQLAlchemy",
+    )
+    return sqlalchemy.text(sql)
+
+
+def _reset_settings_cache() -> None:
+    from data_platform.config import reset_settings_cache
+
+    reset_settings_cache()


### PR DESCRIPTION
Closes #37

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`, `src/data_platform/cycle/__init__.py`


---
### 1. 背景与目标
项目文档 §21 阶段 2 的退出条件是候选冻结和 manifest 机制可单独演练通过，§23 第 3、4 条要求 Lite 队列、cycle 三表、publish manifest 以及下游读取接口可用。#35 和 #36 会分别覆盖冻结性能与 manifest 一致性，但还缺少一个单命令 smoke 串起 submit → validate → freeze → publish_manifest → formal serving。本 issue 提供 `make smoke-p1c`，作为 milestone-2 的最终验收入口。

### 2. 所属模块
`scripts/` + `tests/integration/` + `Makefile`

### 3. 实现范围
- 新增 `scripts/smoke_p1c.sh`，负责检查环境变量、执行 migrations、初始化 catalog/warehouse、调用 Python smoke runner，并在失败时打印关键日志。
- 新增 `scripts/smoke_p1c.py` 或 `src/data_platform/smoke/p1c.py`，按顺序调用 `submit_candidate()`、`validate_pending_candidates()`、`create_cycle()`、`freeze_cycle_candidates()`、`transition_cycle_status()`、`publish_manifest()`、`get_formal_latest()` / `get_formal_by_id()`。
- smoke runner 使用临时 formal Iceberg 表写入一个最小 formal object snapshot 来模拟 main-core 已完成 formal commit；只在 smoke/test helper 中直写 formal 表，生产 serving 仍必须经 manifest 读取。
- 新增 `tests/integration/test_p1c_smoke.py`，调用同一 runner，断言 selection、manifest、formal payload、重复运行幂等。
- 新增或更新 `Makefile`，加入 `smoke-p1c` target。
- stdout 成功时必须包含 `P1c smoke OK`，并输出各步骤耗时 JSON，便于 §19.1 性能基线观察。

### 4. 不在本次范围
- 不接入 Dagster、cron、daemon 或外部 orchestrator。
- 不调用真实 Tushare 或每日刷新 API；#27 已覆盖结构化数据 daily refresh smoke，本 issue 只覆盖 Layer B + cycle + formal serving。
- 不实现 main-core formal object 业务逻辑，只写最小 formal table fixture。
- 不扩展 contracts schema 或新增 L4-L7 业务判断。

### 5. 关键交付物
- `scripts/smoke_p1c.sh` 可执行，失败时退出码非零。
- `def run_p1c_smoke(partition_date: date | None = None) -> P1cSmokeResult`，其中 `P1cSmokeResult` 为 frozen dataclass，包含 `cycle_id`、`candidate_count`、`manifest_snapshot_id`、`duration_ms`。
- `Makefile` target：`smoke-p1c: ; ./scripts/smoke_p1c.sh`。
- `tests/integration/test_p1c_smoke.py::test_p1c_smoke_end_to_end` 调用真实 public APIs，不直接写队列表或 manifest 表。
- smoke 内 formal 读取必须调用 `data_platform.serving.formal.get_formal_latest()` 和 `get_formal_by_id()`，不能直接扫描 formal head。
- 运行日志包含每步名称：`submit`、`validate`、`freeze`、`publish_manifest`、`formal_latest`。

### 6. 验收标准
- [ ] `make smoke-p1c` 在干净 PG