### PR TITLE
[codex] document root env symlink hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ should use the processed directory. Existing deployments may still set
 `DP_RAW_ZONE_PATH` directly; that override remains supported for backward
 compatibility.
 
+In the local `project-ult` workspace, `data-platform/.env` is a symlink to
+`../.env`. Keep real credentials and local DP overrides in the workspace-level
+`project-ult/.env`; the subproject `.env` path is retained for settings code
+and tests that default to reading `.env` from this repository root.
+
 The default `.env.example` layout is:
 
 ```env

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -394,7 +394,7 @@ data_platform.adapters.tushare
 cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
 pytest tests/adapters/test_tushare.py -q
 # 真实拉取（需要 token，可选）
-DP_TUSHARE_TOKEN=$TUSHARE_TOKEN DP_DATA_STORAGE_ROOT_PATH=/tmp/dp_data \
+DP_TUSHARE_TOKEN="${DP_TUSHARE_TOKEN:?set DP_TUSHARE_TOKEN}" DP_DATA_STORAGE_ROOT_PATH=/tmp/dp_data \
   python -m data_platform.adapters.tushare.adapter --asset tushare_stock_basic --date 20260415
 ```
 


### PR DESCRIPTION
## Summary
- Document that local data-platform/.env is a symlink to workspace-level project-ult/.env.
- Clarify that real credentials and local DP overrides stay in the workspace root env file.
- Update the optional Tushare live example to require an existing environment token instead of showing a token assignment pattern.

## Validation
- git diff --check
- staged secret/DSN/ts-code pattern scan: 0 hits

## Notes
- Docs-only hygiene PR.
- No .env changes, no contracts changes, no live smoke run.