### PR TITLE
feat(#88): [milestone-2 review] P0: Cycle can be marked published without a manifest

### DIFF
--- a/src/data_platform/cycle/repository.py
+++ b/src/data_platform/cycle/repository.py
@@ -24,9 +24,10 @@ _FORWARD_TRANSITIONS: Final[dict[CycleStatus, CycleStatus]] = {
     "phase0": "phase1",
     "phase1": "phase2",
     "phase2": "phase3",
-    "phase3": "published",
 }
-_FAILED_SOURCES: Final[frozenset[CycleStatus]] = frozenset(_FORWARD_TRANSITIONS)
+_FAILED_SOURCES: Final[frozenset[CycleStatus]] = frozenset(
+    ("pending", "phase0", "phase1", "phase2", "phase3")
+)
 
 
 class CycleAlreadyExists(RuntimeError):

--- a/tests/cycle/test_cycle_metadata.py
+++ b/tests/cycle/test_cycle_metadata.py
@@ -20,6 +20,7 @@ from data_platform.cycle import (
     InvalidCycleTransition,
     create_cycle,
     get_cycle,
+    publish_manifest,
     transition_cycle_status,
 )
 
@@ -277,11 +278,11 @@ def test_legal_cycle_status_transitions_pass(cycle_repository_env: str) -> None:
     create_cycle(date(2026, 4, 16))
     cycle_id = "CYCLE_20260416"
 
-    for status in ["phase0", "phase1", "phase2", "phase3", "published"]:
+    for status in ["phase0", "phase1", "phase2", "phase3"]:
         metadata = transition_cycle_status(cycle_id, status)
         assert metadata.status == status
 
-    assert get_cycle(cycle_id).status == "published"
+    assert get_cycle(cycle_id).status == "phase3"
 
 
 def test_direct_pending_to_published_transition_fails(cycle_repository_env: str) -> None:
@@ -320,8 +321,9 @@ def test_failed_status_can_be_entered_from_any_nonterminal_status(
 def test_published_cycle_cannot_transition_to_failed(cycle_repository_env: str) -> None:
     create_cycle(date(2026, 4, 16))
     cycle_id = "CYCLE_20260416"
-    for status in ["phase0", "phase1", "phase2", "phase3", "published"]:
+    for status in ["phase0", "phase1", "phase2", "phase3"]:
         transition_cycle_status(cycle_id, status)
+    publish_manifest(cycle_id, {"formal.recommendation_set": 123})
 
     with pytest.raises(InvalidCycleTransition):
         transition_cycle_status(cycle_id, "failed")

--- a/tests/cycle/test_publish_manifest.py
+++ b/tests/cycle/test_publish_manifest.py
@@ -203,18 +203,19 @@ def test_repeated_publish_raises_and_preserves_original_manifest(
     )
 
 
-def test_publish_manifest_rejects_published_cycle_without_manifest(
+def test_transition_cycle_status_cannot_publish_without_manifest(
     cycle_repository_env: str,
     cycle_engine: Any,
 ) -> None:
     create_cycle(date(2026, 4, 16))
     _advance_cycle_to_phase3("CYCLE_20260416")
-    transition_cycle_status("CYCLE_20260416", "published")
 
     with pytest.raises(InvalidCycleTransition):
-        publish_manifest("CYCLE_20260416", {"formal.recommendation_set": 123})
+        transition_cycle_status("CYCLE_20260416", "published")
 
-    assert get_cycle("CYCLE_20260416").status == "published"
+    assert get_cycle("CYCLE_20260416").status == "phase3"
+    with pytest.raises(PublishManifestNotFound):
+        get_publish_manifest("CYCLE_20260416")
     assert _manifest_count(cycle_engine) == 0
 
 


### PR DESCRIPTION
Closes #88

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `scripts/smoke_p1c.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
`transition_cycle_status` still allows the `phase3 -> published` transition through the generic state machine, while `transition_cycle_status` is exported as a public cycle API. That makes it possible to create a `cycle_metadata.status = 'published'` row with no `cycle_publish_manifest`, directly violating the manifest-as-consistency-anchor model that #33 and #34 depend on.

## 实现范围
- 修改文件: `src/data_platform/cycle/repository.py`
- Remove `phase3 -> published` from the generic transition map or make `transition_cycle_status(..., 'published')` reject. Keep the status update inside `publish_manifest` as the only publish path, and add a regression test proving a published cycle cannot exist without a manifest via public APIs.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/data-platform/.venv/bin/python -m pytest
```
