### PR TITLE
feat(#87): [milestone-2 review] P0: Formal Serving bypasses the required DuckDB read path

### DIFF
--- a/src/data_platform/serving/formal.py
+++ b/src/data_platform/serving/formal.py
@@ -17,8 +17,7 @@ from data_platform.cycle.manifest import (
     get_publish_manifest,
     validate_snapshot_id,
 )
-from data_platform.serving.catalog import load_catalog
-from data_platform.serving.reader import _validate_identifier
+import data_platform.serving.reader as serving_reader
 
 
 FORMAL_NAMESPACE: Final[str] = "formal"
@@ -128,7 +127,7 @@ def formal_table_identifier(object_type: str) -> str:
     """Return the manifest key and Iceberg identifier for one formal object type."""
 
     try:
-        _validate_identifier(object_type)
+        serving_reader._validate_identifier(object_type)
     except (TypeError, ValueError) as exc:
         raise FormalObjectTypeInvalid(object_type) from exc
     return f"{FORMAL_NAMESPACE}.{object_type}"
@@ -159,11 +158,10 @@ def _snapshot_from_manifest(
 
 
 def _read_formal_snapshot(table_identifier: str, snapshot_id: int) -> pa.Table:
-    table = load_catalog().load_table(table_identifier)
-    payload = table.scan(snapshot_id=snapshot_id).to_arrow()
+    payload = serving_reader.read_iceberg_snapshot(table_identifier, snapshot_id)
     if isinstance(payload, pa.Table):
         return payload
-    msg = "formal Iceberg scan did not return a PyArrow table"
+    msg = "formal DuckDB Iceberg scan did not return a PyArrow table"
     raise TypeError(msg)
 
 

--- a/src/data_platform/serving/reader.py
+++ b/src/data_platform/serving/reader.py
@@ -74,6 +74,19 @@ FROM {_canonical_table_expression(table)}
             raise
 
 
+def read_iceberg_snapshot(table_identifier: str, snapshot_id: int) -> pa.Table:
+    """Read one Iceberg table snapshot through DuckDB time travel."""
+
+    validated_snapshot_id = _validate_snapshot_id(snapshot_id)
+    sql = f"""
+SELECT *
+FROM {_iceberg_snapshot_expression(table_identifier, validated_snapshot_id)}
+"""
+
+    with with_duckdb_connection() as connection:
+        return connection.execute(sql).to_arrow_table()
+
+
 def get_canonical_stock_basic(active_only: bool = True) -> pa.Table:
     """Read canonical.stock_basic, filtering to active rows by default."""
 
@@ -169,9 +182,16 @@ def _canonical_table_expression(table: str) -> str:
     return f"iceberg_scan({_sql_string_literal(str(latest_metadata_location))})"
 
 
+def _iceberg_snapshot_expression(table_identifier: str, snapshot_id: int) -> str:
+    metadata_location = _latest_metadata_location_for_identifier(table_identifier)
+    return (
+        f"iceberg_scan({_sql_string_literal(str(metadata_location))}, "
+        f"snapshot_from_id = {snapshot_id})"
+    )
+
+
 def _canonical_table_location(table: str) -> Path:
-    warehouse_path = get_settings().iceberg_warehouse_path.expanduser()
-    return warehouse_path / CANONICAL_NAMESPACE / table
+    return _iceberg_table_location(f"{CANONICAL_NAMESPACE}.{table}")
 
 
 def _latest_metadata_location(table: str) -> Path:
@@ -180,6 +200,21 @@ def _latest_metadata_location(table: str) -> Path:
     if metadata_files:
         return metadata_files[-1]
     raise CanonicalTableNotFound(table)
+
+
+def _latest_metadata_location_for_identifier(table_identifier: str) -> Path:
+    metadata_dir = _iceberg_table_location(table_identifier) / "metadata"
+    metadata_files = sorted(metadata_dir.glob("*.metadata.json"))
+    if metadata_files:
+        return metadata_files[-1]
+    msg = f"Iceberg table metadata not found: {table_identifier}"
+    raise FileNotFoundError(msg)
+
+
+def _iceberg_table_location(table_identifier: str) -> Path:
+    parts = _validate_table_identifier(table_identifier)
+    warehouse_path = get_settings().iceberg_warehouse_path.expanduser()
+    return warehouse_path.joinpath(*parts)
 
 
 def _canonical_mart_snapshot_entry(table: str) -> dict[str, str | int] | None:
@@ -218,6 +253,32 @@ def _validate_identifier(identifier: str) -> None:
     raise ValueError(msg)
 
 
+def _validate_table_identifier(table_identifier: str) -> tuple[str, ...]:
+    if not isinstance(table_identifier, str):
+        msg = f"table_identifier must be a string: {table_identifier!r}"
+        raise TypeError(msg)
+    if table_identifier != table_identifier.strip():
+        msg = f"table_identifier must not include surrounding whitespace: {table_identifier!r}"
+        raise ValueError(msg)
+    parts = tuple(table_identifier.split("."))
+    if len(parts) < 2:
+        msg = f"table_identifier must include a namespace and table: {table_identifier!r}"
+        raise ValueError(msg)
+    for part in parts:
+        _validate_identifier(part)
+    return parts
+
+
+def _validate_snapshot_id(snapshot_id: int) -> int:
+    if isinstance(snapshot_id, bool) or not isinstance(snapshot_id, int):
+        msg = f"snapshot_id must be a positive integer: {snapshot_id!r}"
+        raise ValueError(msg)
+    if snapshot_id < 1:
+        msg = f"snapshot_id must be a positive integer: {snapshot_id!r}"
+        raise ValueError(msg)
+    return snapshot_id
+
+
 def _sql_string_literal(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
@@ -236,5 +297,6 @@ __all__ = [
     "UnsupportedFilter",
     "get_canonical_stock_basic",
     "read_canonical",
+    "read_iceberg_snapshot",
     "with_duckdb_connection",
 ]

--- a/tests/serving/test_formal.py
+++ b/tests/serving/test_formal.py
@@ -5,7 +5,6 @@ from collections.abc import Generator, Mapping
 from dataclasses import FrozenInstanceError, fields, is_dataclass
 from datetime import UTC, date, datetime
 import importlib.util
-from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -17,13 +16,10 @@ from data_platform.cycle.manifest import (
     PublishManifestNotFound,
 )
 
-FORMAL_DEPS_MISSING = (
-    importlib.util.find_spec("pyarrow") is None
-    or importlib.util.find_spec("pyiceberg") is None
-)
+FORMAL_DEPS_MISSING = importlib.util.find_spec("pyarrow") is None
 pytestmark = pytest.mark.skipif(
     FORMAL_DEPS_MISSING,
-    reason="formal serving tests require PyArrow and PyIceberg",
+    reason="formal serving tests require PyArrow",
 )
 
 
@@ -33,15 +29,6 @@ FORMAL_IDENTIFIER = "formal.recommendation_set"
 @pytest.fixture()
 def pa_module() -> Any:
     return pytest.importorskip("pyarrow", reason="formal serving tests require PyArrow")
-
-
-@pytest.fixture()
-def memory_catalog_class() -> Any:
-    module = pytest.importorskip(
-        "pyiceberg.catalog.memory",
-        reason="formal serving tests require PyIceberg",
-    )
-    return module.InMemoryCatalog
 
 
 @pytest.fixture()
@@ -93,30 +80,32 @@ def test_formal_table_identifier_validates_object_type(formal_module: Any) -> No
 
 
 def test_latest_and_by_id_read_manifest_snapshots_not_formal_head(
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     formal_module: Any,
-    memory_catalog_class: Any,
     pa_module: Any,
 ) -> None:
-    catalog = create_formal_catalog(tmp_path, memory_catalog_class, pa_module)
-    old_snapshot_id = write_formal_snapshot(catalog, pa_module, version="old", score=1)
-    latest_snapshot_id = write_formal_snapshot(
-        catalog,
-        pa_module,
-        version="latest",
-        score=2,
-    )
-    unpublished_head_snapshot_id = write_formal_snapshot(
-        catalog,
-        pa_module,
-        version="unpublished-head",
-        score=3,
-    )
+    old_snapshot_id = 101
+    latest_snapshot_id = 202
+    unpublished_head_snapshot_id = 303
     old_manifest = make_manifest("CYCLE_20260416", old_snapshot_id)
     latest_manifest = make_manifest("CYCLE_20260417", latest_snapshot_id)
+    payloads = {
+        old_snapshot_id: formal_payload(pa_module, version="old", score=1),
+        latest_snapshot_id: formal_payload(pa_module, version="latest", score=2),
+    }
+    read_calls: list[tuple[str, int]] = []
 
-    monkeypatch.setattr(formal_module, "load_catalog", lambda: catalog)
+    def read_iceberg_snapshot(table_identifier: str, snapshot_id: int) -> Any:
+        assert table_identifier == FORMAL_IDENTIFIER
+        assert snapshot_id != unpublished_head_snapshot_id
+        read_calls.append((table_identifier, snapshot_id))
+        return payloads[snapshot_id]
+
+    monkeypatch.setattr(
+        formal_module.serving_reader,
+        "read_iceberg_snapshot",
+        read_iceberg_snapshot,
+    )
     monkeypatch.setattr(
         formal_module,
         "get_latest_publish_manifest",
@@ -144,23 +133,20 @@ def test_latest_and_by_id_read_manifest_snapshots_not_formal_head(
     assert old.snapshot_id == old_snapshot_id
     assert old.payload.column("version").to_pylist() == ["old"]
     assert old.payload.column("score").to_pylist() == [1]
+    assert read_calls == [
+        (FORMAL_IDENTIFIER, latest_snapshot_id),
+        (FORMAL_IDENTIFIER, old_snapshot_id),
+    ]
 
 
 def test_by_snapshot_reads_only_published_snapshot(
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     formal_module: Any,
-    memory_catalog_class: Any,
     pa_module: Any,
 ) -> None:
-    catalog = create_formal_catalog(tmp_path, memory_catalog_class, pa_module)
-    published_snapshot_id = write_formal_snapshot(
-        catalog,
-        pa_module,
-        version="published",
-        score=10,
-    )
+    published_snapshot_id = 404
     published_manifest = make_manifest("CYCLE_20260416", published_snapshot_id)
+    read_calls: list[tuple[str, int]] = []
 
     def published_lookup(snapshot_id: int, table_identifier: str) -> CyclePublishManifest:
         assert table_identifier == FORMAL_IDENTIFIER
@@ -168,7 +154,15 @@ def test_by_snapshot_reads_only_published_snapshot(
             return published_manifest
         raise formal_module.FormalSnapshotNotPublished(snapshot_id, table_identifier)
 
-    monkeypatch.setattr(formal_module, "load_catalog", lambda: catalog)
+    def read_iceberg_snapshot(table_identifier: str, snapshot_id: int) -> Any:
+        read_calls.append((table_identifier, snapshot_id))
+        return formal_payload(pa_module, version="published", score=10)
+
+    monkeypatch.setattr(
+        formal_module.serving_reader,
+        "read_iceberg_snapshot",
+        read_iceberg_snapshot,
+    )
     monkeypatch.setattr(
         formal_module,
         "get_publish_manifest_for_snapshot",
@@ -184,31 +178,27 @@ def test_by_snapshot_reads_only_published_snapshot(
     assert formal_object.snapshot_id == published_snapshot_id
     assert formal_object.payload.column("version").to_pylist() == ["published"]
     assert formal_object.payload.column("score").to_pylist() == [10]
+    assert read_calls == [(FORMAL_IDENTIFIER, published_snapshot_id)]
 
 
 def test_by_snapshot_rejects_unpublished_current_head_before_reading_table(
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     formal_module: Any,
-    memory_catalog_class: Any,
-    pa_module: Any,
 ) -> None:
-    catalog = create_formal_catalog(tmp_path, memory_catalog_class, pa_module)
-    unpublished_snapshot_id = write_formal_snapshot(
-        catalog,
-        pa_module,
-        version="head",
-        score=99,
-    )
+    unpublished_snapshot_id = 505
 
     def unpublished_lookup(snapshot_id: int, table_identifier: str) -> CyclePublishManifest:
         assert snapshot_id == unpublished_snapshot_id
         raise formal_module.FormalSnapshotNotPublished(snapshot_id, table_identifier)
 
-    def fail_load_catalog() -> object:
-        pytest.fail("unpublished snapshot must be rejected before Iceberg read")
+    def fail_read_iceberg_snapshot(table_identifier: str, snapshot_id: int) -> object:
+        pytest.fail("unpublished snapshot must be rejected before DuckDB Iceberg read")
 
-    monkeypatch.setattr(formal_module, "load_catalog", fail_load_catalog)
+    monkeypatch.setattr(
+        formal_module.serving_reader,
+        "read_iceberg_snapshot",
+        fail_read_iceberg_snapshot,
+    )
     monkeypatch.setattr(
         formal_module,
         "get_publish_manifest_for_snapshot",
@@ -244,13 +234,22 @@ def test_by_snapshot_uses_db_backed_manifest_lookup(
             {"formal.other_object": 80000 + day},
         )
 
-    monkeypatch.setattr(
-        formal_module,
-        "load_catalog",
-        lambda: _fake_snapshot_catalog(
+    read_calls: list[tuple[str, int]] = []
+
+    def read_iceberg_snapshot(table_identifier: str, snapshot_id: int) -> Any:
+        assert table_identifier == FORMAL_IDENTIFIER
+        assert snapshot_id == target_snapshot_id
+        read_calls.append((table_identifier, snapshot_id))
+        return formal_payload(
             pa_module,
-            expected_snapshot_id=target_snapshot_id,
-        ),
+            version=f"snapshot-{target_snapshot_id}",
+            score=target_snapshot_id,
+        )
+
+    monkeypatch.setattr(
+        formal_module.serving_reader,
+        "read_iceberg_snapshot",
+        read_iceberg_snapshot,
     )
 
     formal_object = formal_module.get_formal_by_snapshot(
@@ -264,11 +263,14 @@ def test_by_snapshot_uses_db_backed_manifest_lookup(
         f"snapshot-{target_snapshot_id}"
     ]
     assert formal_object.payload.column("score").to_pylist() == [target_snapshot_id]
+    assert read_calls == [(FORMAL_IDENTIFIER, target_snapshot_id)]
 
     monkeypatch.setattr(
-        formal_module,
-        "load_catalog",
-        lambda: pytest.fail("unpublished snapshot must not read formal table head"),
+        formal_module.serving_reader,
+        "read_iceberg_snapshot",
+        lambda table_identifier, snapshot_id: pytest.fail(
+            "unpublished snapshot must not read formal table head"
+        ),
     )
     with pytest.raises(formal_module.FormalSnapshotNotPublished):
         formal_module.get_formal_by_snapshot(
@@ -306,11 +308,15 @@ def test_manifest_without_object_type_raises_table_snapshot_not_found(
         table_identifier="formal.other_object",
     )
 
-    def fail_load_catalog() -> object:
-        pytest.fail("missing manifest entry must be rejected before Iceberg read")
+    def fail_read_iceberg_snapshot(table_identifier: str, snapshot_id: int) -> object:
+        pytest.fail("missing manifest entry must be rejected before DuckDB Iceberg read")
 
     monkeypatch.setattr(formal_module, "get_latest_publish_manifest", lambda: manifest)
-    monkeypatch.setattr(formal_module, "load_catalog", fail_load_catalog)
+    monkeypatch.setattr(
+        formal_module.serving_reader,
+        "read_iceberg_snapshot",
+        fail_read_iceberg_snapshot,
+    )
 
     with pytest.raises(formal_module.FormalTableSnapshotNotFound):
         formal_module.get_formal_latest("recommendation_set")
@@ -325,38 +331,11 @@ def formal_schema(pa_module: Any) -> Any:
     )
 
 
-def create_formal_catalog(
-    tmp_path: Path,
-    memory_catalog_class: Any,
-    pa_module: Any,
-) -> Any:
-    catalog = memory_catalog_class(
-        "test",
-        warehouse=f"file://{tmp_path / 'warehouse'}",
+def formal_payload(pa_module: Any, *, version: str, score: int) -> Any:
+    return pa_module.table(
+        {"version": [version], "score": [score]},
+        schema=formal_schema(pa_module),
     )
-    catalog.create_namespace_if_not_exists(("formal",))
-    catalog.create_table(FORMAL_IDENTIFIER, schema=formal_schema(pa_module))
-    return catalog
-
-
-def write_formal_snapshot(
-    catalog: Any,
-    pa_module: Any,
-    *,
-    version: str,
-    score: int,
-) -> int:
-    table = catalog.load_table(FORMAL_IDENTIFIER)
-    table.overwrite(
-        pa_module.table(
-            {"version": [version], "score": [score]},
-            schema=formal_schema(pa_module),
-        )
-    )
-    snapshot = table.refresh().current_snapshot()
-    if snapshot is None:
-        raise AssertionError("formal table overwrite did not create a snapshot")
-    return int(snapshot.snapshot_id)
 
 
 def make_manifest(
@@ -470,34 +449,6 @@ def _publish_formal_manifest(
     for status in ("phase0", "phase1", "phase2", "phase3"):
         transition_cycle_status(cycle.cycle_id, status)
     publish_manifest(cycle.cycle_id, snapshots)
-
-
-def _fake_snapshot_catalog(
-    pa_module: Any,
-    *,
-    expected_snapshot_id: int,
-) -> object:
-    class FakeScan:
-        def to_arrow(self) -> Any:
-            return pa_module.table(
-                {
-                    "version": [f"snapshot-{expected_snapshot_id}"],
-                    "score": [expected_snapshot_id],
-                },
-                schema=formal_schema(pa_module),
-            )
-
-    class FakeTable:
-        def scan(self, *, snapshot_id: int) -> FakeScan:
-            assert snapshot_id == expected_snapshot_id
-            return FakeScan()
-
-    class FakeCatalog:
-        def load_table(self, table_identifier: str) -> FakeTable:
-            assert table_identifier == FORMAL_IDENTIFIER
-            return FakeTable()
-
-    return FakeCatalog()
 
 
 def _create_engine(dsn: str, **kwargs: object) -> Any:

--- a/tests/serving/test_reader.py
+++ b/tests/serving/test_reader.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
 from typing import Iterator
 
 import duckdb
+import pyarrow as pa
 import pytest
 from pyiceberg.catalog.memory import InMemoryCatalog
 
@@ -26,6 +28,7 @@ from data_platform.serving.reader import (
     UnsupportedFilter,
     get_canonical_stock_basic,
     read_canonical,
+    read_iceberg_snapshot,
     with_duckdb_connection,
 )
 from tests.serving.test_canonical_writer import (
@@ -175,6 +178,92 @@ def test_read_canonical_raises_for_missing_table(stock_basic_duckdb: Path) -> No
         read_canonical("missing_table")
 
     assert exc_info.value.table == "missing_table"
+
+
+def test_read_iceberg_snapshot_uses_duckdb_time_travel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata_path = (
+        tmp_path
+        / "warehouse"
+        / "formal"
+        / "recommendation_set"
+        / "metadata"
+        / "00002.metadata.json"
+    )
+    expected_payload = pa.table({"version": ["published"]})
+    executed_sql: list[str] = []
+
+    class FakeResult:
+        def to_arrow_table(self) -> pa.Table:
+            return expected_payload
+
+    class FakeConnection:
+        def execute(self, sql: str) -> FakeResult:
+            executed_sql.append(sql)
+            return FakeResult()
+
+    @contextmanager
+    def fake_duckdb_connection() -> Iterator[FakeConnection]:
+        yield FakeConnection()
+
+    monkeypatch.setattr(
+        reader,
+        "_latest_metadata_location_for_identifier",
+        lambda table_identifier: metadata_path,
+    )
+    monkeypatch.setattr(reader, "with_duckdb_connection", fake_duckdb_connection)
+
+    payload = read_iceberg_snapshot("formal.recommendation_set", 123)
+
+    assert payload == expected_payload
+    assert len(executed_sql) == 1
+    assert f"iceberg_scan('{metadata_path}', snapshot_from_id = 123)" in executed_sql[0]
+
+
+def test_read_iceberg_snapshot_reads_pinned_snapshot_not_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_duckdb_iceberg_extension()
+
+    schema = pa.schema([pa.field("version", pa.string())])
+    warehouse_path = tmp_path / "warehouse"
+    catalog = InMemoryCatalog("test", warehouse=f"file://{warehouse_path}")
+    catalog.create_namespace_if_not_exists(("formal",))
+    catalog.create_table("formal.recommendation_set", schema=schema)
+    table = catalog.load_table("formal.recommendation_set")
+
+    table.overwrite(pa.table({"version": ["published"]}, schema=schema))
+    published_snapshot = table.refresh().current_snapshot()
+    if published_snapshot is None:
+        raise AssertionError("published formal snapshot was not created")
+
+    table.overwrite(pa.table({"version": ["unpublished-head"]}, schema=schema))
+    head_snapshot = table.refresh().current_snapshot()
+    if head_snapshot is None:
+        raise AssertionError("formal head snapshot was not created")
+
+    monkeypatch.setattr(
+        reader,
+        "get_settings",
+        lambda: FakeSettings(
+            duckdb_path=tmp_path / "reader.duckdb",
+            iceberg_warehouse_path=warehouse_path,
+        ),
+    )
+    reader._duckdb_connection.cache_clear()
+    try:
+        payload = read_iceberg_snapshot(
+            "formal.recommendation_set",
+            int(published_snapshot.snapshot_id),
+        )
+    finally:
+        reader._duckdb_connection.cache_clear()
+
+    assert int(published_snapshot.snapshot_id) != int(head_snapshot.snapshot_id)
+    assert payload.column("version").to_pylist() == ["published"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #87

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `.env.example`, `cross-cutting`, `docs/spike/iceberg-write-chain.md`, `pyproject.toml`, `scripts/bootstrap_dev.sh`, `scripts/smoke_p1c.sh`, `src/data_platform/adapters/__pycache__/__init__.cpython-314.pyc`, `src/data_platform/adapters/tushare/adapter.py`, `src/data_platform/adapters/tushare/assets.py`, `src/data_platform/config/settings.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The Formal Serving implementation correctly resolves the manifest-pinned snapshot, but it reads the Iceberg table through PyIceberg `table.scan(...).to_arrow()` instead of the project contract's DuckDB + Iceberg serving path. This creates a second serving implementation beside `serving.reader`, leaves the Formal Serving latency baseline untested against DuckDB, and will compound when filters, projections, or shared reader behavior are added.

## 实现范围
- 修改文件: `src/data_platform/serving/formal.py`
- Route formal snapshot reads through a shared DuckDB Iceberg helper, using the manifest snapshot id for time travel, and add tests that assert the Formal Serving APIs use that path and still never read formal head.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/data-platform/.venv/bin/python -m pytest
```
