### PR TITLE
Add holdings derivation marts

### DIFF
--- a/src/data_platform/dbt/dbt_project.yml
+++ b/src/data_platform/dbt/dbt_project.yml
@@ -23,3 +23,7 @@ models:
       +materialized: table
     marts:
       +materialized: table
+    marts_derivations:
+      +materialized: table
+    marts_derivation_lineage:
+      +materialized: table

--- a/src/data_platform/dbt/macros/derivation_tests.sql
+++ b/src/data_platform/dbt/macros/derivation_tests.sql
@@ -1,0 +1,33 @@
+{% test derivation_lineage_key_parity(model, business_model, key_columns) -%}
+with business_keys as (
+    select distinct
+    {%- for column_name in key_columns %}
+        {{ adapter.quote(column_name) }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+    from {{ business_model }}
+),
+
+lineage_keys as (
+    select distinct
+    {%- for column_name in key_columns %}
+        {{ adapter.quote(column_name) }}{% if not loop.last %},{% endif %}
+    {%- endfor %}
+    from {{ model }}
+),
+
+missing_from_lineage as (
+    select * from business_keys
+    except
+    select * from lineage_keys
+),
+
+extra_in_lineage as (
+    select * from lineage_keys
+    except
+    select * from business_keys
+)
+
+select * from missing_from_lineage
+union all
+select * from extra_in_lineage
+{%- endtest %}

--- a/src/data_platform/dbt/models/marts_derivation_lineage/_schema.yml
+++ b/src/data_platform/dbt/models/marts_derivation_lineage/_schema.yml
@@ -1,0 +1,172 @@
+version: 2
+
+models:
+  - name: mart_deriv_lineage_top_holder_qoq_change
+    description: Lineage summary paired to mart_deriv_top_holder_qoq_change on the current holding row key.
+    tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - holding_source
+            - holder_id
+            - security_id
+            - report_date
+            - announced_date
+      - derivation_lineage_key_parity:
+          business_model: ref('mart_deriv_top_holder_qoq_change')
+          key_columns:
+            - holding_source
+            - holder_id
+            - security_id
+            - report_date
+            - announced_date
+    columns:
+      - name: holding_source
+        tests:
+          - not_null
+      - name: holder_id
+        tests:
+          - not_null
+      - name: security_id
+        tests:
+          - not_null
+      - name: report_date
+        tests:
+          - not_null
+      - name: announced_date
+        tests:
+          - not_null
+      - name: source_mart
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - 'mart_fact_holding_position_v2'
+              quote: true
+      - name: source_window_start_date
+        tests:
+          - not_null
+      - name: source_window_end_date
+        tests:
+          - not_null
+      - name: source_interface_ids
+        tests:
+          - not_null
+      - name: source_row_count
+        tests:
+          - not_null
+      - name: source_lineage_row_count
+        tests:
+          - not_null
+      - name: source_lineage_summary
+        tests:
+          - not_null
+
+  - name: mart_deriv_lineage_fund_co_holding
+    description: Lineage summary paired to mart_deriv_fund_co_holding on the lexicographic pair key.
+    tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - report_date
+            - security_id_left
+            - security_id_right
+      - derivation_lineage_key_parity:
+          business_model: ref('mart_deriv_fund_co_holding')
+          key_columns:
+            - report_date
+            - security_id_left
+            - security_id_right
+    columns:
+      - name: report_date
+        tests:
+          - not_null
+      - name: security_id_left
+        tests:
+          - not_null
+      - name: security_id_right
+        tests:
+          - not_null
+      - name: source_mart
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - 'mart_fact_holding_position_v2'
+              quote: true
+      - name: source_window_start_date
+        tests:
+          - not_null
+      - name: source_window_end_date
+        tests:
+          - not_null
+      - name: source_interface_ids
+        tests:
+          - not_null
+      - name: source_row_count
+        tests:
+          - not_null
+      - name: source_lineage_row_count
+        tests:
+          - not_null
+      - name: source_lineage_summary
+        tests:
+          - not_null
+
+  - name: mart_deriv_lineage_northbound_holding_z_score
+    description: Lineage summary paired to mart_deriv_northbound_holding_z_score on the metric row key and source rolling window.
+    tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - security_id
+            - holder_id
+            - report_date
+            - z_score_metric
+      - derivation_lineage_key_parity:
+          business_model: ref('mart_deriv_northbound_holding_z_score')
+          key_columns:
+            - security_id
+            - holder_id
+            - report_date
+            - z_score_metric
+    columns:
+      - name: security_id
+        tests:
+          - not_null
+      - name: holder_id
+        tests:
+          - not_null
+      - name: report_date
+        tests:
+          - not_null
+      - name: z_score_metric
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - 'holding_amount'
+                - 'holding_ratio'
+              quote: true
+      - name: source_mart
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - 'mart_fact_holding_position_v2'
+              quote: true
+      - name: source_window_start_date
+        tests:
+          - not_null
+      - name: source_window_end_date
+        tests:
+          - not_null
+      - name: source_interface_ids
+        tests:
+          - not_null
+      - name: source_row_count
+        tests:
+          - not_null
+      - name: source_lineage_row_count
+        tests:
+          - not_null
+      - name: source_lineage_summary
+        tests:
+          - not_null

--- a/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_fund_co_holding.sql
+++ b/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_fund_co_holding.sql
@@ -1,6 +1,32 @@
 {{ config(materialized="table") }}
 
-with source_rows as (
+with fund_security_positions as (
+    select
+        report_date,
+        holder_id,
+        security_id,
+        max(announced_date) as latest_announced_date
+    from {{ ref('mart_fact_holding_position_v2') }}
+    where holding_source = 'fund_portfolio'
+    group by report_date, holder_id, security_id
+),
+
+fund_pairs as (
+    select
+        left_position.report_date,
+        left_position.security_id as security_id_left,
+        right_position.security_id as security_id_right,
+        left_position.holder_id,
+        left_position.latest_announced_date as left_announced_date,
+        right_position.latest_announced_date as right_announced_date
+    from fund_security_positions as left_position
+    inner join fund_security_positions as right_position
+        on left_position.report_date = right_position.report_date
+        and left_position.holder_id = right_position.holder_id
+        and left_position.security_id < right_position.security_id
+),
+
+source_rows as (
     select
         co_holding.report_date,
         co_holding.security_id_left,
@@ -10,13 +36,38 @@ with source_rows as (
         lineage.source_run_id,
         lineage.raw_loaded_at
     from {{ ref('mart_deriv_fund_co_holding') }} as co_holding
+    inner join fund_pairs
+        on co_holding.report_date = fund_pairs.report_date
+        and co_holding.security_id_left = fund_pairs.security_id_left
+        and co_holding.security_id_right = fund_pairs.security_id_right
     inner join {{ ref('mart_lineage_fact_holding_position') }} as lineage
-        on co_holding.report_date = lineage.report_date
+        on fund_pairs.report_date = lineage.report_date
+        and fund_pairs.holder_id = lineage.holder_id
         and lineage.holding_source = 'fund_portfolio'
-        and lineage.security_id in (
-            co_holding.security_id_left,
-            co_holding.security_id_right
-        )
+        and fund_pairs.security_id_left = lineage.security_id
+        and fund_pairs.left_announced_date = lineage.announced_date
+
+    union all
+
+    select
+        co_holding.report_date,
+        co_holding.security_id_left,
+        co_holding.security_id_right,
+        lineage.report_date as source_report_date,
+        lineage.source_interface_id,
+        lineage.source_run_id,
+        lineage.raw_loaded_at
+    from {{ ref('mart_deriv_fund_co_holding') }} as co_holding
+    inner join fund_pairs
+        on co_holding.report_date = fund_pairs.report_date
+        and co_holding.security_id_left = fund_pairs.security_id_left
+        and co_holding.security_id_right = fund_pairs.security_id_right
+    inner join {{ ref('mart_lineage_fact_holding_position') }} as lineage
+        on fund_pairs.report_date = lineage.report_date
+        and fund_pairs.holder_id = lineage.holder_id
+        and lineage.holding_source = 'fund_portfolio'
+        and fund_pairs.security_id_right = lineage.security_id
+        and fund_pairs.right_announced_date = lineage.announced_date
 )
 
 select

--- a/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_fund_co_holding.sql
+++ b/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_fund_co_holding.sql
@@ -1,0 +1,45 @@
+{{ config(materialized="table") }}
+
+with source_rows as (
+    select
+        co_holding.report_date,
+        co_holding.security_id_left,
+        co_holding.security_id_right,
+        lineage.report_date as source_report_date,
+        lineage.source_interface_id,
+        lineage.source_run_id,
+        lineage.raw_loaded_at
+    from {{ ref('mart_deriv_fund_co_holding') }} as co_holding
+    inner join {{ ref('mart_lineage_fact_holding_position') }} as lineage
+        on co_holding.report_date = lineage.report_date
+        and lineage.holding_source = 'fund_portfolio'
+        and lineage.security_id in (
+            co_holding.security_id_left,
+            co_holding.security_id_right
+        )
+)
+
+select
+    report_date,
+    security_id_left,
+    security_id_right,
+    cast('mart_fact_holding_position_v2' as varchar) as source_mart,
+    min(source_report_date) as source_window_start_date,
+    max(source_report_date) as source_window_end_date,
+    string_agg(distinct source_interface_id, ',') as source_interface_ids,
+    count(*) as source_row_count,
+    count(*) as source_lineage_row_count,
+    string_agg(distinct cast(source_run_id as varchar), ',') as source_run_ids,
+    min(raw_loaded_at) as raw_loaded_at_min,
+    max(raw_loaded_at) as raw_loaded_at_max,
+    concat(
+        'source_rows=',
+        cast(count(*) as varchar),
+        ';lineage_rows=',
+        cast(count(*) as varchar)
+    ) as source_lineage_summary
+from source_rows
+group by
+    report_date,
+    security_id_left,
+    security_id_right

--- a/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_northbound_holding_z_score.sql
+++ b/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_northbound_holding_z_score.sql
@@ -1,0 +1,46 @@
+{{ config(materialized="table") }}
+
+with source_rows as (
+    select
+        z_score.security_id,
+        z_score.holder_id,
+        z_score.report_date,
+        z_score.z_score_metric,
+        lineage.report_date as source_report_date,
+        lineage.source_interface_id,
+        lineage.source_run_id,
+        lineage.raw_loaded_at
+    from {{ ref('mart_deriv_northbound_holding_z_score') }} as z_score
+    inner join {{ ref('mart_lineage_fact_holding_position') }} as lineage
+        on z_score.security_id = lineage.security_id
+        and z_score.holder_id = lineage.holder_id
+        and lineage.holding_source = 'northbound_hold'
+        and lineage.report_date between z_score.window_start_date and z_score.window_end_date
+)
+
+select
+    security_id,
+    holder_id,
+    report_date,
+    z_score_metric,
+    cast('mart_fact_holding_position_v2' as varchar) as source_mart,
+    min(source_report_date) as source_window_start_date,
+    max(source_report_date) as source_window_end_date,
+    string_agg(distinct source_interface_id, ',') as source_interface_ids,
+    count(*) as source_row_count,
+    count(*) as source_lineage_row_count,
+    string_agg(distinct cast(source_run_id as varchar), ',') as source_run_ids,
+    min(raw_loaded_at) as raw_loaded_at_min,
+    max(raw_loaded_at) as raw_loaded_at_max,
+    concat(
+        'source_rows=',
+        cast(count(*) as varchar),
+        ';lineage_rows=',
+        cast(count(*) as varchar)
+    ) as source_lineage_summary
+from source_rows
+group by
+    security_id,
+    holder_id,
+    report_date,
+    z_score_metric

--- a/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_top_holder_qoq_change.sql
+++ b/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_top_holder_qoq_change.sql
@@ -1,0 +1,72 @@
+{{ config(materialized="table") }}
+
+with source_rows as (
+    select
+        qoq.holding_source,
+        qoq.holder_id,
+        qoq.security_id,
+        qoq.report_date,
+        qoq.announced_date,
+        lineage.report_date as source_report_date,
+        lineage.announced_date as source_announced_date,
+        lineage.source_interface_id,
+        lineage.source_run_id,
+        lineage.raw_loaded_at
+    from {{ ref('mart_deriv_top_holder_qoq_change') }} as qoq
+    inner join {{ ref('mart_lineage_fact_holding_position') }} as lineage
+        on qoq.holding_source = lineage.holding_source
+        and qoq.holder_id = lineage.holder_id
+        and qoq.security_id = lineage.security_id
+        and qoq.report_date = lineage.report_date
+        and qoq.announced_date = lineage.announced_date
+
+    union all
+
+    select
+        qoq.holding_source,
+        qoq.holder_id,
+        qoq.security_id,
+        qoq.report_date,
+        qoq.announced_date,
+        lineage.report_date as source_report_date,
+        lineage.announced_date as source_announced_date,
+        lineage.source_interface_id,
+        lineage.source_run_id,
+        lineage.raw_loaded_at
+    from {{ ref('mart_deriv_top_holder_qoq_change') }} as qoq
+    inner join {{ ref('mart_lineage_fact_holding_position') }} as lineage
+        on qoq.holding_source = lineage.holding_source
+        and qoq.holder_id = lineage.holder_id
+        and qoq.security_id = lineage.security_id
+        and qoq.previous_report_date = lineage.report_date
+        and qoq.previous_announced_date = lineage.announced_date
+)
+
+select
+    holding_source,
+    holder_id,
+    security_id,
+    report_date,
+    announced_date,
+    cast('mart_fact_holding_position_v2' as varchar) as source_mart,
+    min(source_report_date) as source_window_start_date,
+    max(source_report_date) as source_window_end_date,
+    string_agg(distinct source_interface_id, ',') as source_interface_ids,
+    count(*) as source_row_count,
+    count(*) as source_lineage_row_count,
+    string_agg(distinct cast(source_run_id as varchar), ',') as source_run_ids,
+    min(raw_loaded_at) as raw_loaded_at_min,
+    max(raw_loaded_at) as raw_loaded_at_max,
+    concat(
+        'source_rows=',
+        cast(count(*) as varchar),
+        ';lineage_rows=',
+        cast(count(*) as varchar)
+    ) as source_lineage_summary
+from source_rows
+group by
+    holding_source,
+    holder_id,
+    security_id,
+    report_date,
+    announced_date

--- a/src/data_platform/dbt/models/marts_derivations/_schema.yml
+++ b/src/data_platform/dbt/models/marts_derivations/_schema.yml
@@ -1,0 +1,117 @@
+version: 2
+
+models:
+  - name: mart_deriv_top_holder_qoq_change
+    description: Quarter-over-quarter change rows derived from canonical holdings for top holder sources only.
+    tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - holding_source
+            - holder_id
+            - security_id
+            - report_date
+            - announced_date
+    columns:
+      - name: holding_source
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - 'top_holder'
+                - 'top_float_holder'
+              quote: true
+      - name: holder_id
+        tests:
+          - not_null
+      - name: security_id
+        tests:
+          - not_null
+      - name: report_date
+        tests:
+          - not_null
+      - name: announced_date
+        tests:
+          - not_null
+
+  - name: mart_deriv_fund_co_holding
+    description: Fund co-holding security pairs derived from canonical fund portfolio holdings, ordered lexicographically to avoid self-pairs and inverse duplicates.
+    tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - report_date
+            - security_id_left
+            - security_id_right
+    columns:
+      - name: report_date
+        tests:
+          - not_null
+      - name: security_id_left
+        tests:
+          - not_null
+      - name: security_id_right
+        tests:
+          - not_null
+      - name: co_holding_fund_count
+        tests:
+          - not_null
+      - name: security_left_fund_count
+        tests:
+          - not_null
+      - name: security_right_fund_count
+        tests:
+          - not_null
+      - name: jaccard_score
+        tests:
+          - not_null
+      - name: latest_announced_date
+        tests:
+          - not_null
+
+  - name: mart_deriv_northbound_holding_z_score
+    description: Rolling z-score features derived from canonical northbound holdings for holding amount and holding ratio.
+    tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - security_id
+            - holder_id
+            - report_date
+            - z_score_metric
+    columns:
+      - name: security_id
+        tests:
+          - not_null
+      - name: holder_id
+        tests:
+          - not_null
+      - name: report_date
+        tests:
+          - not_null
+      - name: z_score_metric
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - 'holding_amount'
+                - 'holding_ratio'
+              quote: true
+      - name: lookback_observations
+        tests:
+          - not_null
+          - accepted_values:
+              values: [8]
+              quote: false
+      - name: window_start_date
+        tests:
+          - not_null
+      - name: window_end_date
+        tests:
+          - not_null
+      - name: observation_count
+        tests:
+          - not_null
+      - name: metric_value
+        tests:
+          - not_null
+      - name: metric_mean
+        tests:
+          - not_null

--- a/src/data_platform/dbt/models/marts_derivations/mart_deriv_fund_co_holding.sql
+++ b/src/data_platform/dbt/models/marts_derivations/mart_deriv_fund_co_holding.sql
@@ -1,0 +1,67 @@
+{{ config(materialized="table") }}
+
+with fund_security_positions as (
+    select
+        report_date,
+        holder_id,
+        security_id,
+        max(announced_date) as latest_announced_date
+    from {{ ref('mart_fact_holding_position_v2') }}
+    where holding_source = 'fund_portfolio'
+    group by report_date, holder_id, security_id
+),
+
+security_counts as (
+    select
+        report_date,
+        security_id,
+        count(distinct holder_id) as fund_count
+    from fund_security_positions
+    group by report_date, security_id
+),
+
+fund_pairs as (
+    select
+        left_position.report_date,
+        left_position.security_id as security_id_left,
+        right_position.security_id as security_id_right,
+        left_position.holder_id,
+        greatest(
+            left_position.latest_announced_date,
+            right_position.latest_announced_date
+        ) as latest_announced_date
+    from fund_security_positions as left_position
+    inner join fund_security_positions as right_position
+        on left_position.report_date = right_position.report_date
+        and left_position.holder_id = right_position.holder_id
+        and left_position.security_id < right_position.security_id
+)
+
+select
+    fund_pairs.report_date,
+    fund_pairs.security_id_left,
+    fund_pairs.security_id_right,
+    count(distinct fund_pairs.holder_id) as co_holding_fund_count,
+    left_counts.fund_count as security_left_fund_count,
+    right_counts.fund_count as security_right_fund_count,
+    cast(count(distinct fund_pairs.holder_id) as double)
+        / nullif(
+            left_counts.fund_count
+            + right_counts.fund_count
+            - count(distinct fund_pairs.holder_id),
+            0
+        ) as jaccard_score,
+    max(fund_pairs.latest_announced_date) as latest_announced_date
+from fund_pairs
+inner join security_counts as left_counts
+    on fund_pairs.report_date = left_counts.report_date
+    and fund_pairs.security_id_left = left_counts.security_id
+inner join security_counts as right_counts
+    on fund_pairs.report_date = right_counts.report_date
+    and fund_pairs.security_id_right = right_counts.security_id
+group by
+    fund_pairs.report_date,
+    fund_pairs.security_id_left,
+    fund_pairs.security_id_right,
+    left_counts.fund_count,
+    right_counts.fund_count

--- a/src/data_platform/dbt/models/marts_derivations/mart_deriv_northbound_holding_z_score.sql
+++ b/src/data_platform/dbt/models/marts_derivations/mart_deriv_northbound_holding_z_score.sql
@@ -1,0 +1,63 @@
+{{ config(materialized="table") }}
+
+with northbound_metrics as (
+    select
+        security_id,
+        holder_id,
+        report_date,
+        cast('holding_amount' as varchar) as z_score_metric,
+        holding_amount as metric_value
+    from {{ ref('mart_fact_holding_position_v2') }}
+    where holding_source = 'northbound_hold'
+
+    union all
+
+    select
+        security_id,
+        holder_id,
+        report_date,
+        cast('holding_ratio' as varchar) as z_score_metric,
+        holding_ratio as metric_value
+    from {{ ref('mart_fact_holding_position_v2') }}
+    where holding_source = 'northbound_hold'
+),
+
+windowed_metrics as (
+    select
+        security_id,
+        holder_id,
+        report_date,
+        z_score_metric,
+        cast(8 as integer) as lookback_observations,
+        min(report_date) over metric_window as window_start_date,
+        max(report_date) over metric_window as window_end_date,
+        count(metric_value) over metric_window as observation_count,
+        metric_value,
+        avg(metric_value) over metric_window as metric_mean,
+        stddev_samp(metric_value) over metric_window as metric_stddev
+    from northbound_metrics
+    window metric_window as (
+        partition by security_id, holder_id, z_score_metric
+        order by report_date
+        rows between 7 preceding and current row
+    )
+)
+
+select
+    security_id,
+    holder_id,
+    report_date,
+    z_score_metric,
+    lookback_observations,
+    window_start_date,
+    window_end_date,
+    observation_count,
+    metric_value,
+    metric_mean,
+    metric_stddev,
+    case
+        when metric_stddev is null or metric_stddev = 0
+            then cast(null as double)
+        else (metric_value - metric_mean) / metric_stddev
+    end as metric_z_score
+from windowed_metrics

--- a/src/data_platform/dbt/models/marts_derivations/mart_deriv_top_holder_qoq_change.sql
+++ b/src/data_platform/dbt/models/marts_derivations/mart_deriv_top_holder_qoq_change.sql
@@ -8,25 +8,58 @@ with top_holder_positions as (
         report_date,
         announced_date,
         holding_amount,
+        holding_ratio
+    from {{ ref('mart_fact_holding_position_v2') }}
+    where holding_source in ('top_holder', 'top_float_holder')
+),
+
+latest_report_positions as (
+    select
+        holding_source,
+        holder_id,
+        security_id,
+        report_date,
+        announced_date,
+        holding_amount,
+        holding_ratio
+    from (
+        select
+            top_holder_positions.*,
+            row_number() over (
+                partition by holding_source, holder_id, security_id, report_date
+                order by announced_date desc
+            ) as announcement_rank
+        from top_holder_positions
+    ) as ranked_positions
+    where announcement_rank = 1
+),
+
+period_changes as (
+    select
+        holding_source,
+        holder_id,
+        security_id,
+        report_date,
+        announced_date,
+        holding_amount,
         holding_ratio,
         lag(report_date) over (
             partition by holding_source, holder_id, security_id
-            order by report_date, announced_date
+            order by report_date
         ) as previous_report_date,
         lag(announced_date) over (
             partition by holding_source, holder_id, security_id
-            order by report_date, announced_date
+            order by report_date
         ) as previous_announced_date,
         lag(holding_amount) over (
             partition by holding_source, holder_id, security_id
-            order by report_date, announced_date
+            order by report_date
         ) as previous_holding_amount,
         lag(holding_ratio) over (
             partition by holding_source, holder_id, security_id
-            order by report_date, announced_date
+            order by report_date
         ) as previous_holding_ratio
-    from {{ ref('mart_fact_holding_position_v2') }}
-    where holding_source in ('top_holder', 'top_float_holder')
+    from latest_report_positions
 )
 
 select
@@ -48,4 +81,4 @@ select
     holding_ratio,
     previous_holding_ratio,
     holding_ratio - previous_holding_ratio as holding_ratio_delta
-from top_holder_positions
+from period_changes

--- a/src/data_platform/dbt/models/marts_derivations/mart_deriv_top_holder_qoq_change.sql
+++ b/src/data_platform/dbt/models/marts_derivations/mart_deriv_top_holder_qoq_change.sql
@@ -1,0 +1,51 @@
+{{ config(materialized="table") }}
+
+with top_holder_positions as (
+    select
+        holding_source,
+        holder_id,
+        security_id,
+        report_date,
+        announced_date,
+        holding_amount,
+        holding_ratio,
+        lag(report_date) over (
+            partition by holding_source, holder_id, security_id
+            order by report_date, announced_date
+        ) as previous_report_date,
+        lag(announced_date) over (
+            partition by holding_source, holder_id, security_id
+            order by report_date, announced_date
+        ) as previous_announced_date,
+        lag(holding_amount) over (
+            partition by holding_source, holder_id, security_id
+            order by report_date, announced_date
+        ) as previous_holding_amount,
+        lag(holding_ratio) over (
+            partition by holding_source, holder_id, security_id
+            order by report_date, announced_date
+        ) as previous_holding_ratio
+    from {{ ref('mart_fact_holding_position_v2') }}
+    where holding_source in ('top_holder', 'top_float_holder')
+)
+
+select
+    holding_source,
+    holder_id,
+    security_id,
+    report_date,
+    announced_date,
+    previous_report_date,
+    previous_announced_date,
+    holding_amount,
+    previous_holding_amount,
+    holding_amount - previous_holding_amount as holding_amount_delta,
+    case
+        when previous_holding_amount is null or previous_holding_amount = 0
+            then cast(null as decimal(38, 18))
+        else (holding_amount - previous_holding_amount) / previous_holding_amount
+    end as holding_amount_delta_pct,
+    holding_ratio,
+    previous_holding_ratio,
+    holding_ratio - previous_holding_ratio as holding_ratio_delta
+from top_holder_positions

--- a/tests/dbt/test_dbt_skeleton.py
+++ b/tests/dbt/test_dbt_skeleton.py
@@ -14,6 +14,10 @@ STAGING_DIR = DBT_PROJECT_DIR / "models" / "staging"
 INTERMEDIATE_DIR = DBT_PROJECT_DIR / "models" / "intermediate"
 MARTS_V2_DIR = DBT_PROJECT_DIR / "models" / "marts_v2"
 MARTS_LINEAGE_DIR = DBT_PROJECT_DIR / "models" / "marts_lineage"
+MARTS_DERIVATIONS_DIR = DBT_PROJECT_DIR / "models" / "marts_derivations"
+MARTS_DERIVATION_LINEAGE_DIR = (
+    DBT_PROJECT_DIR / "models" / "marts_derivation_lineage"
+)
 INTERMEDIATE_MODEL_NAMES = [
     "int_event_timeline",
     "int_financial_reports_latest",
@@ -57,6 +61,16 @@ MART_LINEAGE_MODEL_NAMES = [
     "mart_lineage_fact_holding_position",
     "mart_lineage_fact_northbound_turnover",
 ]
+MART_DERIVATION_MODEL_NAMES = [
+    "mart_deriv_top_holder_qoq_change",
+    "mart_deriv_fund_co_holding",
+    "mart_deriv_northbound_holding_z_score",
+]
+MART_DERIVATION_LINEAGE_MODEL_NAMES = [
+    "mart_deriv_lineage_top_holder_qoq_change",
+    "mart_deriv_lineage_fund_co_holding",
+    "mart_deriv_lineage_northbound_holding_z_score",
+]
 
 
 def test_dbt_skeleton_files_are_present() -> None:
@@ -73,12 +87,22 @@ def test_dbt_skeleton_files_are_present() -> None:
         DBT_PROJECT_DIR / "models" / "intermediate" / ".gitkeep",
         MARTS_V2_DIR / "_schema.yml",
         MARTS_LINEAGE_DIR / "_schema.yml",
+        MARTS_DERIVATIONS_DIR / "_schema.yml",
+        MARTS_DERIVATION_LINEAGE_DIR / "_schema.yml",
         DBT_PROJECT_DIR / "seeds" / ".gitkeep",
         PROJECT_ROOT / "scripts" / "dbt.sh",
         *[STAGING_DIR / f"stg_{asset.dataset}.sql" for asset in TUSHARE_ASSETS],
         *[INTERMEDIATE_DIR / f"{model_name}.sql" for model_name in INTERMEDIATE_MODEL_NAMES],
         *[MARTS_V2_DIR / f"{model_name}.sql" for model_name in MART_V2_MODEL_NAMES],
         *[MARTS_LINEAGE_DIR / f"{model_name}.sql" for model_name in MART_LINEAGE_MODEL_NAMES],
+        *[
+            MARTS_DERIVATIONS_DIR / f"{model_name}.sql"
+            for model_name in MART_DERIVATION_MODEL_NAMES
+        ],
+        *[
+            MARTS_DERIVATION_LINEAGE_DIR / f"{model_name}.sql"
+            for model_name in MART_DERIVATION_LINEAGE_MODEL_NAMES
+        ],
     ]
 
     missing_paths = [path for path in required_paths if not path.exists()]
@@ -97,6 +121,14 @@ def test_dbt_skeleton_files_are_present() -> None:
             *(
                 f"models/marts_lineage/{model_name}.sql"
                 for model_name in MART_LINEAGE_MODEL_NAMES
+            ),
+            *(
+                f"models/marts_derivations/{model_name}.sql"
+                for model_name in MART_DERIVATION_MODEL_NAMES
+            ),
+            *(
+                f"models/marts_derivation_lineage/{model_name}.sql"
+                for model_name in MART_DERIVATION_LINEAGE_MODEL_NAMES
             ),
         ]
     )

--- a/tests/dbt/test_holdings_derivation_marts.py
+++ b/tests/dbt/test_holdings_derivation_marts.py
@@ -27,6 +27,16 @@ def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
             "holder-a",
             "000001.SZ",
             date(2025, 12, 31),
+            date(2026, 1, 15),
+            90,
+            9,
+        )
+        _insert_holding_row(
+            connection,
+            "top_holder",
+            "holder-a",
+            "000001.SZ",
+            date(2025, 12, 31),
             date(2026, 1, 31),
             100,
             10,
@@ -65,6 +75,13 @@ def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
             where report_date = date '2026-03-31'
             """
         ).fetchone()
+        qoq_rows = connection.execute(
+            """
+            select report_date, announced_date, previous_report_date
+            from mart_deriv_top_holder_qoq_change
+            order by report_date, announced_date
+            """
+        ).fetchall()
         key_diff_count = _key_diff_count(
             connection,
             "mart_deriv_top_holder_qoq_change",
@@ -82,6 +99,10 @@ def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
         connection.close()
 
     assert qoq_row == (date(2025, 12, 31), date(2026, 1, 31), 25, 0.25, 2)
+    assert qoq_rows == [
+        (date(2025, 12, 31), date(2026, 1, 31), None),
+        (date(2026, 3, 31), date(2026, 4, 30), date(2025, 12, 31)),
+    ]
     assert key_diff_count == 0
     assert lineage_row == ("mart_fact_holding_position_v2", "top10_holders", 2)
 
@@ -158,6 +179,73 @@ def test_fund_co_holding_orders_pairs_and_dedupes_inverse_pairs() -> None:
     ]
     assert inverse_pair_count == 0
     assert key_diff_count == 0
+
+
+def test_fund_co_holding_lineage_only_counts_contributing_pair_rows() -> None:
+    duckdb = pytest.importorskip("duckdb")
+
+    connection = duckdb.connect(":memory:")
+    try:
+        _create_holding_fixture_tables(connection)
+        for holder_id, security_id in [
+            ("fund-1", "000001.SZ"),
+            ("fund-1", "000002.SZ"),
+            ("fund-2", "000001.SZ"),
+            ("fund-2", "000002.SZ"),
+        ]:
+            _insert_holding_row(
+                connection,
+                "fund_portfolio",
+                holder_id,
+                security_id,
+                date(2026, 3, 31),
+                date(2026, 4, 30),
+                10,
+                1,
+                source_run_id=f"run-{holder_id}-{security_id}",
+            )
+        _insert_holding_row(
+            connection,
+            "fund_portfolio",
+            "fund-side-only",
+            "000001.SZ",
+            date(2026, 3, 31),
+            date(2026, 4, 30),
+            10,
+            1,
+            source_run_id="run-side-only",
+        )
+
+        _create_mart_table(
+            connection,
+            "mart_deriv_fund_co_holding",
+            MARTS_DERIVATIONS_DIR,
+        )
+        _create_mart_table(
+            connection,
+            "mart_deriv_lineage_fund_co_holding",
+            MARTS_DERIVATION_LINEAGE_DIR,
+        )
+
+        lineage_row = connection.execute(
+            """
+            select source_row_count, source_lineage_row_count, source_run_ids
+            from mart_deriv_lineage_fund_co_holding
+            where report_date = date '2026-03-31'
+              and security_id_left = '000001.SZ'
+              and security_id_right = '000002.SZ'
+            """
+        ).fetchone()
+    finally:
+        connection.close()
+
+    assert lineage_row[0:2] == (4, 4)
+    assert set(lineage_row[2].split(",")) == {
+        "run-fund-1-000001.SZ",
+        "run-fund-1-000002.SZ",
+        "run-fund-2-000001.SZ",
+        "run-fund-2-000002.SZ",
+    }
 
 
 def test_northbound_z_score_nulls_when_window_stddev_is_null_or_zero() -> None:
@@ -278,6 +366,7 @@ def _insert_holding_row(
     announced_date: date,
     holding_amount: int,
     holding_ratio: int,
+    source_run_id: str | None = None,
 ) -> None:
     source_interface_id = {
         "top_holder": "top10_holders",
@@ -321,7 +410,7 @@ def _insert_holding_row(
             announced_date,
             "fixture",
             source_interface_id,
-            f"run-{source_interface_id}",
+            source_run_id or f"run-{source_interface_id}",
             datetime(2026, 5, 1, 0, 0, 0),
         ],
     )

--- a/tests/dbt/test_holdings_derivation_marts.py
+++ b/tests/dbt/test_holdings_derivation_marts.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.dbt.test_marts_models import _create_mart_table
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DBT_PROJECT_DIR = PROJECT_ROOT / "src" / "data_platform" / "dbt"
+MARTS_DERIVATIONS_DIR = DBT_PROJECT_DIR / "models" / "marts_derivations"
+MARTS_DERIVATION_LINEAGE_DIR = DBT_PROJECT_DIR / "models" / "marts_derivation_lineage"
+
+
+def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
+    duckdb = pytest.importorskip("duckdb")
+
+    connection = duckdb.connect(":memory:")
+    try:
+        _create_holding_fixture_tables(connection)
+        _insert_holding_row(
+            connection,
+            "top_holder",
+            "holder-a",
+            "000001.SZ",
+            date(2025, 12, 31),
+            date(2026, 1, 31),
+            100,
+            10,
+        )
+        _insert_holding_row(
+            connection,
+            "top_holder",
+            "holder-a",
+            "000001.SZ",
+            date(2026, 3, 31),
+            date(2026, 4, 30),
+            125,
+            12,
+        )
+
+        _create_mart_table(
+            connection,
+            "mart_deriv_top_holder_qoq_change",
+            MARTS_DERIVATIONS_DIR,
+        )
+        _create_mart_table(
+            connection,
+            "mart_deriv_lineage_top_holder_qoq_change",
+            MARTS_DERIVATION_LINEAGE_DIR,
+        )
+
+        qoq_row = connection.execute(
+            """
+            select
+                previous_report_date,
+                previous_announced_date,
+                holding_amount_delta,
+                holding_amount_delta_pct,
+                holding_ratio_delta
+            from mart_deriv_top_holder_qoq_change
+            where report_date = date '2026-03-31'
+            """
+        ).fetchone()
+        key_diff_count = _key_diff_count(
+            connection,
+            "mart_deriv_top_holder_qoq_change",
+            "mart_deriv_lineage_top_holder_qoq_change",
+            ["holding_source", "holder_id", "security_id", "report_date", "announced_date"],
+        )
+        lineage_row = connection.execute(
+            """
+            select source_mart, source_interface_ids, source_row_count
+            from mart_deriv_lineage_top_holder_qoq_change
+            where report_date = date '2026-03-31'
+            """
+        ).fetchone()
+    finally:
+        connection.close()
+
+    assert qoq_row == (date(2025, 12, 31), date(2026, 1, 31), 25, 0.25, 2)
+    assert key_diff_count == 0
+    assert lineage_row == ("mart_fact_holding_position_v2", "top10_holders", 2)
+
+
+def test_fund_co_holding_orders_pairs_and_dedupes_inverse_pairs() -> None:
+    duckdb = pytest.importorskip("duckdb")
+
+    connection = duckdb.connect(":memory:")
+    try:
+        _create_holding_fixture_tables(connection)
+        for holder_id, security_id in [
+            ("fund-1", "000001.SZ"),
+            ("fund-1", "000002.SZ"),
+            ("fund-1", "000003.SZ"),
+            ("fund-2", "000001.SZ"),
+            ("fund-2", "000002.SZ"),
+        ]:
+            _insert_holding_row(
+                connection,
+                "fund_portfolio",
+                holder_id,
+                security_id,
+                date(2026, 3, 31),
+                date(2026, 4, 30),
+                10,
+                1,
+            )
+
+        _create_mart_table(
+            connection,
+            "mart_deriv_fund_co_holding",
+            MARTS_DERIVATIONS_DIR,
+        )
+        _create_mart_table(
+            connection,
+            "mart_deriv_lineage_fund_co_holding",
+            MARTS_DERIVATION_LINEAGE_DIR,
+        )
+
+        pair_rows = connection.execute(
+            """
+            select
+                security_id_left,
+                security_id_right,
+                co_holding_fund_count,
+                security_left_fund_count,
+                security_right_fund_count,
+                round(jaccard_score, 6),
+                latest_announced_date
+            from mart_deriv_fund_co_holding
+            order by security_id_left, security_id_right
+            """
+        ).fetchall()
+        inverse_pair_count = connection.execute(
+            """
+            select count(*)
+            from mart_deriv_fund_co_holding
+            where security_id_left >= security_id_right
+            """
+        ).fetchone()[0]
+        key_diff_count = _key_diff_count(
+            connection,
+            "mart_deriv_fund_co_holding",
+            "mart_deriv_lineage_fund_co_holding",
+            ["report_date", "security_id_left", "security_id_right"],
+        )
+    finally:
+        connection.close()
+
+    assert pair_rows == [
+        ("000001.SZ", "000002.SZ", 2, 2, 2, 1.0, date(2026, 4, 30)),
+        ("000001.SZ", "000003.SZ", 1, 2, 1, 0.5, date(2026, 4, 30)),
+        ("000002.SZ", "000003.SZ", 1, 2, 1, 0.5, date(2026, 4, 30)),
+    ]
+    assert inverse_pair_count == 0
+    assert key_diff_count == 0
+
+
+def test_northbound_z_score_nulls_when_window_stddev_is_null_or_zero() -> None:
+    duckdb = pytest.importorskip("duckdb")
+
+    connection = duckdb.connect(":memory:")
+    try:
+        _create_holding_fixture_tables(connection)
+        for report_date, holding_ratio in [
+            (date(2026, 4, 1), 1),
+            (date(2026, 4, 2), 2),
+            (date(2026, 4, 3), 3),
+        ]:
+            _insert_holding_row(
+                connection,
+                "northbound_hold",
+                "northbound:sh",
+                "000001.SZ",
+                report_date,
+                report_date,
+                100,
+                holding_ratio,
+            )
+
+        _create_mart_table(
+            connection,
+            "mart_deriv_northbound_holding_z_score",
+            MARTS_DERIVATIONS_DIR,
+        )
+        _create_mart_table(
+            connection,
+            "mart_deriv_lineage_northbound_holding_z_score",
+            MARTS_DERIVATION_LINEAGE_DIR,
+        )
+
+        amount_latest = connection.execute(
+            """
+            select observation_count, metric_stddev, metric_z_score
+            from mart_deriv_northbound_holding_z_score
+            where report_date = date '2026-04-03'
+              and z_score_metric = 'holding_amount'
+            """
+        ).fetchone()
+        ratio_first = connection.execute(
+            """
+            select observation_count, metric_stddev, metric_z_score
+            from mart_deriv_northbound_holding_z_score
+            where report_date = date '2026-04-01'
+              and z_score_metric = 'holding_ratio'
+            """
+        ).fetchone()
+        ratio_latest_z_score = connection.execute(
+            """
+            select round(metric_z_score, 6)
+            from mart_deriv_northbound_holding_z_score
+            where report_date = date '2026-04-03'
+              and z_score_metric = 'holding_ratio'
+            """
+        ).fetchone()[0]
+        key_diff_count = _key_diff_count(
+            connection,
+            "mart_deriv_northbound_holding_z_score",
+            "mart_deriv_lineage_northbound_holding_z_score",
+            ["security_id", "holder_id", "report_date", "z_score_metric"],
+        )
+    finally:
+        connection.close()
+
+    assert amount_latest == (3, 0.0, None)
+    assert ratio_first == (1, None, None)
+    assert ratio_latest_z_score == 1.0
+    assert key_diff_count == 0
+
+
+def _create_holding_fixture_tables(connection: Any) -> None:
+    connection.execute(
+        """
+        create table mart_fact_holding_position_v2(
+            holding_source varchar,
+            holder_id varchar,
+            holder_name varchar,
+            holder_type varchar,
+            security_id varchar,
+            report_date date,
+            announced_date date,
+            holding_amount decimal(38, 18),
+            holding_ratio decimal(38, 18),
+            holding_float_ratio decimal(38, 18),
+            holding_change decimal(38, 18),
+            market_value decimal(38, 18),
+            exchange varchar
+        )
+        """
+    )
+    connection.execute(
+        """
+        create table mart_lineage_fact_holding_position(
+            holding_source varchar,
+            holder_id varchar,
+            security_id varchar,
+            report_date date,
+            announced_date date,
+            source_provider varchar,
+            source_interface_id varchar,
+            source_run_id varchar,
+            raw_loaded_at timestamp
+        )
+        """
+    )
+
+
+def _insert_holding_row(
+    connection: Any,
+    holding_source: str,
+    holder_id: str,
+    security_id: str,
+    report_date: date,
+    announced_date: date,
+    holding_amount: int,
+    holding_ratio: int,
+) -> None:
+    source_interface_id = {
+        "top_holder": "top10_holders",
+        "top_float_holder": "top10_floatholders",
+        "fund_portfolio": "fund_portfolio",
+        "northbound_hold": "hsgt_hold_top10",
+    }[holding_source]
+    connection.execute(
+        """
+        insert into mart_fact_holding_position_v2 values (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        [
+            holding_source,
+            holder_id,
+            holder_id,
+            "fund" if holding_source == "fund_portfolio" else "holder",
+            security_id,
+            report_date,
+            announced_date,
+            holding_amount,
+            holding_ratio,
+            holding_ratio,
+            None,
+            None,
+            None,
+        ],
+    )
+    connection.execute(
+        """
+        insert into mart_lineage_fact_holding_position values (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        [
+            holding_source,
+            holder_id,
+            security_id,
+            report_date,
+            announced_date,
+            "fixture",
+            source_interface_id,
+            f"run-{source_interface_id}",
+            datetime(2026, 5, 1, 0, 0, 0),
+        ],
+    )
+
+
+def _key_diff_count(
+    connection: Any,
+    business_table: str,
+    lineage_table: str,
+    key_columns: list[str],
+) -> int:
+    key_select = ", ".join(key_columns)
+    return connection.execute(
+        f"""
+        select count(*)
+        from (
+            select {key_select} from {business_table}
+            except
+            select {key_select} from {lineage_table}
+
+            union all
+
+            select {key_select} from {lineage_table}
+            except
+            select {key_select} from {business_table}
+        )
+        """
+    ).fetchone()[0]

--- a/tests/dbt/test_marts_provider_neutrality.py
+++ b/tests/dbt/test_marts_provider_neutrality.py
@@ -27,6 +27,9 @@ V2_MARTS_DIR: Final[Path] = (
 LINEAGE_MARTS_DIR: Final[Path] = (
     PROJECT_ROOT / "src" / "data_platform" / "dbt" / "models" / "marts_lineage"
 )
+DERIVATION_MARTS_DIR: Final[Path] = (
+    PROJECT_ROOT / "src" / "data_platform" / "dbt" / "models" / "marts_derivations"
+)
 
 FORBIDDEN_LINEAGE_TOKENS: Final[tuple[re.Pattern[str], ...]] = (
     re.compile(r"(?<![A-Za-z0-9_])source_run_id(?![A-Za-z0-9_])"),
@@ -48,6 +51,12 @@ def _lineage_mart_sql_files() -> Iterable[Path]:
     if not LINEAGE_MARTS_DIR.is_dir():
         return ()
     return sorted(p for p in LINEAGE_MARTS_DIR.glob("*.sql") if p.is_file())
+
+
+def _derivation_mart_sql_files() -> Iterable[Path]:
+    if not DERIVATION_MARTS_DIR.is_dir():
+        return ()
+    return sorted(p for p in DERIVATION_MARTS_DIR.glob("*.sql") if p.is_file())
 
 
 @pytest.mark.parametrize(
@@ -142,3 +151,31 @@ def test_dim_security_lineage_mart_discloses_composite_source_interface() -> Non
     assert "stock_company_source_run_id" in body
     assert "namechange_source_run_id" in body
     assert "cast('stock_basic' as varchar) as source_interface_id" not in body
+
+
+@pytest.mark.parametrize(
+    "mart_sql",
+    list(_derivation_mart_sql_files()),
+    ids=lambda p: p.name,
+)
+def test_derivation_business_mart_sql_is_provider_neutral(mart_sql: Path) -> None:
+    """Derivation business marts must only expose provider-neutral fields."""
+
+    body = mart_sql.read_text(encoding="utf-8")
+    lowered = body.lower()
+    forbidden_patterns = (
+        *FORBIDDEN_LINEAGE_TOKENS,
+        *FORBIDDEN_PROVIDER_SHAPED_TOKENS,
+        re.compile(r"ref\(['\"]stg_"),
+        re.compile(r"tushare"),
+    )
+    leaks = sorted(
+        match.group(0)
+        for pattern in forbidden_patterns
+        for match in pattern.finditer(lowered)
+    )
+
+    assert not leaks, (
+        f"{mart_sql.relative_to(PROJECT_ROOT)} (derivation business mart) "
+        f"leaks provider/raw tokens {sorted(set(leaks))}"
+    )


### PR DESCRIPTION
## Scope
- Add dbt-only holdings derivation business marts for top-holder QoQ change, fund co-holding pairs, and northbound holding z-scores.
- Add lineage sibling marts with source mart, source window, source interface summaries, row counts, run summaries, and dbt key parity tests.
- Register derivation model directories in dbt config and skeleton coverage.

## Tests
- Added YAML not_null / accepted_values / unique-combination coverage.
- Added generic derivation lineage key parity test.
- Added provider-neutrality assertions for derivation business marts.
- Added fixture behavior tests for QoQ lag, co-holding pair ordering/deduping, and z-score null behavior when stddev is null or zero.

## Notes
- No live token or live provider access required; dbt checks used local RawWriter fixtures and a temporary DuckDB profile.
- Contracts untouched.
- No evidence/docs PR content, no subsystem-holdings changes, no graph-engine #55 changes, and no Ex-3 generation.
