### PR TITLE
[codex] add bounded holdings backfill orchestration

### DIFF
--- a/scripts/holdings_backfill.py
+++ b/scripts/holdings_backfill.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Plan or explicitly execute bounded holdings Raw Zone backfills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from data_platform.holdings_backfill import (
+    SUPPORTED_HOLDINGS_BACKFILL_DATASETS,
+    build_holdings_backfill_plan,
+    execute_holdings_backfill_plan,
+    public_execution_summary,
+    public_plan_summary,
+)
+from data_platform.raw import RawWriter
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        plan = build_holdings_backfill_plan(
+            datasets=_split_many(args.dataset),
+            stock_codes=_split_many(args.stock_code),
+            fund_codes=_split_many(args.fund_code),
+            periods=_split_many(args.period),
+            trade_dates=_split_many(args.trade_date),
+            start_date=args.start_date,
+            end_date=args.end_date,
+            market_types=_split_many(args.market_type),
+            exchanges=_split_many(args.exchange),
+            max_plan_items=args.max_plan_items,
+        )
+        payload: dict[str, Any] = {
+            "mode": "holdings_backfill",
+            "execute_live": args.execute_live,
+            "plan": public_plan_summary(plan),
+        }
+        if plan.has_rejections:
+            _emit_payload(payload, args.json_report)
+            return 2
+        if args.execute_live:
+            if args.raw_zone_path is None or args.iceberg_warehouse_path is None:
+                msg = "--execute-live requires --raw-zone-path and --iceberg-warehouse-path"
+                raise ValueError(msg)
+            from data_platform.adapters.tushare.adapter import TushareAdapter
+
+            result = execute_holdings_backfill_plan(
+                plan,
+                adapter=TushareAdapter(),
+                raw_writer=RawWriter(
+                    raw_zone_path=args.raw_zone_path,
+                    iceberg_warehouse_path=args.iceberg_warehouse_path,
+                ),
+            )
+            payload["execution"] = public_execution_summary(result)
+        _emit_payload(payload, args.json_report)
+    except Exception as exc:
+        payload = {
+            "mode": "holdings_backfill",
+            "execute_live": args.execute_live,
+            "ok": False,
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+        }
+        _emit_payload(payload, args.json_report)
+        return 2
+    return 0
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        required=True,
+        help=(
+            "Holdings dataset to backfill. Repeat or comma-separate. Supported: "
+            + ", ".join(SUPPORTED_HOLDINGS_BACKFILL_DATASETS)
+        ),
+    )
+    parser.add_argument("--stock-code", action="append", help="Bounded A-share code scope.")
+    parser.add_argument("--fund-code", action="append", help="Bounded fund code scope.")
+    parser.add_argument("--period", action="append", help="Report period in YYYYMMDD.")
+    parser.add_argument("--trade-date", action="append", help="Trade date in YYYYMMDD.")
+    parser.add_argument("--start-date", help="Inclusive trade-date range start in YYYYMMDD.")
+    parser.add_argument("--end-date", help="Inclusive trade-date range end in YYYYMMDD.")
+    parser.add_argument("--market-type", action="append", help="Bounded hsgt_top10 market type.")
+    parser.add_argument("--exchange", action="append", help="Bounded hsgt_hold_top10 exchange.")
+    parser.add_argument("--max-plan-items", type=int, default=5_000)
+    parser.add_argument(
+        "--execute-live",
+        action="store_true",
+        help="Opt in to live adapter execution. Omit for plan-only dry run.",
+    )
+    parser.add_argument("--raw-zone-path", type=Path)
+    parser.add_argument("--iceberg-warehouse-path", type=Path)
+    parser.add_argument("--json-report", type=Path, help="Write JSON payload to this path.")
+    return parser.parse_args(argv)
+
+
+def _split_many(values: Sequence[str] | None) -> list[str]:
+    if values is None:
+        return []
+    result: list[str] = []
+    for value in values:
+        result.extend(part.strip() for part in value.split(",") if part.strip())
+    return result
+
+
+def _emit_payload(payload: dict[str, Any], path: Path | None) -> None:
+    text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if path is not None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        return
+    sys.stdout.write(text)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data_platform/holdings_backfill.py
+++ b/src/data_platform/holdings_backfill.py
@@ -1,0 +1,711 @@
+"""Bounded historical backfill planning for holdings Raw Zone intake."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Any, Literal, TypeAlias
+
+import pyarrow as pa  # type: ignore[import-untyped]
+
+from data_platform.adapters.base import AssetSpec, FetchParams, FetchableAdapter
+from data_platform.adapters.tushare.assets import TUSHARE_ASSETS
+from data_platform.raw import RawArtifact, RawWriter
+
+
+PlanItemStatus: TypeAlias = Literal["planned", "skipped", "rejected"]
+ExecutionItemStatus: TypeAlias = Literal["ok", "skipped"]
+
+SUPPORTED_HOLDINGS_BACKFILL_DATASETS: tuple[str, ...] = (
+    "top10_holders",
+    "top10_floatholders",
+    "fund_portfolio",
+    "hsgt_top10",
+    "hsgt_hold_top10",
+)
+STOCK_CODE_DATASETS = frozenset({"top10_holders", "top10_floatholders"})
+FUND_CODE_DATASETS = frozenset({"fund_portfolio"})
+# Keep this aligned with daily_refresh.HK_HOLD_DAILY_PUBLICATION_LAST_DATE
+# without importing daily_refresh into the plan-only API surface.
+HSGT_HOLD_TOP10_BACKFILL_LAST_DATE = date(2024, 8, 20)
+DEFAULT_MAX_PLAN_ITEMS = 5_000
+DATE_FORMAT = "%Y%m%d"
+
+
+class HoldingsBackfillPlanError(ValueError):
+    """Raised when a rejected backfill plan is passed to execution."""
+
+
+@dataclass(frozen=True, slots=True)
+class HoldingsBackfillPlanItem:
+    """One auditable holdings backfill planning decision."""
+
+    dataset: str
+    status: PlanItemStatus
+    partition_date: date | None = None
+    fetch_params: FetchParams = field(default_factory=dict)
+    bounds: Mapping[str, Any] = field(default_factory=dict)
+    reason_type: str | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "fetch_params", dict(self.fetch_params))
+        object.__setattr__(self, "bounds", dict(self.bounds))
+
+
+@dataclass(frozen=True, slots=True)
+class HoldingsBackfillPlan:
+    """A bounded holdings backfill plan with planned, skipped, and rejected items."""
+
+    items: tuple[HoldingsBackfillPlanItem, ...]
+    max_plan_items: int = DEFAULT_MAX_PLAN_ITEMS
+
+    @property
+    def planned_items(self) -> tuple[HoldingsBackfillPlanItem, ...]:
+        return tuple(item for item in self.items if item.status == "planned")
+
+    @property
+    def skipped_items(self) -> tuple[HoldingsBackfillPlanItem, ...]:
+        return tuple(item for item in self.items if item.status == "skipped")
+
+    @property
+    def rejected_items(self) -> tuple[HoldingsBackfillPlanItem, ...]:
+        return tuple(item for item in self.items if item.status == "rejected")
+
+    @property
+    def has_rejections(self) -> bool:
+        return bool(self.rejected_items)
+
+    @property
+    def ok(self) -> bool:
+        return not self.has_rejections
+
+
+@dataclass(frozen=True, slots=True)
+class HoldingsBackfillExecutionItem:
+    """Execution result for a planned or skipped holdings backfill item."""
+
+    dataset: str
+    status: ExecutionItemStatus
+    partition_date: date | None
+    row_count: int = 0
+    artifact: RawArtifact | None = None
+    reason_type: str | None = None
+    reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HoldingsBackfillExecutionResult:
+    """Result of executing a holdings backfill plan into Raw Zone artifacts."""
+
+    items: tuple[HoldingsBackfillExecutionItem, ...]
+
+    @property
+    def ok(self) -> bool:
+        return all(item.status in {"ok", "skipped"} for item in self.items)
+
+    @property
+    def artifacts(self) -> tuple[RawArtifact, ...]:
+        return tuple(item.artifact for item in self.items if item.artifact is not None)
+
+
+def build_holdings_backfill_plan(
+    *,
+    datasets: Sequence[str],
+    stock_codes: Sequence[str] = (),
+    fund_codes: Sequence[str] = (),
+    periods: Sequence[str] = (),
+    trade_dates: Sequence[str] = (),
+    start_date: str | None = None,
+    end_date: str | None = None,
+    market_types: Sequence[str] = (),
+    exchanges: Sequence[str] = (),
+    max_plan_items: int = DEFAULT_MAX_PLAN_ITEMS,
+) -> HoldingsBackfillPlan:
+    """Build a fail-closed holdings backfill plan from explicit bounded inputs."""
+
+    if max_plan_items < 1:
+        msg = "max_plan_items must be positive"
+        raise ValueError(msg)
+
+    dataset_list, dataset_rejections = _normalize_datasets(datasets)
+    normalized_stock_codes = _normalize_non_empty_strings(stock_codes)
+    normalized_fund_codes = _normalize_non_empty_strings(fund_codes)
+    normalized_periods, period_rejections = _parse_date_values(periods, "period")
+    normalized_trade_dates, trade_date_rejections = _resolve_trade_dates(
+        trade_dates=trade_dates,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    normalized_market_types = _normalize_non_empty_strings(market_types)
+    normalized_exchanges = _normalize_non_empty_strings(exchanges)
+
+    items: list[HoldingsBackfillPlanItem] = [
+        *dataset_rejections,
+        *period_rejections,
+        *trade_date_rejections,
+    ]
+    for dataset in dataset_list:
+        items.extend(
+            _plan_dataset(
+                dataset=dataset,
+                stock_codes=normalized_stock_codes,
+                fund_codes=normalized_fund_codes,
+                periods=normalized_periods,
+                trade_dates=normalized_trade_dates,
+                market_types=normalized_market_types,
+                exchanges=normalized_exchanges,
+            )
+        )
+
+    planned_count = sum(1 for item in items if item.status == "planned")
+    if planned_count > max_plan_items:
+        items.append(
+            _rejected_item(
+                "holdings",
+                "plan_item_limit_exceeded",
+                (
+                    f"bounded holdings backfill plan has {planned_count} planned items; "
+                    f"limit is {max_plan_items}"
+                ),
+                bounds={"planned_count": planned_count, "max_plan_items": max_plan_items},
+            )
+        )
+
+    return HoldingsBackfillPlan(tuple(items), max_plan_items=max_plan_items)
+
+
+def execute_holdings_backfill_plan(
+    plan: HoldingsBackfillPlan,
+    *,
+    adapter: FetchableAdapter,
+    raw_writer: RawWriter,
+) -> HoldingsBackfillExecutionResult:
+    """Execute planned holdings backfill items through an adapter into Raw Zone."""
+
+    if plan.has_rejections:
+        reasons = ", ".join(
+            f"{item.dataset}:{item.reason_type}" for item in plan.rejected_items
+        )
+        msg = f"holdings backfill plan has rejected item(s): {reasons}"
+        raise HoldingsBackfillPlanError(msg)
+
+    assets_by_dataset = _assets_by_dataset(adapter.get_assets())
+    execution_items: list[HoldingsBackfillExecutionItem] = []
+    for item in plan.items:
+        if item.status == "skipped":
+            execution_items.append(
+                HoldingsBackfillExecutionItem(
+                    dataset=item.dataset,
+                    status="skipped",
+                    partition_date=item.partition_date,
+                    reason_type=item.reason_type,
+                    reason=item.reason,
+                )
+            )
+            continue
+        if item.status != "planned":
+            continue
+        if item.partition_date is None:
+            msg = f"planned holdings backfill item lacks partition_date: {item.dataset}"
+            raise HoldingsBackfillPlanError(msg)
+
+        asset = assets_by_dataset[item.dataset]
+        result = adapter.fetch(asset.name, item.fetch_params)
+        if not isinstance(result, pa.Table):
+            msg = f"holdings backfill adapter returned unsupported result for {item.dataset}"
+            raise TypeError(msg)
+
+        artifact = raw_writer.write_arrow(
+            adapter.source_id(),
+            asset.dataset,
+            item.partition_date,
+            str(uuid.uuid4()),
+            result,
+            metadata=asset.metadata,
+            request_params=item.fetch_params,
+        )
+        execution_items.append(
+            HoldingsBackfillExecutionItem(
+                dataset=item.dataset,
+                status="ok",
+                partition_date=item.partition_date,
+                row_count=artifact.row_count,
+                artifact=artifact,
+            )
+        )
+
+    return HoldingsBackfillExecutionResult(tuple(execution_items))
+
+
+def public_plan_summary(plan: HoldingsBackfillPlan) -> dict[str, Any]:
+    """Return a provider-neutral summary of a holdings backfill plan."""
+
+    return {
+        "ok": plan.ok,
+        "planned_count": len(plan.planned_items),
+        "skipped_count": len(plan.skipped_items),
+        "rejected_count": len(plan.rejected_items),
+        "max_plan_items": plan.max_plan_items,
+        "items": [_public_plan_item(item) for item in plan.items],
+    }
+
+
+def public_execution_summary(result: HoldingsBackfillExecutionResult) -> dict[str, Any]:
+    """Return a redacted execution summary suitable for PR notes and operator logs."""
+
+    return {
+        "ok": result.ok,
+        "artifact_count": len(result.artifacts),
+        "row_count": sum(item.row_count for item in result.items),
+        "items": [
+            {
+                "dataset": item.dataset,
+                "status": item.status,
+                "partition_date": (
+                    None if item.partition_date is None else f"{item.partition_date:%Y%m%d}"
+                ),
+                "row_count": item.row_count,
+                **_reason_fields(item.reason_type, item.reason),
+            }
+            for item in result.items
+        ],
+    }
+
+
+def _plan_dataset(
+    *,
+    dataset: str,
+    stock_codes: tuple[str, ...],
+    fund_codes: tuple[str, ...],
+    periods: tuple[date, ...],
+    trade_dates: tuple[date, ...],
+    market_types: tuple[str, ...],
+    exchanges: tuple[str, ...],
+) -> tuple[HoldingsBackfillPlanItem, ...]:
+    if dataset in STOCK_CODE_DATASETS:
+        return _plan_stock_code_dataset(dataset, stock_codes, periods)
+    if dataset in FUND_CODE_DATASETS:
+        return _plan_fund_code_dataset(dataset, fund_codes, periods)
+    if dataset == "hsgt_top10":
+        return _plan_hsgt_top10_dataset(trade_dates, market_types)
+    if dataset == "hsgt_hold_top10":
+        return _plan_hsgt_hold_top10_dataset(trade_dates, exchanges)
+    return (
+        _rejected_item(
+            dataset,
+            "unsupported_dataset",
+            f"holdings backfill does not support dataset {dataset!r}",
+        ),
+    )
+
+
+def _plan_stock_code_dataset(
+    dataset: str,
+    stock_codes: tuple[str, ...],
+    periods: tuple[date, ...],
+) -> tuple[HoldingsBackfillPlanItem, ...]:
+    missing = []
+    if not stock_codes:
+        missing.append("stock_codes")
+    if not periods:
+        missing.append("periods")
+    if missing:
+        return (
+            _rejected_item(
+                dataset,
+                "missing_bounded_inputs",
+                f"{dataset} requires explicit stock_codes and periods",
+                bounds={"missing": missing},
+            ),
+        )
+
+    return tuple(
+        _planned_item(
+            dataset=dataset,
+            partition_date=period,
+            fetch_params={"ts_code": stock_code, "period": f"{period:%Y%m%d}"},
+            bounds={"stock_code": stock_code, "period": f"{period:%Y%m%d}"},
+        )
+        for stock_code in stock_codes
+        for period in periods
+    )
+
+
+def _plan_fund_code_dataset(
+    dataset: str,
+    fund_codes: tuple[str, ...],
+    periods: tuple[date, ...],
+) -> tuple[HoldingsBackfillPlanItem, ...]:
+    missing = []
+    if not fund_codes:
+        missing.append("fund_codes")
+    if not periods:
+        missing.append("periods")
+    if missing:
+        return (
+            _rejected_item(
+                dataset,
+                "missing_bounded_inputs",
+                f"{dataset} requires explicit fund_codes and periods",
+                bounds={"missing": missing},
+            ),
+        )
+
+    return tuple(
+        _planned_item(
+            dataset=dataset,
+            partition_date=period,
+            fetch_params={"ts_code": fund_code, "period": f"{period:%Y%m%d}"},
+            bounds={"fund_code": fund_code, "period": f"{period:%Y%m%d}"},
+        )
+        for fund_code in fund_codes
+        for period in periods
+    )
+
+
+def _plan_hsgt_top10_dataset(
+    trade_dates: tuple[date, ...],
+    market_types: tuple[str, ...],
+) -> tuple[HoldingsBackfillPlanItem, ...]:
+    missing = []
+    if not trade_dates:
+        missing.append("trade_dates")
+    if not market_types:
+        missing.append("market_types")
+    if missing:
+        return (
+            _rejected_item(
+                "hsgt_top10",
+                "missing_bounded_inputs",
+                "hsgt_top10 requires explicit trade_dates/date range and market_types",
+                bounds={"missing": missing},
+            ),
+        )
+
+    return tuple(
+        _planned_item(
+            dataset="hsgt_top10",
+            partition_date=trade_date,
+            fetch_params={"trade_date": f"{trade_date:%Y%m%d}", "market_type": market_type},
+            bounds={"trade_date": f"{trade_date:%Y%m%d}", "market_type": market_type},
+        )
+        for trade_date in trade_dates
+        for market_type in market_types
+    )
+
+
+def _plan_hsgt_hold_top10_dataset(
+    trade_dates: tuple[date, ...],
+    exchanges: tuple[str, ...],
+) -> tuple[HoldingsBackfillPlanItem, ...]:
+    missing = []
+    if not trade_dates:
+        missing.append("trade_dates")
+    if not exchanges:
+        missing.append("exchanges")
+    if missing:
+        return (
+            _rejected_item(
+                "hsgt_hold_top10",
+                "missing_bounded_inputs",
+                "hsgt_hold_top10 requires explicit historical trade_dates/date range and exchanges",
+                bounds={"missing": missing},
+            ),
+        )
+
+    items: list[HoldingsBackfillPlanItem] = []
+    for trade_date in trade_dates:
+        for exchange in exchanges:
+            bounds = {"trade_date": f"{trade_date:%Y%m%d}", "exchange": exchange}
+            if trade_date > HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:
+                items.append(
+                    _skipped_item(
+                        dataset="hsgt_hold_top10",
+                        partition_date=trade_date,
+                        reason_type="post_publication_cutoff",
+                        reason=(
+                            "northbound holding daily publication is only verifiable through "
+                            f"{HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:%Y-%m-%d}"
+                        ),
+                        bounds=bounds,
+                    )
+                )
+                continue
+            items.append(
+                _planned_item(
+                    dataset="hsgt_hold_top10",
+                    partition_date=trade_date,
+                    fetch_params={"trade_date": f"{trade_date:%Y%m%d}", "exchange": exchange},
+                    bounds=bounds,
+                )
+            )
+    return tuple(items)
+
+
+def _normalize_datasets(
+    datasets: Sequence[str],
+) -> tuple[tuple[str, ...], tuple[HoldingsBackfillPlanItem, ...]]:
+    normalized = _normalize_non_empty_strings(datasets)
+    if not normalized:
+        return (), (
+            _rejected_item(
+                "holdings",
+                "missing_datasets",
+                "holdings backfill requires at least one explicit dataset",
+            ),
+        )
+
+    supported = set(SUPPORTED_HOLDINGS_BACKFILL_DATASETS)
+    accepted: list[str] = []
+    rejected: list[HoldingsBackfillPlanItem] = []
+    for dataset in normalized:
+        if dataset in supported:
+            accepted.append(dataset)
+        else:
+            rejected.append(
+                _rejected_item(
+                    dataset,
+                    "unsupported_dataset",
+                    f"holdings backfill does not support dataset {dataset!r}",
+                )
+            )
+    return tuple(accepted), tuple(rejected)
+
+
+def _resolve_trade_dates(
+    *,
+    trade_dates: Sequence[str],
+    start_date: str | None,
+    end_date: str | None,
+) -> tuple[tuple[date, ...], tuple[HoldingsBackfillPlanItem, ...]]:
+    parsed_trade_dates, rejections = _parse_date_values(trade_dates, "trade_date")
+    range_values: list[date] = []
+
+    if start_date is None and end_date is None:
+        return parsed_trade_dates, rejections
+    if start_date is None or end_date is None:
+        return parsed_trade_dates, (
+            *rejections,
+            _rejected_item(
+                "holdings",
+                "incomplete_date_range",
+                "date range requires both start_date and end_date",
+            ),
+        )
+
+    parsed_start = _parse_yyyymmdd(start_date)
+    parsed_end = _parse_yyyymmdd(end_date)
+    if parsed_start is None or parsed_end is None:
+        return parsed_trade_dates, (
+            *rejections,
+            _rejected_item(
+                "holdings",
+                "invalid_date_range",
+                "date range bounds must use valid YYYYMMDD dates",
+                bounds={"start_date": start_date, "end_date": end_date},
+            ),
+        )
+    if parsed_start > parsed_end:
+        return parsed_trade_dates, (
+            *rejections,
+            _rejected_item(
+                "holdings",
+                "invalid_date_range",
+                "start_date must be less than or equal to end_date",
+                bounds={"start_date": start_date, "end_date": end_date},
+            ),
+        )
+
+    current = parsed_start
+    while current <= parsed_end:
+        range_values.append(current)
+        current += timedelta(days=1)
+    return _dedupe_dates((*parsed_trade_dates, *range_values)), rejections
+
+
+def _parse_date_values(
+    values: Sequence[str],
+    field_name: str,
+) -> tuple[tuple[date, ...], tuple[HoldingsBackfillPlanItem, ...]]:
+    parsed: list[date] = []
+    rejected: list[HoldingsBackfillPlanItem] = []
+    for value in _normalize_non_empty_strings(values):
+        parsed_value = _parse_yyyymmdd(value)
+        if parsed_value is None:
+            rejected.append(
+                _rejected_item(
+                    "holdings",
+                    f"invalid_{field_name}",
+                    f"{field_name} must use a valid YYYYMMDD date",
+                    bounds={field_name: value},
+                )
+            )
+            continue
+        parsed.append(parsed_value)
+    return _dedupe_dates(parsed), tuple(rejected)
+
+
+def _parse_yyyymmdd(value: str) -> date | None:
+    try:
+        parsed = datetime.strptime(value, DATE_FORMAT).date()
+    except ValueError:
+        return None
+    if f"{parsed:%Y%m%d}" != value:
+        return None
+    return parsed
+
+
+def _normalize_non_empty_strings(values: Sequence[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for part in str(value).split(","):
+            candidate = part.strip()
+            if candidate and candidate not in seen:
+                normalized.append(candidate)
+                seen.add(candidate)
+    return tuple(normalized)
+
+
+def _dedupe_dates(values: Sequence[date]) -> tuple[date, ...]:
+    deduped: list[date] = []
+    seen: set[date] = set()
+    for value in values:
+        if value not in seen:
+            deduped.append(value)
+            seen.add(value)
+    return tuple(deduped)
+
+
+def _planned_item(
+    *,
+    dataset: str,
+    partition_date: date,
+    fetch_params: Mapping[str, Any],
+    bounds: Mapping[str, Any],
+) -> HoldingsBackfillPlanItem:
+    return HoldingsBackfillPlanItem(
+        dataset=dataset,
+        status="planned",
+        partition_date=partition_date,
+        fetch_params=fetch_params,
+        bounds=bounds,
+    )
+
+
+def _skipped_item(
+    *,
+    dataset: str,
+    partition_date: date,
+    reason_type: str,
+    reason: str,
+    bounds: Mapping[str, Any],
+) -> HoldingsBackfillPlanItem:
+    return HoldingsBackfillPlanItem(
+        dataset=dataset,
+        status="skipped",
+        partition_date=partition_date,
+        bounds=bounds,
+        reason_type=reason_type,
+        reason=reason,
+    )
+
+
+def _rejected_item(
+    dataset: str,
+    reason_type: str,
+    reason: str,
+    *,
+    bounds: Mapping[str, Any] | None = None,
+) -> HoldingsBackfillPlanItem:
+    return HoldingsBackfillPlanItem(
+        dataset=dataset,
+        status="rejected",
+        bounds=bounds or {},
+        reason_type=reason_type,
+        reason=reason,
+    )
+
+
+def _public_plan_item(item: HoldingsBackfillPlanItem) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "dataset": item.dataset,
+        "status": item.status,
+    }
+    if item.partition_date is not None:
+        payload["partition_date"] = f"{item.partition_date:%Y%m%d}"
+    if item.bounds:
+        payload["bounds"] = _json_safe_public_value(item.bounds)
+    payload.update(_reason_fields(item.reason_type, item.reason))
+    return payload
+
+
+def _reason_fields(reason_type: str | None, reason: str | None) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    if reason_type is not None:
+        fields["reason_type"] = reason_type
+    if reason is not None:
+        fields["reason"] = reason
+    return fields
+
+
+def _json_safe_public_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_safe_public_value(item)
+            for key, item in value.items()
+            if not str(key).startswith("_")
+        }
+    if isinstance(value, list | tuple):
+        return [_json_safe_public_value(item) for item in value]
+    if isinstance(value, date):
+        return f"{value:%Y%m%d}"
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    return str(value)
+
+
+def _assets_by_dataset(assets: Sequence[AssetSpec]) -> dict[str, AssetSpec]:
+    assets_by_dataset = {asset.dataset: asset for asset in assets}
+    missing = [
+        dataset
+        for dataset in SUPPORTED_HOLDINGS_BACKFILL_DATASETS
+        if dataset not in assets_by_dataset
+    ]
+    if missing:
+        msg = "adapter is missing holdings assets: " + ", ".join(missing)
+        raise ValueError(msg)
+    return assets_by_dataset
+
+
+def default_holdings_assets_by_dataset() -> dict[str, AssetSpec]:
+    """Return the built-in holdings assets keyed by public dataset name."""
+
+    return {
+        dataset: asset
+        for dataset, asset in _assets_by_dataset(TUSHARE_ASSETS).items()
+        if dataset in SUPPORTED_HOLDINGS_BACKFILL_DATASETS
+    }
+
+
+__all__ = [
+    "DEFAULT_MAX_PLAN_ITEMS",
+    "HSGT_HOLD_TOP10_BACKFILL_LAST_DATE",
+    "HoldingsBackfillExecutionItem",
+    "HoldingsBackfillExecutionResult",
+    "HoldingsBackfillPlan",
+    "HoldingsBackfillPlanError",
+    "HoldingsBackfillPlanItem",
+    "SUPPORTED_HOLDINGS_BACKFILL_DATASETS",
+    "build_holdings_backfill_plan",
+    "default_holdings_assets_by_dataset",
+    "execute_holdings_backfill_plan",
+    "public_execution_summary",
+    "public_plan_summary",
+]

--- a/src/data_platform/holdings_backfill.py
+++ b/src/data_platform/holdings_backfill.py
@@ -28,6 +28,14 @@ SUPPORTED_HOLDINGS_BACKFILL_DATASETS: tuple[str, ...] = (
 )
 STOCK_CODE_DATASETS = frozenset({"top10_holders", "top10_floatholders"})
 FUND_CODE_DATASETS = frozenset({"fund_portfolio"})
+SENSITIVE_BOUND_KEYS = frozenset({"stock_code", "fund_code", "ts_code", "symbol", "code"})
+SENSITIVE_BOUND_CLASSES = {
+    "stock_code": "stock_code",
+    "fund_code": "fund_code",
+    "ts_code": "stock_code",
+    "symbol": "security_symbol",
+    "code": "security_code",
+}
 # Keep this aligned with daily_refresh.HK_HOLD_DAILY_PUBLICATION_LAST_DATE
 # without importing daily_refresh into the plan-only API surface.
 HSGT_HOLD_TOP10_BACKFILL_LAST_DATE = date(2024, 8, 20)
@@ -291,9 +299,9 @@ def _plan_dataset(
     if dataset in FUND_CODE_DATASETS:
         return _plan_fund_code_dataset(dataset, fund_codes, periods)
     if dataset == "hsgt_top10":
-        return _plan_hsgt_top10_dataset(trade_dates, market_types)
+        return _plan_hsgt_top10_dataset(trade_dates, market_types, stock_codes)
     if dataset == "hsgt_hold_top10":
-        return _plan_hsgt_hold_top10_dataset(trade_dates, exchanges)
+        return _plan_hsgt_hold_top10_dataset(trade_dates, exchanges, stock_codes)
     return (
         _rejected_item(
             dataset,
@@ -370,18 +378,21 @@ def _plan_fund_code_dataset(
 def _plan_hsgt_top10_dataset(
     trade_dates: tuple[date, ...],
     market_types: tuple[str, ...],
+    stock_codes: tuple[str, ...],
 ) -> tuple[HoldingsBackfillPlanItem, ...]:
     missing = []
     if not trade_dates:
         missing.append("trade_dates")
     if not market_types:
         missing.append("market_types")
+    if not stock_codes:
+        missing.append("stock_codes")
     if missing:
         return (
             _rejected_item(
                 "hsgt_top10",
                 "missing_bounded_inputs",
-                "hsgt_top10 requires explicit trade_dates/date range and market_types",
+                "hsgt_top10 requires explicit stock_codes, trade_dates/date range, and market_types",
                 bounds={"missing": missing},
             ),
         )
@@ -390,29 +401,44 @@ def _plan_hsgt_top10_dataset(
         _planned_item(
             dataset="hsgt_top10",
             partition_date=trade_date,
-            fetch_params={"trade_date": f"{trade_date:%Y%m%d}", "market_type": market_type},
-            bounds={"trade_date": f"{trade_date:%Y%m%d}", "market_type": market_type},
+            fetch_params={
+                "trade_date": f"{trade_date:%Y%m%d}",
+                "market_type": market_type,
+                "ts_code": stock_code,
+            },
+            bounds={
+                "trade_date": f"{trade_date:%Y%m%d}",
+                "market_type": market_type,
+                "stock_code": stock_code,
+            },
         )
         for trade_date in trade_dates
         for market_type in market_types
+        for stock_code in stock_codes
     )
 
 
 def _plan_hsgt_hold_top10_dataset(
     trade_dates: tuple[date, ...],
     exchanges: tuple[str, ...],
+    stock_codes: tuple[str, ...],
 ) -> tuple[HoldingsBackfillPlanItem, ...]:
     missing = []
     if not trade_dates:
         missing.append("trade_dates")
     if not exchanges:
         missing.append("exchanges")
+    if not stock_codes:
+        missing.append("stock_codes")
     if missing:
         return (
             _rejected_item(
                 "hsgt_hold_top10",
                 "missing_bounded_inputs",
-                "hsgt_hold_top10 requires explicit historical trade_dates/date range and exchanges",
+                (
+                    "hsgt_hold_top10 requires explicit stock_codes, historical "
+                    "trade_dates/date range, and exchanges"
+                ),
                 bounds={"missing": missing},
             ),
         )
@@ -420,29 +446,38 @@ def _plan_hsgt_hold_top10_dataset(
     items: list[HoldingsBackfillPlanItem] = []
     for trade_date in trade_dates:
         for exchange in exchanges:
-            bounds = {"trade_date": f"{trade_date:%Y%m%d}", "exchange": exchange}
-            if trade_date > HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:
+            for stock_code in stock_codes:
+                bounds = {
+                    "trade_date": f"{trade_date:%Y%m%d}",
+                    "exchange": exchange,
+                    "stock_code": stock_code,
+                }
+                if trade_date > HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:
+                    items.append(
+                        _skipped_item(
+                            dataset="hsgt_hold_top10",
+                            partition_date=trade_date,
+                            reason_type="post_publication_cutoff",
+                            reason=(
+                                "northbound holding daily publication is only verifiable through "
+                                f"{HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:%Y-%m-%d}"
+                            ),
+                            bounds=bounds,
+                        )
+                    )
+                    continue
                 items.append(
-                    _skipped_item(
+                    _planned_item(
                         dataset="hsgt_hold_top10",
                         partition_date=trade_date,
-                        reason_type="post_publication_cutoff",
-                        reason=(
-                            "northbound holding daily publication is only verifiable through "
-                            f"{HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:%Y-%m-%d}"
-                        ),
+                        fetch_params={
+                            "trade_date": f"{trade_date:%Y%m%d}",
+                            "exchange": exchange,
+                            "ts_code": stock_code,
+                        },
                         bounds=bounds,
                     )
                 )
-                continue
-            items.append(
-                _planned_item(
-                    dataset="hsgt_hold_top10",
-                    partition_date=trade_date,
-                    fetch_params={"trade_date": f"{trade_date:%Y%m%d}", "exchange": exchange},
-                    bounds=bounds,
-                )
-            )
     return tuple(items)
 
 
@@ -639,9 +674,37 @@ def _public_plan_item(item: HoldingsBackfillPlanItem) -> dict[str, Any]:
     if item.partition_date is not None:
         payload["partition_date"] = f"{item.partition_date:%Y%m%d}"
     if item.bounds:
-        payload["bounds"] = _json_safe_public_value(item.bounds)
+        payload["bounds"] = _public_bounds(item.bounds)
     payload.update(_reason_fields(item.reason_type, item.reason))
     return payload
+
+
+def _public_bounds(bounds: Mapping[str, Any]) -> dict[str, Any]:
+    public: dict[str, Any] = {}
+    for key, value in bounds.items():
+        public_key = str(key)
+        if public_key in SENSITIVE_BOUND_KEYS:
+            identifier_values = _bound_identifier_values(value)
+            public[f"{public_key}_class"] = SENSITIVE_BOUND_CLASSES[public_key]
+            public[f"{public_key}_count"] = len(identifier_values)
+            continue
+        if public_key.startswith("_"):
+            continue
+        if isinstance(value, Mapping):
+            public[public_key] = _public_bounds(value)
+            continue
+        public[public_key] = _json_safe_public_value(value)
+    return public
+
+
+def _bound_identifier_values(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, Sequence) and not isinstance(value, bytes | bytearray):
+        return tuple(str(item) for item in value if str(item))
+    if value is None:
+        return ()
+    return (str(value),)
 
 
 def _reason_fields(reason_type: str | None, reason: str | None) -> dict[str, Any]:

--- a/src/data_platform/holdings_backfill.py
+++ b/src/data_platform/holdings_backfill.py
@@ -215,6 +215,9 @@ def execute_holdings_backfill_plan(
         msg = f"holdings backfill plan has rejected item(s): {reasons}"
         raise HoldingsBackfillPlanError(msg)
 
+    for item in plan.planned_items:
+        _validate_planned_item_for_execution(item)
+
     assets_by_dataset = _assets_by_dataset(adapter.get_assets())
     execution_items: list[HoldingsBackfillExecutionItem] = []
     for item in plan.items:
@@ -234,7 +237,6 @@ def execute_holdings_backfill_plan(
         if item.partition_date is None:
             msg = f"planned holdings backfill item lacks partition_date: {item.dataset}"
             raise HoldingsBackfillPlanError(msg)
-        _validate_planned_item_for_execution(item)
 
         asset = assets_by_dataset[item.dataset]
         result = adapter.fetch(asset.name, item.fetch_params)
@@ -752,41 +754,88 @@ def _json_safe_public_value(value: Any) -> Any:
 
 
 def _validate_planned_item_for_execution(item: HoldingsBackfillPlanItem) -> None:
-    if item.dataset not in HSGT_BACKFILL_DATASETS:
+    if item.partition_date is None:
+        msg = f"planned holdings backfill item lacks partition_date: {item.dataset}"
+        raise HoldingsBackfillPlanError(msg)
+
+    if item.dataset in STOCK_CODE_DATASETS | FUND_CODE_DATASETS:
+        _require_non_empty_scalar_param(item, "ts_code")
+        period = _parse_fetch_date_param(
+            item,
+            "period",
+            partition_label="report period",
+        )
+        if period != item.partition_date:
+            msg = (
+                f"planned {item.dataset} backfill item requires a period matching "
+                "partition_date before execution"
+            )
+            raise HoldingsBackfillPlanError(msg)
         return
 
-    ts_code = item.fetch_params.get("ts_code")
-    if not isinstance(ts_code, str) or not ts_code.strip():
+    if item.dataset in HSGT_BACKFILL_DATASETS:
+        _require_non_empty_scalar_param(item, "ts_code")
+        trade_date = _parse_fetch_date_param(
+            item,
+            "trade_date",
+            partition_label="trade_date",
+        )
+        if trade_date != item.partition_date:
+            msg = (
+                f"planned {item.dataset} backfill item requires a trade_date matching "
+                "partition_date before execution"
+            )
+            raise HoldingsBackfillPlanError(msg)
+        if item.dataset == "hsgt_top10":
+            _require_non_empty_scalar_param(item, "market_type")
+            return
+        if item.dataset == "hsgt_hold_top10":
+            _require_non_empty_scalar_param(item, "exchange")
+            if trade_date > HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:
+                msg = (
+                    "planned hsgt_hold_top10 backfill item is after the supported "
+                    f"{HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:%Y-%m-%d} cutoff"
+                )
+                raise HoldingsBackfillPlanError(msg)
+            return
+
+    msg = f"planned holdings backfill item has unsupported dataset: {item.dataset}"
+    raise HoldingsBackfillPlanError(msg)
+
+
+def _require_non_empty_scalar_param(
+    item: HoldingsBackfillPlanItem,
+    param_name: str,
+) -> str:
+    value = item.fetch_params.get(param_name)
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or value != value.strip()
+    ):
         msg = (
-            f"planned {item.dataset} backfill item requires a non-empty scalar ts_code "
+            f"planned {item.dataset} backfill item requires a non-empty scalar "
+            f"{param_name} before execution"
+        )
+        raise HoldingsBackfillPlanError(msg)
+    return value
+
+
+def _parse_fetch_date_param(
+    item: HoldingsBackfillPlanItem,
+    param_name: str,
+    *,
+    partition_label: str,
+) -> date:
+    value = _require_non_empty_scalar_param(item, param_name)
+    parsed = _parse_yyyymmdd(value)
+    if parsed is None:
+        msg = (
+            f"planned {item.dataset} backfill item requires a valid {partition_label} "
             "before execution"
         )
         raise HoldingsBackfillPlanError(msg)
-
-    trade_date = item.fetch_params.get("trade_date")
-    parsed_trade_date = _parse_fetch_trade_date(trade_date)
-    if parsed_trade_date is None or parsed_trade_date != item.partition_date:
-        msg = (
-            f"planned {item.dataset} backfill item requires a trade_date matching "
-            "partition_date before execution"
-        )
-        raise HoldingsBackfillPlanError(msg)
-
-    if (
-        item.dataset == "hsgt_hold_top10"
-        and parsed_trade_date > HSGT_HOLD_TOP10_BACKFILL_LAST_DATE
-    ):
-        msg = (
-            "planned hsgt_hold_top10 backfill item is after the supported "
-            f"{HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:%Y-%m-%d} cutoff"
-        )
-        raise HoldingsBackfillPlanError(msg)
-
-
-def _parse_fetch_trade_date(value: Any) -> date | None:
-    if not isinstance(value, str):
-        return None
-    return _parse_yyyymmdd(value)
+    return parsed
 
 
 def _looks_like_public_identifier(value: str) -> bool:

--- a/src/data_platform/holdings_backfill.py
+++ b/src/data_platform/holdings_backfill.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
@@ -28,14 +29,27 @@ SUPPORTED_HOLDINGS_BACKFILL_DATASETS: tuple[str, ...] = (
 )
 STOCK_CODE_DATASETS = frozenset({"top10_holders", "top10_floatholders"})
 FUND_CODE_DATASETS = frozenset({"fund_portfolio"})
-SENSITIVE_BOUND_KEYS = frozenset({"stock_code", "fund_code", "ts_code", "symbol", "code"})
-SENSITIVE_BOUND_CLASSES = {
+HSGT_BACKFILL_DATASETS = frozenset({"hsgt_top10", "hsgt_hold_top10"})
+PUBLIC_IDENTIFIER_BOUND_CLASSES = {
     "stock_code": "stock_code",
     "fund_code": "fund_code",
-    "ts_code": "stock_code",
-    "symbol": "security_symbol",
-    "code": "security_code",
 }
+PUBLIC_SAFE_BOUND_KEYS = frozenset(
+    {
+        "exchange",
+        "market_type",
+        "max_plan_items",
+        "missing",
+        "period",
+        "planned_count",
+        "start_date",
+        "end_date",
+        "trade_date",
+    }
+)
+PUBLIC_IDENTIFIER_VALUE_RE = re.compile(
+    r"^(?:\d{5}\.HK|\d{6}\.(?:BJ|OF|SH|SZ)|[A-Z0-9]{1,12}\.(?:BJ|HK|OF|SH|SZ))$"
+)
 # Keep this aligned with daily_refresh.HK_HOLD_DAILY_PUBLICATION_LAST_DATE
 # without importing daily_refresh into the plan-only API surface.
 HSGT_HOLD_TOP10_BACKFILL_LAST_DATE = date(2024, 8, 20)
@@ -220,6 +234,7 @@ def execute_holdings_backfill_plan(
         if item.partition_date is None:
             msg = f"planned holdings backfill item lacks partition_date: {item.dataset}"
             raise HoldingsBackfillPlanError(msg)
+        _validate_planned_item_for_execution(item)
 
         asset = assets_by_dataset[item.dataset]
         result = adapter.fetch(asset.name, item.fetch_params)
@@ -683,12 +698,12 @@ def _public_bounds(bounds: Mapping[str, Any]) -> dict[str, Any]:
     public: dict[str, Any] = {}
     for key, value in bounds.items():
         public_key = str(key)
-        if public_key in SENSITIVE_BOUND_KEYS:
+        if public_key in PUBLIC_IDENTIFIER_BOUND_CLASSES:
             identifier_values = _bound_identifier_values(value)
-            public[f"{public_key}_class"] = SENSITIVE_BOUND_CLASSES[public_key]
+            public[f"{public_key}_class"] = PUBLIC_IDENTIFIER_BOUND_CLASSES[public_key]
             public[f"{public_key}_count"] = len(identifier_values)
             continue
-        if public_key.startswith("_"):
+        if public_key not in PUBLIC_SAFE_BOUND_KEYS:
             continue
         if isinstance(value, Mapping):
             public[public_key] = _public_bounds(value)
@@ -721,7 +736,7 @@ def _json_safe_public_value(value: Any) -> Any:
         return {
             str(key): _json_safe_public_value(item)
             for key, item in value.items()
-            if not str(key).startswith("_")
+            if str(key) in PUBLIC_SAFE_BOUND_KEYS
         }
     if isinstance(value, list | tuple):
         return [_json_safe_public_value(item) for item in value]
@@ -729,9 +744,53 @@ def _json_safe_public_value(value: Any) -> Any:
         return f"{value:%Y%m%d}"
     if isinstance(value, Decimal):
         return str(value)
+    if isinstance(value, str) and _looks_like_public_identifier(value):
+        return "[redacted]"
     if isinstance(value, str | int | float | bool) or value is None:
         return value
     return str(value)
+
+
+def _validate_planned_item_for_execution(item: HoldingsBackfillPlanItem) -> None:
+    if item.dataset not in HSGT_BACKFILL_DATASETS:
+        return
+
+    ts_code = item.fetch_params.get("ts_code")
+    if not isinstance(ts_code, str) or not ts_code.strip():
+        msg = (
+            f"planned {item.dataset} backfill item requires a non-empty scalar ts_code "
+            "before execution"
+        )
+        raise HoldingsBackfillPlanError(msg)
+
+    trade_date = item.fetch_params.get("trade_date")
+    parsed_trade_date = _parse_fetch_trade_date(trade_date)
+    if parsed_trade_date is None or parsed_trade_date != item.partition_date:
+        msg = (
+            f"planned {item.dataset} backfill item requires a trade_date matching "
+            "partition_date before execution"
+        )
+        raise HoldingsBackfillPlanError(msg)
+
+    if (
+        item.dataset == "hsgt_hold_top10"
+        and parsed_trade_date > HSGT_HOLD_TOP10_BACKFILL_LAST_DATE
+    ):
+        msg = (
+            "planned hsgt_hold_top10 backfill item is after the supported "
+            f"{HSGT_HOLD_TOP10_BACKFILL_LAST_DATE:%Y-%m-%d} cutoff"
+        )
+        raise HoldingsBackfillPlanError(msg)
+
+
+def _parse_fetch_trade_date(value: Any) -> date | None:
+    if not isinstance(value, str):
+        return None
+    return _parse_yyyymmdd(value)
+
+
+def _looks_like_public_identifier(value: str) -> bool:
+    return bool(PUBLIC_IDENTIFIER_VALUE_RE.fullmatch(value.strip().upper()))
 
 
 def _assets_by_dataset(assets: Sequence[AssetSpec]) -> dict[str, AssetSpec]:

--- a/tests/unit/test_holdings_backfill.py
+++ b/tests/unit/test_holdings_backfill.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+
+from data_platform.adapters.tushare import (  # noqa: E402
+    TUSHARE_ASSETS,
+    TUSHARE_FUND_PORTFOLIO_ASSET,
+    TUSHARE_HSGT_HOLD_TOP10_ASSET,
+    TUSHARE_HSGT_TOP10_ASSET,
+    TUSHARE_TOP10_FLOATHOLDERS_ASSET,
+    TUSHARE_TOP10_HOLDERS_ASSET,
+)
+from data_platform.holdings_backfill import (  # noqa: E402
+    SUPPORTED_HOLDINGS_BACKFILL_DATASETS,
+    HoldingsBackfillPlanError,
+    build_holdings_backfill_plan,
+    execute_holdings_backfill_plan,
+    public_plan_summary,
+)
+from data_platform.raw import RawWriter  # noqa: E402
+
+
+class FakeHoldingsAdapter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def source_id(self) -> str:
+        return "tushare"
+
+    def get_assets(self) -> list[Any]:
+        return list(TUSHARE_ASSETS)
+
+    def get_resources(self) -> dict[str, Any]:
+        return {}
+
+    def get_staging_dbt_models(self) -> list[str]:
+        return []
+
+    def get_quota_config(self) -> dict[str, Any]:
+        return {}
+
+    def fetch(self, asset_id: str, params: dict[str, Any]) -> Any:
+        self.calls.append((asset_id, dict(params)))
+        asset = next(asset for asset in TUSHARE_ASSETS if asset.name == asset_id)
+        return _table_for_asset(asset, params)
+
+
+def test_five_holdings_interfaces_generate_bounded_plan() -> None:
+    plan = _full_plan()
+
+    assert plan.ok is True
+    assert [item.dataset for item in plan.planned_items] == [
+        "top10_holders",
+        "top10_floatholders",
+        "fund_portfolio",
+        "hsgt_top10",
+        "hsgt_hold_top10",
+    ]
+    assert {item.status for item in plan.items} == {"planned"}
+    assert {item.dataset for item in plan.items} == set(SUPPORTED_HOLDINGS_BACKFILL_DATASETS)
+
+
+@pytest.mark.parametrize(
+    ("datasets", "kwargs", "reason_type"),
+    [
+        (
+            ["top10_holders"],
+            {"periods": ["20240331"]},
+            "missing_bounded_inputs",
+        ),
+        (
+            ["fund_portfolio"],
+            {"fund_codes": ["001753.OF"]},
+            "missing_bounded_inputs",
+        ),
+        (
+            ["hsgt_top10"],
+            {"market_types": ["1"]},
+            "missing_bounded_inputs",
+        ),
+    ],
+)
+def test_missing_code_or_date_boundaries_are_rejected(
+    datasets: list[str],
+    kwargs: dict[str, list[str]],
+    reason_type: str,
+) -> None:
+    plan = build_holdings_backfill_plan(datasets=datasets, **kwargs)
+
+    assert plan.ok is False
+    assert len(plan.rejected_items) == 1
+    assert plan.rejected_items[0].reason_type == reason_type
+    assert plan.planned_items == ()
+
+
+def test_hsgt_hold_top10_skips_after_cutoff_without_calling_live_path() -> None:
+    plan = build_holdings_backfill_plan(
+        datasets=["hsgt_hold_top10"],
+        trade_dates=["20240820", "20240821"],
+        exchanges=["SH"],
+    )
+
+    assert [item.status for item in plan.items] == ["planned", "skipped"]
+    assert plan.items[0].fetch_params == {"trade_date": "20240820", "exchange": "SH"}
+    assert plan.items[1].reason_type == "post_publication_cutoff"
+    assert "2024-08-20" in str(plan.items[1].reason)
+
+
+def test_execute_uses_adapter_params_from_plan_and_writes_raw(tmp_path: Path) -> None:
+    adapter = FakeHoldingsAdapter()
+    writer = RawWriter(
+        raw_zone_path=tmp_path / "raw",
+        iceberg_warehouse_path=tmp_path / "warehouse",
+    )
+
+    result = execute_holdings_backfill_plan(
+        _full_plan(),
+        adapter=adapter,  # type: ignore[arg-type]
+        raw_writer=writer,
+    )
+
+    assert result.ok is True
+    assert len(result.artifacts) == 5
+    assert adapter.calls == [
+        (TUSHARE_TOP10_HOLDERS_ASSET.name, {"ts_code": "000001.SZ", "period": "20240331"}),
+        (
+            TUSHARE_TOP10_FLOATHOLDERS_ASSET.name,
+            {"ts_code": "000001.SZ", "period": "20240331"},
+        ),
+        (TUSHARE_FUND_PORTFOLIO_ASSET.name, {"ts_code": "001753.OF", "period": "20240331"}),
+        (TUSHARE_HSGT_TOP10_ASSET.name, {"trade_date": "20240402", "market_type": "1"}),
+        (TUSHARE_HSGT_HOLD_TOP10_ASSET.name, {"trade_date": "20240402", "exchange": "SH"}),
+    ]
+    assert {
+        artifact.path.parent.name
+        for artifact in result.artifacts
+    } == {"dt=20240331", "dt=20240402"}
+
+
+def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
+    adapter = FakeHoldingsAdapter()
+    plan = build_holdings_backfill_plan(
+        datasets=["top10_holders"],
+        periods=["20240331"],
+    )
+
+    with pytest.raises(HoldingsBackfillPlanError, match="rejected"):
+        execute_holdings_backfill_plan(
+            plan,
+            adapter=adapter,  # type: ignore[arg-type]
+            raw_writer=RawWriter(
+                raw_zone_path=tmp_path / "raw",
+                iceberg_warehouse_path=tmp_path / "warehouse",
+            ),
+        )
+
+    assert adapter.calls == []
+
+
+def test_public_plan_summary_does_not_leak_raw_provider_or_private_fields() -> None:
+    summary = public_plan_summary(_full_plan())
+    encoded = json.dumps(summary, sort_keys=True)
+
+    forbidden_terms = {
+        "asset",
+        "doc_api",
+        "fetch_params",
+        "fields",
+        "hk_hold",
+        "provider",
+        "raw",
+        "request_params",
+        "source_id",
+        "source_interface_id",
+        "Tushare",
+        "_",
+    }
+    assert not forbidden_terms.intersection(encoded.split('"'))
+    assert "ts_code" not in encoded
+
+
+def _full_plan() -> Any:
+    return build_holdings_backfill_plan(
+        datasets=SUPPORTED_HOLDINGS_BACKFILL_DATASETS,
+        stock_codes=["000001.SZ"],
+        fund_codes=["001753.OF"],
+        periods=["20240331"],
+        trade_dates=["20240402"],
+        market_types=["1"],
+        exchanges=["SH"],
+    )
+
+
+def _table_for_asset(asset: Any, params: dict[str, Any]) -> Any:
+    row = _row_for_asset(asset, params)
+    return pa.table(
+        {field.name: [row[field.name]] for field in asset.schema},
+        schema=asset.schema,
+    )
+
+
+def _row_for_asset(asset: Any, params: dict[str, Any]) -> dict[str, Any]:
+    row: dict[str, Any] = {}
+    date_value = params.get("period") or params.get("trade_date") or "20240331"
+    for field in asset.schema:
+        if field.name == "ts_code":
+            row[field.name] = params.get("ts_code", "000001.SZ")
+        elif field.name == "symbol":
+            row[field.name] = "000001.SZ"
+        elif field.name in {"ann_date", "end_date", "trade_date"}:
+            row[field.name] = date_value
+        elif field.name == "market_type":
+            row[field.name] = params.get("market_type", "1")
+        elif field.name == "exchange":
+            row[field.name] = params.get("exchange", "SH")
+        elif field.name == "rank":
+            row[field.name] = "1"
+        elif pa.types.is_decimal(field.type):
+            row[field.name] = Decimal("1.0")
+        elif pa.types.is_integer(field.type):
+            row[field.name] = 1
+        elif pa.types.is_floating(field.type):
+            row[field.name] = 1.0
+        elif pa.types.is_boolean(field.type):
+            row[field.name] = True
+        else:
+            row[field.name] = f"{field.name}-value"
+    return row

--- a/tests/unit/test_holdings_backfill.py
+++ b/tests/unit/test_holdings_backfill.py
@@ -209,6 +209,33 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
     [
         (
             HoldingsBackfillPlanItem(
+                dataset="top10_holders",
+                status="planned",
+                partition_date=date(2024, 3, 31),
+                fetch_params={"ts_code": "000001.SZ", "period": "20240430"},
+            ),
+            "period matching partition_date",
+        ),
+        (
+            HoldingsBackfillPlanItem(
+                dataset="top10_floatholders",
+                status="planned",
+                partition_date=date(2024, 3, 31),
+                fetch_params={"ts_code": "000001.SZ"},
+            ),
+            "non-empty scalar period",
+        ),
+        (
+            HoldingsBackfillPlanItem(
+                dataset="fund_portfolio",
+                status="planned",
+                partition_date=date(2024, 3, 31),
+                fetch_params={},
+            ),
+            "non-empty scalar ts_code",
+        ),
+        (
+            HoldingsBackfillPlanItem(
                 dataset="hsgt_top10",
                 status="planned",
                 partition_date=date(2024, 4, 2),
@@ -228,6 +255,33 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
                 },
             ),
             "non-empty scalar ts_code",
+        ),
+        (
+            HoldingsBackfillPlanItem(
+                dataset="hsgt_top10",
+                status="planned",
+                partition_date=date(2024, 4, 2),
+                fetch_params={"trade_date": "20240403", "market_type": "1", "ts_code": "000001.SZ"},
+            ),
+            "trade_date matching partition_date",
+        ),
+        (
+            HoldingsBackfillPlanItem(
+                dataset="hsgt_top10",
+                status="planned",
+                partition_date=date(2024, 4, 2),
+                fetch_params={"trade_date": "20240402", "ts_code": "000001.SZ"},
+            ),
+            "non-empty scalar market_type",
+        ),
+        (
+            HoldingsBackfillPlanItem(
+                dataset="hsgt_hold_top10",
+                status="planned",
+                partition_date=date(2024, 4, 2),
+                fetch_params={"trade_date": "20240402", "ts_code": "000001.SZ"},
+            ),
+            "non-empty scalar exchange",
         ),
         (
             HoldingsBackfillPlanItem(
@@ -253,6 +307,38 @@ def test_execute_revalidates_malformed_planned_hsgt_items_without_adapter_call(
     plan = HoldingsBackfillPlan((item,))
 
     with pytest.raises(HoldingsBackfillPlanError, match=match):
+        execute_holdings_backfill_plan(
+            plan,
+            adapter=adapter,  # type: ignore[arg-type]
+            raw_writer=RawWriter(
+                raw_zone_path=tmp_path / "raw",
+                iceberg_warehouse_path=tmp_path / "warehouse",
+            ),
+        )
+
+    assert adapter.calls == []
+
+
+def test_execute_preflights_full_plan_before_first_adapter_call(tmp_path: Path) -> None:
+    adapter = FakeHoldingsAdapter()
+    plan = HoldingsBackfillPlan(
+        (
+            HoldingsBackfillPlanItem(
+                dataset="top10_holders",
+                status="planned",
+                partition_date=date(2024, 3, 31),
+                fetch_params={"ts_code": "000001.SZ", "period": "20240331"},
+            ),
+            HoldingsBackfillPlanItem(
+                dataset="hsgt_top10",
+                status="planned",
+                partition_date=date(2024, 4, 2),
+                fetch_params={"trade_date": "20240402", "ts_code": "000001.SZ"},
+            ),
+        )
+    )
+
+    with pytest.raises(HoldingsBackfillPlanError, match="non-empty scalar market_type"):
         execute_holdings_backfill_plan(
             plan,
             adapter=adapter,  # type: ignore[arg-type]

--- a/tests/unit/test_holdings_backfill.py
+++ b/tests/unit/test_holdings_backfill.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+from datetime import date
 from decimal import Decimal
 from pathlib import Path
 from types import ModuleType
@@ -21,7 +22,9 @@ from data_platform.adapters.tushare import (  # noqa: E402
 )
 from data_platform.holdings_backfill import (  # noqa: E402
     SUPPORTED_HOLDINGS_BACKFILL_DATASETS,
+    HoldingsBackfillPlan,
     HoldingsBackfillPlanError,
+    HoldingsBackfillPlanItem,
     build_holdings_backfill_plan,
     execute_holdings_backfill_plan,
     public_plan_summary,
@@ -201,6 +204,67 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
     assert adapter.calls == []
 
 
+@pytest.mark.parametrize(
+    ("item", "match"),
+    [
+        (
+            HoldingsBackfillPlanItem(
+                dataset="hsgt_top10",
+                status="planned",
+                partition_date=date(2024, 4, 2),
+                fetch_params={"trade_date": "20240402", "market_type": "1"},
+            ),
+            "non-empty scalar ts_code",
+        ),
+        (
+            HoldingsBackfillPlanItem(
+                dataset="hsgt_top10",
+                status="planned",
+                partition_date=date(2024, 4, 2),
+                fetch_params={
+                    "trade_date": "20240402",
+                    "market_type": "1",
+                    "ts_code": ["000001.SZ"],
+                },
+            ),
+            "non-empty scalar ts_code",
+        ),
+        (
+            HoldingsBackfillPlanItem(
+                dataset="hsgt_hold_top10",
+                status="planned",
+                partition_date=date(2024, 8, 21),
+                fetch_params={
+                    "trade_date": "20240821",
+                    "exchange": "SH",
+                    "ts_code": "000001.SZ",
+                },
+            ),
+            "2024-08-20 cutoff",
+        ),
+    ],
+)
+def test_execute_revalidates_malformed_planned_hsgt_items_without_adapter_call(
+    tmp_path: Path,
+    item: HoldingsBackfillPlanItem,
+    match: str,
+) -> None:
+    adapter = FakeHoldingsAdapter()
+    plan = HoldingsBackfillPlan((item,))
+
+    with pytest.raises(HoldingsBackfillPlanError, match=match):
+        execute_holdings_backfill_plan(
+            plan,
+            adapter=adapter,  # type: ignore[arg-type]
+            raw_writer=RawWriter(
+                raw_zone_path=tmp_path / "raw",
+                iceberg_warehouse_path=tmp_path / "warehouse",
+            ),
+        )
+
+    assert adapter.calls == []
+
+
 def test_public_plan_summary_does_not_leak_raw_provider_or_private_fields() -> None:
     summary = public_plan_summary(_full_plan())
     encoded = json.dumps(summary, sort_keys=True)
@@ -224,6 +288,32 @@ def test_public_plan_summary_does_not_leak_raw_provider_or_private_fields() -> N
         "_",
     }
     assert not forbidden_terms.intersection(encoded.split('"'))
+    assert "ts_code" not in encoded
+
+
+def test_public_plan_summary_drops_unknown_identifier_bounds() -> None:
+    plan = HoldingsBackfillPlan(
+        (
+            HoldingsBackfillPlanItem(
+                dataset="top10_holders",
+                status="rejected",
+                bounds={
+                    "period": "20240331",
+                    "requested_identifiers": ["000001.SZ"],
+                    "_raw_params": {"ts_code": "000001.SZ"},
+                },
+                reason_type="example",
+                reason="example rejection",
+            ),
+        )
+    )
+
+    summary = public_plan_summary(plan)
+    encoded = json.dumps(summary, sort_keys=True)
+
+    assert summary["items"][0]["bounds"] == {"period": "20240331"}
+    assert "000001.SZ" not in encoded
+    assert "requested_identifiers" not in encoded
     assert "ts_code" not in encoded
 
 

--- a/tests/unit/test_holdings_backfill.py
+++ b/tests/unit/test_holdings_backfill.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 from decimal import Decimal
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import pytest
@@ -85,6 +87,11 @@ def test_five_holdings_interfaces_generate_bounded_plan() -> None:
             {"market_types": ["1"]},
             "missing_bounded_inputs",
         ),
+        (
+            ["hsgt_hold_top10"],
+            {"trade_dates": ["20240402"], "exchanges": ["SH"]},
+            "missing_bounded_inputs",
+        ),
     ],
 )
 def test_missing_code_or_date_boundaries_are_rejected(
@@ -100,15 +107,39 @@ def test_missing_code_or_date_boundaries_are_rejected(
     assert plan.planned_items == ()
 
 
+@pytest.mark.parametrize(
+    ("dataset", "kwargs"),
+    [
+        ("hsgt_top10", {"trade_dates": ["20240402"], "market_types": ["1"]}),
+        ("hsgt_hold_top10", {"trade_dates": ["20240402"], "exchanges": ["SH"]}),
+    ],
+)
+def test_hsgt_backfill_rejects_unbounded_market_or_exchange_scope(
+    dataset: str,
+    kwargs: dict[str, list[str]],
+) -> None:
+    plan = build_holdings_backfill_plan(datasets=[dataset], **kwargs)
+
+    assert plan.ok is False
+    assert plan.planned_items == ()
+    assert plan.rejected_items[0].reason_type == "missing_bounded_inputs"
+    assert "stock_codes" in plan.rejected_items[0].bounds["missing"]
+
+
 def test_hsgt_hold_top10_skips_after_cutoff_without_calling_live_path() -> None:
     plan = build_holdings_backfill_plan(
         datasets=["hsgt_hold_top10"],
+        stock_codes=["000001.SZ"],
         trade_dates=["20240820", "20240821"],
         exchanges=["SH"],
     )
 
     assert [item.status for item in plan.items] == ["planned", "skipped"]
-    assert plan.items[0].fetch_params == {"trade_date": "20240820", "exchange": "SH"}
+    assert plan.items[0].fetch_params == {
+        "trade_date": "20240820",
+        "exchange": "SH",
+        "ts_code": "000001.SZ",
+    }
     assert plan.items[1].reason_type == "post_publication_cutoff"
     assert "2024-08-20" in str(plan.items[1].reason)
 
@@ -135,8 +166,14 @@ def test_execute_uses_adapter_params_from_plan_and_writes_raw(tmp_path: Path) ->
             {"ts_code": "000001.SZ", "period": "20240331"},
         ),
         (TUSHARE_FUND_PORTFOLIO_ASSET.name, {"ts_code": "001753.OF", "period": "20240331"}),
-        (TUSHARE_HSGT_TOP10_ASSET.name, {"trade_date": "20240402", "market_type": "1"}),
-        (TUSHARE_HSGT_HOLD_TOP10_ASSET.name, {"trade_date": "20240402", "exchange": "SH"}),
+        (
+            TUSHARE_HSGT_TOP10_ASSET.name,
+            {"trade_date": "20240402", "market_type": "1", "ts_code": "000001.SZ"},
+        ),
+        (
+            TUSHARE_HSGT_HOLD_TOP10_ASSET.name,
+            {"trade_date": "20240402", "exchange": "SH", "ts_code": "000001.SZ"},
+        ),
     ]
     assert {
         artifact.path.parent.name
@@ -168,6 +205,10 @@ def test_public_plan_summary_does_not_leak_raw_provider_or_private_fields() -> N
     summary = public_plan_summary(_full_plan())
     encoded = json.dumps(summary, sort_keys=True)
 
+    assert "000001.SZ" not in encoded
+    assert "001753.OF" not in encoded
+    assert "stock_code_count" in encoded
+    assert "fund_code_count" in encoded
     forbidden_terms = {
         "asset",
         "doc_api",
@@ -186,6 +227,37 @@ def test_public_plan_summary_does_not_leak_raw_provider_or_private_fields() -> N
     assert "ts_code" not in encoded
 
 
+def test_cli_json_report_sanitizes_identifier_bounds(tmp_path: Path) -> None:
+    report_path = tmp_path / "reports" / "holdings.json"
+    cli = _load_holdings_backfill_cli()
+
+    exit_code = cli.main(
+        [
+            "--dataset",
+            "top10_holders",
+            "--stock-code",
+            "000001.SZ",
+            "--period",
+            "20240331",
+            "--json-report",
+            str(report_path),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    encoded = json.dumps(payload, sort_keys=True)
+    assert payload["execute_live"] is False
+    assert "execution" not in payload
+    assert payload["plan"]["items"][0]["bounds"] == {
+        "period": "20240331",
+        "stock_code_class": "stock_code",
+        "stock_code_count": 1,
+    }
+    assert "000001.SZ" not in encoded
+    assert "ts_code" not in encoded
+
+
 def _full_plan() -> Any:
     return build_holdings_backfill_plan(
         datasets=SUPPORTED_HOLDINGS_BACKFILL_DATASETS,
@@ -196,6 +268,16 @@ def _full_plan() -> Any:
         market_types=["1"],
         exchanges=["SH"],
     )
+
+
+def _load_holdings_backfill_cli() -> ModuleType:
+    script_path = Path(__file__).parents[2] / "scripts" / "holdings_backfill.py"
+    spec = importlib.util.spec_from_file_location("holdings_backfill_cli", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _table_for_asset(asset: Any, params: dict[str, Any]) -> Any:


### PR DESCRIPTION
## Summary
- Adds bounded holdings historical backfill planning and execution inside data-platform.
- Covers top10_holders, top10_floatholders, fund_portfolio, hsgt_top10, and hsgt_hold_top10.
- Keeps execution on data-platform adapter -> Raw Zone artifacts; staging/dbt/canonical remain downstream and are not run by this PR.
- Adds a plan-only CLI surface; live execution requires explicit --execute-live plus Raw Zone paths.

## Guardrails
- Bounded inputs are required; missing stock/fund code, period, date range, market type, or exchange inputs produce rejected plan items.
- hsgt_hold_top10 dates after 2024-08-20 are skipped with an auditable cutoff reason.
- Public plan summaries omit raw/provider/private request fields.
- No contracts changes, no derivation marts, no subsystem producer path, and no Ex-3 output.

## Validation
- python3 -m pytest tests/unit/test_holdings_backfill.py
- uv run --no-sync python -m pytest tests/unit/test_holdings_backfill.py tests/adapters/test_tushare_holdings.py tests/test_repository_artifact_guard.py
- uv run --no-sync python -m pytest tests/integration/test_daily_refresh.py -k "hk_hold or top10"
- PYTHONPATH=src python3 scripts/holdings_backfill.py --dataset top10_holders,hsgt_hold_top10 --stock-code 000001.SZ --period 20240331 --trade-date 20240821 --exchange SH --max-plan-items 20
- python3 -m ruff check src/data_platform/holdings_backfill.py scripts/holdings_backfill.py tests/unit/test_holdings_backfill.py
- git diff --check

## Live Proof
- Not attempted for PR1; no raw live output or secrets were written.
