### PR TITLE
Prepare holdings marts for live producer proof

### DIFF
--- a/scripts/holdings_backfill.py
+++ b/scripts/holdings_backfill.py
@@ -16,6 +16,7 @@ from data_platform.holdings_backfill import (
     execute_holdings_backfill_plan,
     public_execution_summary,
     public_plan_summary,
+    validate_holdings_backfill_live_gate,
 )
 from data_platform.raw import RawWriter
 
@@ -44,6 +45,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             _emit_payload(payload, args.json_report)
             return 2
         if args.execute_live:
+            validate_holdings_backfill_live_gate(execute_live=args.execute_live)
             if args.raw_zone_path is None or args.iceberg_warehouse_path is None:
                 msg = "--execute-live requires --raw-zone-path and --iceberg-warehouse-path"
                 raise ValueError(msg)
@@ -56,6 +58,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     raw_zone_path=args.raw_zone_path,
                     iceberg_warehouse_path=args.iceberg_warehouse_path,
                 ),
+                execute_live=args.execute_live,
             )
             payload["execution"] = public_execution_summary(result)
         _emit_payload(payload, args.json_report)

--- a/src/data_platform/dbt/models/marts_derivation_lineage/_schema.yml
+++ b/src/data_platform/dbt/models/marts_derivation_lineage/_schema.yml
@@ -6,20 +6,15 @@ models:
     tests:
       - unique_combination_of_columns:
           combination_of_columns:
-            - holding_source
-            - holder_id
-            - security_id
-            - report_date
-            - announced_date
+            - mart_key
       - derivation_lineage_key_parity:
           business_model: ref('mart_deriv_top_holder_qoq_change')
           key_columns:
-            - holding_source
-            - holder_id
-            - security_id
-            - report_date
-            - announced_date
+            - mart_key
     columns:
+      - name: mart_key
+        tests:
+          - not_null
       - name: holding_source
         tests:
           - not_null
@@ -35,6 +30,15 @@ models:
       - name: announced_date
         tests:
           - not_null
+      - name: dataset
+        tests:
+          - not_null
+      - name: snapshot_id
+        tests:
+          - not_null
+      - name: as_of_date
+        tests:
+          - not_null
       - name: source_mart
         tests:
           - not_null
@@ -60,22 +64,30 @@ models:
       - name: source_lineage_summary
         tests:
           - not_null
+      - name: source_run_ids
+        tests:
+          - not_null
+      - name: raw_loaded_at_min
+        tests:
+          - not_null
+      - name: raw_loaded_at_max
+        tests:
+          - not_null
 
   - name: mart_deriv_lineage_fund_co_holding
     description: Lineage summary paired to mart_deriv_fund_co_holding on the lexicographic pair key.
     tests:
       - unique_combination_of_columns:
           combination_of_columns:
-            - report_date
-            - security_id_left
-            - security_id_right
+            - mart_key
       - derivation_lineage_key_parity:
           business_model: ref('mart_deriv_fund_co_holding')
           key_columns:
-            - report_date
-            - security_id_left
-            - security_id_right
+            - mart_key
     columns:
+      - name: mart_key
+        tests:
+          - not_null
       - name: report_date
         tests:
           - not_null
@@ -85,6 +97,15 @@ models:
       - name: security_id_right
         tests:
           - not_null
+      - name: dataset
+        tests:
+          - not_null
+      - name: snapshot_id
+        tests:
+          - not_null
+      - name: as_of_date
+        tests:
+          - not_null
       - name: source_mart
         tests:
           - not_null
@@ -110,24 +131,30 @@ models:
       - name: source_lineage_summary
         tests:
           - not_null
+      - name: source_run_ids
+        tests:
+          - not_null
+      - name: raw_loaded_at_min
+        tests:
+          - not_null
+      - name: raw_loaded_at_max
+        tests:
+          - not_null
 
   - name: mart_deriv_lineage_northbound_holding_z_score
     description: Lineage summary paired to mart_deriv_northbound_holding_z_score on the metric row key and source rolling window.
     tests:
       - unique_combination_of_columns:
           combination_of_columns:
-            - security_id
-            - holder_id
-            - report_date
-            - z_score_metric
+            - mart_key
       - derivation_lineage_key_parity:
           business_model: ref('mart_deriv_northbound_holding_z_score')
           key_columns:
-            - security_id
-            - holder_id
-            - report_date
-            - z_score_metric
+            - mart_key
     columns:
+      - name: mart_key
+        tests:
+          - not_null
       - name: security_id
         tests:
           - not_null
@@ -145,6 +172,15 @@ models:
                 - 'holding_amount'
                 - 'holding_ratio'
               quote: true
+      - name: dataset
+        tests:
+          - not_null
+      - name: snapshot_id
+        tests:
+          - not_null
+      - name: as_of_date
+        tests:
+          - not_null
       - name: source_mart
         tests:
           - not_null
@@ -168,5 +204,14 @@ models:
         tests:
           - not_null
       - name: source_lineage_summary
+        tests:
+          - not_null
+      - name: source_run_ids
+        tests:
+          - not_null
+      - name: raw_loaded_at_min
+        tests:
+          - not_null
+      - name: raw_loaded_at_max
         tests:
           - not_null

--- a/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_fund_co_holding.sql
+++ b/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_fund_co_holding.sql
@@ -28,9 +28,11 @@ fund_pairs as (
 
 source_rows as (
     select
+        co_holding.mart_key,
         co_holding.report_date,
         co_holding.security_id_left,
         co_holding.security_id_right,
+        co_holding.latest_announced_date,
         lineage.report_date as source_report_date,
         lineage.source_interface_id,
         lineage.source_run_id,
@@ -50,9 +52,11 @@ source_rows as (
     union all
 
     select
+        co_holding.mart_key,
         co_holding.report_date,
         co_holding.security_id_left,
         co_holding.security_id_right,
+        co_holding.latest_announced_date,
         lineage.report_date as source_report_date,
         lineage.source_interface_id,
         lineage.source_run_id,
@@ -71,9 +75,13 @@ source_rows as (
 )
 
 select
+    mart_key,
     report_date,
     security_id_left,
     security_id_right,
+    cast('fund_co_holding' as varchar) as dataset,
+    concat('fund_co_holding:', mart_key) as snapshot_id,
+    latest_announced_date as as_of_date,
     cast('mart_fact_holding_position_v2' as varchar) as source_mart,
     min(source_report_date) as source_window_start_date,
     max(source_report_date) as source_window_end_date,
@@ -91,6 +99,8 @@ select
     ) as source_lineage_summary
 from source_rows
 group by
+    mart_key,
     report_date,
     security_id_left,
-    security_id_right
+    security_id_right,
+    latest_announced_date

--- a/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_northbound_holding_z_score.sql
+++ b/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_northbound_holding_z_score.sql
@@ -2,10 +2,12 @@
 
 with source_rows as (
     select
+        z_score.mart_key,
         z_score.security_id,
         z_score.holder_id,
         z_score.report_date,
         z_score.z_score_metric,
+        z_score.window_end_date,
         lineage.report_date as source_report_date,
         lineage.source_interface_id,
         lineage.source_run_id,
@@ -19,10 +21,14 @@ with source_rows as (
 )
 
 select
+    mart_key,
     security_id,
     holder_id,
     report_date,
     z_score_metric,
+    cast('northbound_holding_z_score' as varchar) as dataset,
+    concat('northbound_holding_z_score:', mart_key) as snapshot_id,
+    window_end_date as as_of_date,
     cast('mart_fact_holding_position_v2' as varchar) as source_mart,
     min(source_report_date) as source_window_start_date,
     max(source_report_date) as source_window_end_date,
@@ -40,7 +46,9 @@ select
     ) as source_lineage_summary
 from source_rows
 group by
+    mart_key,
     security_id,
     holder_id,
     report_date,
-    z_score_metric
+    z_score_metric,
+    window_end_date

--- a/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_top_holder_qoq_change.sql
+++ b/src/data_platform/dbt/models/marts_derivation_lineage/mart_deriv_lineage_top_holder_qoq_change.sql
@@ -2,6 +2,7 @@
 
 with source_rows as (
     select
+        qoq.mart_key,
         qoq.holding_source,
         qoq.holder_id,
         qoq.security_id,
@@ -23,6 +24,7 @@ with source_rows as (
     union all
 
     select
+        qoq.mart_key,
         qoq.holding_source,
         qoq.holder_id,
         qoq.security_id,
@@ -43,11 +45,15 @@ with source_rows as (
 )
 
 select
+    mart_key,
     holding_source,
     holder_id,
     security_id,
     report_date,
     announced_date,
+    cast('top_holder_qoq_change' as varchar) as dataset,
+    concat('top_holder_qoq_change:', mart_key) as snapshot_id,
+    announced_date as as_of_date,
     cast('mart_fact_holding_position_v2' as varchar) as source_mart,
     min(source_report_date) as source_window_start_date,
     max(source_report_date) as source_window_end_date,
@@ -65,6 +71,7 @@ select
     ) as source_lineage_summary
 from source_rows
 group by
+    mart_key,
     holding_source,
     holder_id,
     security_id,

--- a/src/data_platform/dbt/models/marts_derivations/_schema.yml
+++ b/src/data_platform/dbt/models/marts_derivations/_schema.yml
@@ -6,12 +6,18 @@ models:
     tests:
       - unique_combination_of_columns:
           combination_of_columns:
+            - mart_key
+      - unique_combination_of_columns:
+          combination_of_columns:
             - holding_source
             - holder_id
             - security_id
             - report_date
             - announced_date
     columns:
+      - name: mart_key
+        tests:
+          - not_null
       - name: holding_source
         tests:
           - not_null
@@ -38,10 +44,19 @@ models:
     tests:
       - unique_combination_of_columns:
           combination_of_columns:
+            - mart_key
+      - unique_combination_of_columns:
+          combination_of_columns:
             - report_date
             - security_id_left
             - security_id_right
     columns:
+      - name: mart_key
+        tests:
+          - not_null
+      - name: row_id
+        tests:
+          - not_null
       - name: report_date
         tests:
           - not_null
@@ -66,10 +81,16 @@ models:
       - name: latest_announced_date
         tests:
           - not_null
+      - name: evidence_ref
+        tests:
+          - not_null
 
   - name: mart_deriv_northbound_holding_z_score
     description: Rolling z-score features derived from canonical northbound holdings for holding amount and holding ratio.
     tests:
+      - unique_combination_of_columns:
+          combination_of_columns:
+            - mart_key
       - unique_combination_of_columns:
           combination_of_columns:
             - security_id
@@ -77,6 +98,12 @@ models:
             - report_date
             - z_score_metric
     columns:
+      - name: mart_key
+        tests:
+          - not_null
+      - name: row_id
+        tests:
+          - not_null
       - name: security_id
         tests:
           - not_null
@@ -113,5 +140,14 @@ models:
         tests:
           - not_null
       - name: metric_mean
+        tests:
+          - not_null
+      - name: metric_stddev
+        tests:
+          - not_null
+      - name: metric_z_score
+        tests:
+          - not_null
+      - name: evidence_ref
         tests:
           - not_null

--- a/src/data_platform/dbt/models/marts_derivations/mart_deriv_fund_co_holding.sql
+++ b/src/data_platform/dbt/models/marts_derivations/mart_deriv_fund_co_holding.sql
@@ -35,33 +35,73 @@ fund_pairs as (
         on left_position.report_date = right_position.report_date
         and left_position.holder_id = right_position.holder_id
         and left_position.security_id < right_position.security_id
+),
+
+co_holding_rows as (
+    select
+        fund_pairs.report_date,
+        fund_pairs.security_id_left,
+        fund_pairs.security_id_right,
+        count(distinct fund_pairs.holder_id) as co_holding_fund_count,
+        left_counts.fund_count as security_left_fund_count,
+        right_counts.fund_count as security_right_fund_count,
+        cast(count(distinct fund_pairs.holder_id) as double)
+            / nullif(
+                left_counts.fund_count
+                + right_counts.fund_count
+                - count(distinct fund_pairs.holder_id),
+                0
+            ) as jaccard_score,
+        max(fund_pairs.latest_announced_date) as latest_announced_date
+    from fund_pairs
+    inner join security_counts as left_counts
+        on fund_pairs.report_date = left_counts.report_date
+        and fund_pairs.security_id_left = left_counts.security_id
+    inner join security_counts as right_counts
+        on fund_pairs.report_date = right_counts.report_date
+        and fund_pairs.security_id_right = right_counts.security_id
+    group by
+        fund_pairs.report_date,
+        fund_pairs.security_id_left,
+        fund_pairs.security_id_right,
+        left_counts.fund_count,
+        right_counts.fund_count
 )
 
 select
-    fund_pairs.report_date,
-    fund_pairs.security_id_left,
-    fund_pairs.security_id_right,
-    count(distinct fund_pairs.holder_id) as co_holding_fund_count,
-    left_counts.fund_count as security_left_fund_count,
-    right_counts.fund_count as security_right_fund_count,
-    cast(count(distinct fund_pairs.holder_id) as double)
-        / nullif(
-            left_counts.fund_count
-            + right_counts.fund_count
-            - count(distinct fund_pairs.holder_id),
-            0
-        ) as jaccard_score,
-    max(fund_pairs.latest_announced_date) as latest_announced_date
-from fund_pairs
-inner join security_counts as left_counts
-    on fund_pairs.report_date = left_counts.report_date
-    and fund_pairs.security_id_left = left_counts.security_id
-inner join security_counts as right_counts
-    on fund_pairs.report_date = right_counts.report_date
-    and fund_pairs.security_id_right = right_counts.security_id
-group by
-    fund_pairs.report_date,
-    fund_pairs.security_id_left,
-    fund_pairs.security_id_right,
-    left_counts.fund_count,
-    right_counts.fund_count
+    md5(
+        concat_ws(
+            '|',
+            cast(report_date as varchar),
+            security_id_left,
+            security_id_right
+        )
+    ) as mart_key,
+    md5(
+        concat_ws(
+            '|',
+            cast(report_date as varchar),
+            security_id_left,
+            security_id_right
+        )
+    ) as row_id,
+    report_date,
+    security_id_left,
+    security_id_right,
+    co_holding_fund_count,
+    security_left_fund_count,
+    security_right_fund_count,
+    jaccard_score,
+    latest_announced_date,
+    concat(
+        'mart_deriv_fund_co_holding:',
+        md5(
+            concat_ws(
+                '|',
+                cast(report_date as varchar),
+                security_id_left,
+                security_id_right
+            )
+        )
+    ) as evidence_ref
+from co_holding_rows

--- a/src/data_platform/dbt/models/marts_derivations/mart_deriv_northbound_holding_z_score.sql
+++ b/src/data_platform/dbt/models/marts_derivations/mart_deriv_northbound_holding_z_score.sql
@@ -41,9 +41,48 @@ windowed_metrics as (
         order by report_date
         rows between 7 preceding and current row
     )
+),
+
+z_score_rows as (
+    select
+        security_id,
+        holder_id,
+        report_date,
+        z_score_metric,
+        lookback_observations,
+        window_start_date,
+        window_end_date,
+        observation_count,
+        metric_value,
+        metric_mean,
+        metric_stddev,
+        case
+            when metric_stddev is null or metric_stddev = 0
+                then cast(null as double)
+            else (metric_value - metric_mean) / metric_stddev
+        end as metric_z_score
+    from windowed_metrics
 )
 
 select
+    md5(
+        concat_ws(
+            '|',
+            security_id,
+            holder_id,
+            cast(report_date as varchar),
+            z_score_metric
+        )
+    ) as mart_key,
+    md5(
+        concat_ws(
+            '|',
+            security_id,
+            holder_id,
+            cast(report_date as varchar),
+            z_score_metric
+        )
+    ) as row_id,
     security_id,
     holder_id,
     report_date,
@@ -55,9 +94,20 @@ select
     metric_value,
     metric_mean,
     metric_stddev,
-    case
-        when metric_stddev is null or metric_stddev = 0
-            then cast(null as double)
-        else (metric_value - metric_mean) / metric_stddev
-    end as metric_z_score
-from windowed_metrics
+    metric_z_score,
+    concat(
+        'mart_deriv_northbound_holding_z_score:',
+        md5(
+            concat_ws(
+                '|',
+                security_id,
+                holder_id,
+                cast(report_date as varchar),
+                z_score_metric
+            )
+        )
+    ) as evidence_ref
+from z_score_rows
+where metric_stddev is not null
+  and metric_stddev <> 0
+  and metric_z_score is not null

--- a/src/data_platform/dbt/models/marts_derivations/mart_deriv_top_holder_qoq_change.sql
+++ b/src/data_platform/dbt/models/marts_derivations/mart_deriv_top_holder_qoq_change.sql
@@ -63,6 +63,16 @@ period_changes as (
 )
 
 select
+    md5(
+        concat_ws(
+            '|',
+            holding_source,
+            holder_id,
+            security_id,
+            cast(report_date as varchar),
+            cast(announced_date as varchar)
+        )
+    ) as mart_key,
     holding_source,
     holder_id,
     security_id,

--- a/src/data_platform/dbt/models/marts_v2/_schema.yml
+++ b/src/data_platform/dbt/models/marts_v2/_schema.yml
@@ -222,12 +222,18 @@ models:
     tests:
       - unique_combination_of_columns:
           combination_of_columns:
+            - position_id
+      - unique_combination_of_columns:
+          combination_of_columns:
             - holding_source
             - holder_id
             - security_id
             - report_date
             - announced_date
     columns:
+      - name: position_id
+        tests:
+          - not_null
       - name: holding_source
         tests:
           - not_null
@@ -248,6 +254,18 @@ models:
         tests:
           - not_null
       - name: announced_date
+        tests:
+          - not_null
+      - name: holding_ratio
+        tests:
+          - not_null
+      - name: dataset
+        tests:
+          - not_null
+      - name: snapshot_id
+        tests:
+          - not_null
+      - name: as_of_date
         tests:
           - not_null
 

--- a/src/data_platform/dbt/models/marts_v2/mart_fact_holding_position_v2.sql
+++ b/src/data_platform/dbt/models/marts_v2/mart_fact_holding_position_v2.sql
@@ -70,9 +70,91 @@ northbound_positions as (
         cast(null as decimal(38, 18)) as market_value,
         exchange as exchange
     from {{ ref('stg_hsgt_hold_top10') }}
+),
+
+holding_positions as (
+    select
+        holding_source,
+        holder_id,
+        holder_name,
+        holder_type,
+        security_id,
+        report_date,
+        announced_date,
+        holding_amount,
+        holding_ratio,
+        holding_float_ratio,
+        holding_change,
+        market_value,
+        exchange
+    from issuer_top_holders
+
+    union all by name
+
+    select
+        holding_source,
+        holder_id,
+        holder_name,
+        holder_type,
+        security_id,
+        report_date,
+        announced_date,
+        holding_amount,
+        holding_ratio,
+        holding_float_ratio,
+        holding_change,
+        market_value,
+        exchange
+    from issuer_top_float_holders
+
+    union all by name
+
+    select
+        holding_source,
+        holder_id,
+        holder_name,
+        holder_type,
+        security_id,
+        report_date,
+        announced_date,
+        holding_amount,
+        holding_ratio,
+        holding_float_ratio,
+        holding_change,
+        market_value,
+        exchange
+    from fund_positions
+
+    union all by name
+
+    select
+        holding_source,
+        holder_id,
+        holder_name,
+        holder_type,
+        security_id,
+        report_date,
+        announced_date,
+        holding_amount,
+        holding_ratio,
+        holding_float_ratio,
+        holding_change,
+        market_value,
+        exchange
+    from northbound_positions
 )
 
 select
+    md5(
+        concat_ws(
+            '|',
+            holding_source,
+            holder_id,
+            security_id,
+            cast(report_date as varchar),
+            cast(announced_date as varchar)
+        )
+    ) as position_id,
     holding_source,
     holder_id,
     holder_name,
@@ -85,59 +167,8 @@ select
     holding_float_ratio,
     holding_change,
     market_value,
-    exchange
-from issuer_top_holders
-
-union all by name
-
-select
-    holding_source,
-    holder_id,
-    holder_name,
-    holder_type,
-    security_id,
-    report_date,
-    announced_date,
-    holding_amount,
-    holding_ratio,
-    holding_float_ratio,
-    holding_change,
-    market_value,
-    exchange
-from issuer_top_float_holders
-
-union all by name
-
-select
-    holding_source,
-    holder_id,
-    holder_name,
-    holder_type,
-    security_id,
-    report_date,
-    announced_date,
-    holding_amount,
-    holding_ratio,
-    holding_float_ratio,
-    holding_change,
-    market_value,
-    exchange
-from fund_positions
-
-union all by name
-
-select
-    holding_source,
-    holder_id,
-    holder_name,
-    holder_type,
-    security_id,
-    report_date,
-    announced_date,
-    holding_amount,
-    holding_ratio,
-    holding_float_ratio,
-    holding_change,
-    market_value,
-    exchange
-from northbound_positions
+    exchange,
+    cast('holding_position' as varchar) as dataset,
+    concat('holding_position:', cast(report_date as varchar)) as snapshot_id,
+    announced_date as as_of_date
+from holding_positions

--- a/src/data_platform/holdings_backfill.py
+++ b/src/data_platform/holdings_backfill.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import uuid
 from collections.abc import Mapping, Sequence
@@ -55,6 +56,7 @@ PUBLIC_IDENTIFIER_VALUE_RE = re.compile(
 HSGT_HOLD_TOP10_BACKFILL_LAST_DATE = date(2024, 8, 20)
 DEFAULT_MAX_PLAN_ITEMS = 5_000
 DATE_FORMAT = "%Y%m%d"
+LIVE_HOLDINGS_BACKFILL_ENV = "DP_TUSHARE_LIVE_HOLDINGS_BACKFILL"
 
 
 class HoldingsBackfillPlanError(ValueError):
@@ -205,8 +207,11 @@ def execute_holdings_backfill_plan(
     *,
     adapter: FetchableAdapter,
     raw_writer: RawWriter,
+    execute_live: bool = False,
 ) -> HoldingsBackfillExecutionResult:
     """Execute planned holdings backfill items through an adapter into Raw Zone."""
+
+    validate_holdings_backfill_live_gate(execute_live=execute_live)
 
     if plan.has_rejections:
         reasons = ", ".join(
@@ -264,6 +269,17 @@ def execute_holdings_backfill_plan(
         )
 
     return HoldingsBackfillExecutionResult(tuple(execution_items))
+
+
+def validate_holdings_backfill_live_gate(*, execute_live: bool) -> None:
+    """Fail closed unless both the code path and environment opt in to live writes."""
+
+    if not execute_live:
+        msg = "live holdings backfill requires execute_live=True"
+        raise HoldingsBackfillPlanError(msg)
+    if os.environ.get(LIVE_HOLDINGS_BACKFILL_ENV) != "1":
+        msg = f"live holdings backfill requires {LIVE_HOLDINGS_BACKFILL_ENV}=1"
+        raise HoldingsBackfillPlanError(msg)
 
 
 def public_plan_summary(plan: HoldingsBackfillPlan) -> dict[str, Any]:
@@ -873,10 +889,12 @@ __all__ = [
     "HoldingsBackfillPlan",
     "HoldingsBackfillPlanError",
     "HoldingsBackfillPlanItem",
+    "LIVE_HOLDINGS_BACKFILL_ENV",
     "SUPPORTED_HOLDINGS_BACKFILL_DATASETS",
     "build_holdings_backfill_plan",
     "default_holdings_assets_by_dataset",
     "execute_holdings_backfill_plan",
     "public_execution_summary",
     "public_plan_summary",
+    "validate_holdings_backfill_live_gate",
 ]

--- a/tests/dbt/test_holdings_derivation_marts.py
+++ b/tests/dbt/test_holdings_derivation_marts.py
@@ -13,6 +13,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DBT_PROJECT_DIR = PROJECT_ROOT / "src" / "data_platform" / "dbt"
 MARTS_DERIVATIONS_DIR = DBT_PROJECT_DIR / "models" / "marts_derivations"
 MARTS_DERIVATION_LINEAGE_DIR = DBT_PROJECT_DIR / "models" / "marts_derivation_lineage"
+TEST_STOCK_A = "TESTSTKA.SZ"
+TEST_STOCK_B = "TESTSTKB.SZ"
+TEST_STOCK_C = "TESTSTKC.SZ"
 
 
 def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
@@ -25,7 +28,7 @@ def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
             connection,
             "top_holder",
             "holder-a",
-            "000001.SZ",
+            TEST_STOCK_A,
             date(2025, 12, 31),
             date(2026, 1, 15),
             90,
@@ -35,7 +38,7 @@ def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
             connection,
             "top_holder",
             "holder-a",
-            "000001.SZ",
+            TEST_STOCK_A,
             date(2025, 12, 31),
             date(2026, 1, 31),
             100,
@@ -45,7 +48,7 @@ def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
             connection,
             "top_holder",
             "holder-a",
-            "000001.SZ",
+            TEST_STOCK_A,
             date(2026, 3, 31),
             date(2026, 4, 30),
             125,
@@ -86,7 +89,31 @@ def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
             connection,
             "mart_deriv_top_holder_qoq_change",
             "mart_deriv_lineage_top_holder_qoq_change",
-            ["holding_source", "holder_id", "security_id", "report_date", "announced_date"],
+            ["mart_key"],
+        )
+        missing_columns = _missing_columns(
+            connection,
+            "mart_deriv_top_holder_qoq_change",
+            {"mart_key"},
+        ) | _missing_columns(
+            connection,
+            "mart_deriv_lineage_top_holder_qoq_change",
+            {
+                "mart_key",
+                "dataset",
+                "snapshot_id",
+                "as_of_date",
+                "source_mart",
+                "source_window_start_date",
+                "source_window_end_date",
+                "source_interface_ids",
+                "source_row_count",
+                "source_lineage_row_count",
+                "source_lineage_summary",
+                "source_run_ids",
+                "raw_loaded_at_min",
+                "raw_loaded_at_max",
+            },
         )
         lineage_row = connection.execute(
             """
@@ -104,6 +131,7 @@ def test_top_holder_qoq_change_uses_canonical_lag_and_pairs_lineage() -> None:
         (date(2026, 3, 31), date(2026, 4, 30), date(2025, 12, 31)),
     ]
     assert key_diff_count == 0
+    assert missing_columns == set()
     assert lineage_row == ("mart_fact_holding_position_v2", "top10_holders", 2)
 
 
@@ -114,11 +142,11 @@ def test_fund_co_holding_orders_pairs_and_dedupes_inverse_pairs() -> None:
     try:
         _create_holding_fixture_tables(connection)
         for holder_id, security_id in [
-            ("fund-1", "000001.SZ"),
-            ("fund-1", "000002.SZ"),
-            ("fund-1", "000003.SZ"),
-            ("fund-2", "000001.SZ"),
-            ("fund-2", "000002.SZ"),
+            ("fund-1", TEST_STOCK_A),
+            ("fund-1", TEST_STOCK_B),
+            ("fund-1", TEST_STOCK_C),
+            ("fund-2", TEST_STOCK_A),
+            ("fund-2", TEST_STOCK_B),
         ]:
             _insert_holding_row(
                 connection,
@@ -167,18 +195,28 @@ def test_fund_co_holding_orders_pairs_and_dedupes_inverse_pairs() -> None:
             connection,
             "mart_deriv_fund_co_holding",
             "mart_deriv_lineage_fund_co_holding",
-            ["report_date", "security_id_left", "security_id_right"],
+            ["mart_key"],
+        )
+        missing_columns = _missing_columns(
+            connection,
+            "mart_deriv_fund_co_holding",
+            {"mart_key", "row_id", "evidence_ref"},
+        ) | _missing_columns(
+            connection,
+            "mart_deriv_lineage_fund_co_holding",
+            {"mart_key", "dataset", "snapshot_id", "as_of_date"},
         )
     finally:
         connection.close()
 
     assert pair_rows == [
-        ("000001.SZ", "000002.SZ", 2, 2, 2, 1.0, date(2026, 4, 30)),
-        ("000001.SZ", "000003.SZ", 1, 2, 1, 0.5, date(2026, 4, 30)),
-        ("000002.SZ", "000003.SZ", 1, 2, 1, 0.5, date(2026, 4, 30)),
+        (TEST_STOCK_A, TEST_STOCK_B, 2, 2, 2, 1.0, date(2026, 4, 30)),
+        (TEST_STOCK_A, TEST_STOCK_C, 1, 2, 1, 0.5, date(2026, 4, 30)),
+        (TEST_STOCK_B, TEST_STOCK_C, 1, 2, 1, 0.5, date(2026, 4, 30)),
     ]
     assert inverse_pair_count == 0
     assert key_diff_count == 0
+    assert missing_columns == set()
 
 
 def test_fund_co_holding_lineage_only_counts_contributing_pair_rows() -> None:
@@ -188,10 +226,10 @@ def test_fund_co_holding_lineage_only_counts_contributing_pair_rows() -> None:
     try:
         _create_holding_fixture_tables(connection)
         for holder_id, security_id in [
-            ("fund-1", "000001.SZ"),
-            ("fund-1", "000002.SZ"),
-            ("fund-2", "000001.SZ"),
-            ("fund-2", "000002.SZ"),
+            ("fund-1", TEST_STOCK_A),
+            ("fund-1", TEST_STOCK_B),
+            ("fund-2", TEST_STOCK_A),
+            ("fund-2", TEST_STOCK_B),
         ]:
             _insert_holding_row(
                 connection,
@@ -208,7 +246,7 @@ def test_fund_co_holding_lineage_only_counts_contributing_pair_rows() -> None:
             connection,
             "fund_portfolio",
             "fund-side-only",
-            "000001.SZ",
+            TEST_STOCK_A,
             date(2026, 3, 31),
             date(2026, 4, 30),
             10,
@@ -232,23 +270,24 @@ def test_fund_co_holding_lineage_only_counts_contributing_pair_rows() -> None:
             select source_row_count, source_lineage_row_count, source_run_ids
             from mart_deriv_lineage_fund_co_holding
             where report_date = date '2026-03-31'
-              and security_id_left = '000001.SZ'
-              and security_id_right = '000002.SZ'
-            """
+              and security_id_left = ?
+              and security_id_right = ?
+            """,
+            [TEST_STOCK_A, TEST_STOCK_B],
         ).fetchone()
     finally:
         connection.close()
 
     assert lineage_row[0:2] == (4, 4)
     assert set(lineage_row[2].split(",")) == {
-        "run-fund-1-000001.SZ",
-        "run-fund-1-000002.SZ",
-        "run-fund-2-000001.SZ",
-        "run-fund-2-000002.SZ",
+        f"run-fund-1-{TEST_STOCK_A}",
+        f"run-fund-1-{TEST_STOCK_B}",
+        f"run-fund-2-{TEST_STOCK_A}",
+        f"run-fund-2-{TEST_STOCK_B}",
     }
 
 
-def test_northbound_z_score_nulls_when_window_stddev_is_null_or_zero() -> None:
+def test_northbound_z_score_filters_rows_when_window_stddev_is_null_or_zero() -> None:
     duckdb = pytest.importorskip("duckdb")
 
     connection = duckdb.connect(":memory:")
@@ -263,7 +302,7 @@ def test_northbound_z_score_nulls_when_window_stddev_is_null_or_zero() -> None:
                 connection,
                 "northbound_hold",
                 "northbound:sh",
-                "000001.SZ",
+                TEST_STOCK_A,
                 report_date,
                 report_date,
                 100,
@@ -281,43 +320,52 @@ def test_northbound_z_score_nulls_when_window_stddev_is_null_or_zero() -> None:
             MARTS_DERIVATION_LINEAGE_DIR,
         )
 
-        amount_latest = connection.execute(
+        amount_row_count = connection.execute(
             """
-            select observation_count, metric_stddev, metric_z_score
+            select count(*)
             from mart_deriv_northbound_holding_z_score
-            where report_date = date '2026-04-03'
-              and z_score_metric = 'holding_amount'
+            where z_score_metric = 'holding_amount'
             """
-        ).fetchone()
-        ratio_first = connection.execute(
+        ).fetchone()[0]
+        ratio_first_row_count = connection.execute(
             """
-            select observation_count, metric_stddev, metric_z_score
+            select count(*)
             from mart_deriv_northbound_holding_z_score
             where report_date = date '2026-04-01'
               and z_score_metric = 'holding_ratio'
             """
-        ).fetchone()
+        ).fetchone()[0]
         ratio_latest_z_score = connection.execute(
             """
-            select round(metric_z_score, 6)
+            select observation_count, round(metric_stddev, 6), round(metric_z_score, 6)
             from mart_deriv_northbound_holding_z_score
             where report_date = date '2026-04-03'
               and z_score_metric = 'holding_ratio'
             """
-        ).fetchone()[0]
+        ).fetchone()
         key_diff_count = _key_diff_count(
             connection,
             "mart_deriv_northbound_holding_z_score",
             "mart_deriv_lineage_northbound_holding_z_score",
-            ["security_id", "holder_id", "report_date", "z_score_metric"],
+            ["mart_key"],
+        )
+        missing_columns = _missing_columns(
+            connection,
+            "mart_deriv_northbound_holding_z_score",
+            {"mart_key", "row_id", "evidence_ref"},
+        ) | _missing_columns(
+            connection,
+            "mart_deriv_lineage_northbound_holding_z_score",
+            {"mart_key", "dataset", "snapshot_id", "as_of_date"},
         )
     finally:
         connection.close()
 
-    assert amount_latest == (3, 0.0, None)
-    assert ratio_first == (1, None, None)
-    assert ratio_latest_z_score == 1.0
+    assert amount_row_count == 0
+    assert ratio_first_row_count == 0
+    assert ratio_latest_z_score == (3, 1.0, 1.0)
     assert key_diff_count == 0
+    assert missing_columns == set()
 
 
 def _create_holding_fixture_tables(connection: Any) -> None:
@@ -439,3 +487,14 @@ def _key_diff_count(
         )
         """
     ).fetchone()[0]
+
+
+def _missing_columns(
+    connection: Any,
+    table_name: str,
+    expected_columns: set[str],
+) -> set[str]:
+    actual_columns = {
+        row[1] for row in connection.execute(f"pragma table_info('{table_name}')").fetchall()
+    }
+    return expected_columns - actual_columns

--- a/tests/dbt/test_marts_models.py
+++ b/tests/dbt/test_marts_models.py
@@ -28,6 +28,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DBT_PROJECT_DIR = PROJECT_ROOT / "src" / "data_platform" / "dbt"
 MARTS_V2_DIR = DBT_PROJECT_DIR / "models" / "marts_v2"
 MARTS_LINEAGE_DIR = DBT_PROJECT_DIR / "models" / "marts_lineage"
+TEST_STOCK_CODE = "TESTSTK.SZ"
 
 
 
@@ -276,7 +277,7 @@ def _write_same_day_block_trade_rows(raw_zone_path: Path, tmp_path: Path) -> Non
             _sample_table_with_values(
                 asset,
                 {
-                    "ts_code": "000001.SZ",
+                    "ts_code": TEST_STOCK_CODE,
                     "trade_date": "20260415",
                     "buyer": "buyer-a",
                     "seller": "seller-a",
@@ -288,7 +289,7 @@ def _write_same_day_block_trade_rows(raw_zone_path: Path, tmp_path: Path) -> Non
             _sample_table_with_values(
                 asset,
                 {
-                    "ts_code": "000001.SZ",
+                    "ts_code": TEST_STOCK_CODE,
                     "trade_date": "20260415",
                     "buyer": "buyer-b",
                     "seller": "seller-b",
@@ -495,6 +496,12 @@ def test_holdings_marts_preserve_promoted_holdings_fixtures(tmp_path: Path) -> N
             "mart_lineage_fact_northbound_turnover",
             MARTS_LINEAGE_DIR,
         )
+        expected_hsgt_top10_security_id = connection.execute(
+            "select ts_code from stg_hsgt_top10"
+        ).fetchone()[0]
+        expected_hsgt_hold_security_id = connection.execute(
+            "select ts_code from stg_hsgt_hold_top10"
+        ).fetchone()[0]
 
         holding_sources = {
             row[0]
@@ -516,6 +523,18 @@ def test_holdings_marts_preserve_promoted_holdings_fixtures(tmp_path: Path) -> N
             )
             """
         ).fetchone()[0]
+        holding_position_duplicate_count = connection.execute(
+            """
+            select count(*)
+            from (
+                select position_id
+                from mart_fact_holding_position_v2
+                group by position_id
+                having count(*) > 1
+            )
+            """
+        ).fetchone()[0]
+        holding_columns = _table_columns(connection, "mart_fact_holding_position_v2")
         northbound_row = connection.execute(
             """
             select security_id, trade_date, market_type, rank
@@ -547,7 +566,23 @@ def test_holdings_marts_preserve_promoted_holdings_fixtures(tmp_path: Path) -> N
         "northbound_hold",
     }
     assert holding_duplicate_count == 0
-    assert northbound_row == ("000001.SZ", date(2026, 4, 15), "market_type-fixture", 1)
+    assert holding_position_duplicate_count == 0
+    assert {
+        "position_id",
+        "holder_id",
+        "security_id",
+        "report_date",
+        "holding_ratio",
+        "dataset",
+        "snapshot_id",
+        "as_of_date",
+    }.issubset(holding_columns)
+    assert northbound_row == (
+        expected_hsgt_top10_security_id,
+        date(2026, 4, 15),
+        "market_type-fixture",
+        1,
+    )
     assert holding_lineage_sources == {
         "top10_holders",
         "top10_floatholders",
@@ -555,7 +590,7 @@ def test_holdings_marts_preserve_promoted_holdings_fixtures(tmp_path: Path) -> N
         "hsgt_hold_top10",
     }
     assert northbound_lineage_row == (
-        "000001.SZ",
+        expected_hsgt_hold_security_id,
         date(2026, 4, 15),
         "market_type-fixture",
         1,

--- a/tests/unit/test_holdings_backfill.py
+++ b/tests/unit/test_holdings_backfill.py
@@ -82,7 +82,7 @@ def test_five_holdings_interfaces_generate_bounded_plan() -> None:
         ),
         (
             ["fund_portfolio"],
-            {"fund_codes": ["001753.OF"]},
+            {"fund_codes": ["TESTFUND.OF"]},
             "missing_bounded_inputs",
         ),
         (
@@ -132,7 +132,7 @@ def test_hsgt_backfill_rejects_unbounded_market_or_exchange_scope(
 def test_hsgt_hold_top10_skips_after_cutoff_without_calling_live_path() -> None:
     plan = build_holdings_backfill_plan(
         datasets=["hsgt_hold_top10"],
-        stock_codes=["000001.SZ"],
+        stock_codes=["TESTSTK.SZ"],
         trade_dates=["20240820", "20240821"],
         exchanges=["SH"],
     )
@@ -141,41 +141,47 @@ def test_hsgt_hold_top10_skips_after_cutoff_without_calling_live_path() -> None:
     assert plan.items[0].fetch_params == {
         "trade_date": "20240820",
         "exchange": "SH",
-        "ts_code": "000001.SZ",
+        "ts_code": "TESTSTK.SZ",
     }
     assert plan.items[1].reason_type == "post_publication_cutoff"
     assert "2024-08-20" in str(plan.items[1].reason)
 
 
-def test_execute_uses_adapter_params_from_plan_and_writes_raw(tmp_path: Path) -> None:
+def test_execute_uses_adapter_params_from_plan_and_writes_raw(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     adapter = FakeHoldingsAdapter()
     writer = RawWriter(
         raw_zone_path=tmp_path / "raw",
         iceberg_warehouse_path=tmp_path / "warehouse",
     )
 
+    monkeypatch.setenv("DP_TUSHARE_LIVE_HOLDINGS_BACKFILL", "1")
+
     result = execute_holdings_backfill_plan(
         _full_plan(),
         adapter=adapter,  # type: ignore[arg-type]
         raw_writer=writer,
+        execute_live=True,
     )
 
     assert result.ok is True
     assert len(result.artifacts) == 5
     assert adapter.calls == [
-        (TUSHARE_TOP10_HOLDERS_ASSET.name, {"ts_code": "000001.SZ", "period": "20240331"}),
+        (TUSHARE_TOP10_HOLDERS_ASSET.name, {"ts_code": "TESTSTK.SZ", "period": "20240331"}),
         (
             TUSHARE_TOP10_FLOATHOLDERS_ASSET.name,
-            {"ts_code": "000001.SZ", "period": "20240331"},
+            {"ts_code": "TESTSTK.SZ", "period": "20240331"},
         ),
-        (TUSHARE_FUND_PORTFOLIO_ASSET.name, {"ts_code": "001753.OF", "period": "20240331"}),
+        (TUSHARE_FUND_PORTFOLIO_ASSET.name, {"ts_code": "TESTFUND.OF", "period": "20240331"}),
         (
             TUSHARE_HSGT_TOP10_ASSET.name,
-            {"trade_date": "20240402", "market_type": "1", "ts_code": "000001.SZ"},
+            {"trade_date": "20240402", "market_type": "1", "ts_code": "TESTSTK.SZ"},
         ),
         (
             TUSHARE_HSGT_HOLD_TOP10_ASSET.name,
-            {"trade_date": "20240402", "exchange": "SH", "ts_code": "000001.SZ"},
+            {"trade_date": "20240402", "exchange": "SH", "ts_code": "TESTSTK.SZ"},
         ),
     ]
     assert {
@@ -184,8 +190,49 @@ def test_execute_uses_adapter_params_from_plan_and_writes_raw(tmp_path: Path) ->
     } == {"dt=20240331", "dt=20240402"}
 
 
-def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("execute_live", "env_value", "match"),
+    [
+        (False, "1", "execute_live=True"),
+        (True, None, "DP_TUSHARE_LIVE_HOLDINGS_BACKFILL=1"),
+        (True, "0", "DP_TUSHARE_LIVE_HOLDINGS_BACKFILL=1"),
+    ],
+)
+def test_execute_requires_double_live_gate_before_adapter_or_writer_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    execute_live: bool,
+    env_value: str | None,
+    match: str,
+) -> None:
     adapter = FakeHoldingsAdapter()
+    writer = RecordingRawWriter(
+        raw_zone_path=tmp_path / "raw",
+        iceberg_warehouse_path=tmp_path / "warehouse",
+    )
+    if env_value is None:
+        monkeypatch.delenv("DP_TUSHARE_LIVE_HOLDINGS_BACKFILL", raising=False)
+    else:
+        monkeypatch.setenv("DP_TUSHARE_LIVE_HOLDINGS_BACKFILL", env_value)
+
+    with pytest.raises(HoldingsBackfillPlanError, match=match):
+        execute_holdings_backfill_plan(
+            _full_plan(),
+            adapter=adapter,  # type: ignore[arg-type]
+            raw_writer=writer,
+            execute_live=execute_live,
+        )
+
+    assert adapter.calls == []
+    assert writer.write_arrow_calls == 0
+
+
+def test_execute_refuses_rejected_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    adapter = FakeHoldingsAdapter()
+    monkeypatch.setenv("DP_TUSHARE_LIVE_HOLDINGS_BACKFILL", "1")
     plan = build_holdings_backfill_plan(
         datasets=["top10_holders"],
         periods=["20240331"],
@@ -199,6 +246,7 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
                 raw_zone_path=tmp_path / "raw",
                 iceberg_warehouse_path=tmp_path / "warehouse",
             ),
+            execute_live=True,
         )
 
     assert adapter.calls == []
@@ -212,7 +260,7 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
                 dataset="top10_holders",
                 status="planned",
                 partition_date=date(2024, 3, 31),
-                fetch_params={"ts_code": "000001.SZ", "period": "20240430"},
+                fetch_params={"ts_code": "TESTSTK.SZ", "period": "20240430"},
             ),
             "period matching partition_date",
         ),
@@ -221,7 +269,7 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
                 dataset="top10_floatholders",
                 status="planned",
                 partition_date=date(2024, 3, 31),
-                fetch_params={"ts_code": "000001.SZ"},
+                fetch_params={"ts_code": "TESTSTK.SZ"},
             ),
             "non-empty scalar period",
         ),
@@ -251,7 +299,7 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
                 fetch_params={
                     "trade_date": "20240402",
                     "market_type": "1",
-                    "ts_code": ["000001.SZ"],
+                    "ts_code": ["TESTSTK.SZ"],
                 },
             ),
             "non-empty scalar ts_code",
@@ -261,7 +309,7 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
                 dataset="hsgt_top10",
                 status="planned",
                 partition_date=date(2024, 4, 2),
-                fetch_params={"trade_date": "20240403", "market_type": "1", "ts_code": "000001.SZ"},
+                fetch_params={"trade_date": "20240403", "market_type": "1", "ts_code": "TESTSTK.SZ"},
             ),
             "trade_date matching partition_date",
         ),
@@ -270,7 +318,7 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
                 dataset="hsgt_top10",
                 status="planned",
                 partition_date=date(2024, 4, 2),
-                fetch_params={"trade_date": "20240402", "ts_code": "000001.SZ"},
+                fetch_params={"trade_date": "20240402", "ts_code": "TESTSTK.SZ"},
             ),
             "non-empty scalar market_type",
         ),
@@ -279,7 +327,7 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
                 dataset="hsgt_hold_top10",
                 status="planned",
                 partition_date=date(2024, 4, 2),
-                fetch_params={"trade_date": "20240402", "ts_code": "000001.SZ"},
+                fetch_params={"trade_date": "20240402", "ts_code": "TESTSTK.SZ"},
             ),
             "non-empty scalar exchange",
         ),
@@ -291,7 +339,7 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
                 fetch_params={
                     "trade_date": "20240821",
                     "exchange": "SH",
-                    "ts_code": "000001.SZ",
+                    "ts_code": "TESTSTK.SZ",
                 },
             ),
             "2024-08-20 cutoff",
@@ -299,11 +347,13 @@ def test_execute_refuses_rejected_plan(tmp_path: Path) -> None:
     ],
 )
 def test_execute_revalidates_malformed_planned_hsgt_items_without_adapter_call(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     item: HoldingsBackfillPlanItem,
     match: str,
 ) -> None:
     adapter = FakeHoldingsAdapter()
+    monkeypatch.setenv("DP_TUSHARE_LIVE_HOLDINGS_BACKFILL", "1")
     plan = HoldingsBackfillPlan((item,))
 
     with pytest.raises(HoldingsBackfillPlanError, match=match):
@@ -314,26 +364,31 @@ def test_execute_revalidates_malformed_planned_hsgt_items_without_adapter_call(
                 raw_zone_path=tmp_path / "raw",
                 iceberg_warehouse_path=tmp_path / "warehouse",
             ),
+            execute_live=True,
         )
 
     assert adapter.calls == []
 
 
-def test_execute_preflights_full_plan_before_first_adapter_call(tmp_path: Path) -> None:
+def test_execute_preflights_full_plan_before_first_adapter_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     adapter = FakeHoldingsAdapter()
+    monkeypatch.setenv("DP_TUSHARE_LIVE_HOLDINGS_BACKFILL", "1")
     plan = HoldingsBackfillPlan(
         (
             HoldingsBackfillPlanItem(
                 dataset="top10_holders",
                 status="planned",
                 partition_date=date(2024, 3, 31),
-                fetch_params={"ts_code": "000001.SZ", "period": "20240331"},
+                fetch_params={"ts_code": "TESTSTK.SZ", "period": "20240331"},
             ),
             HoldingsBackfillPlanItem(
                 dataset="hsgt_top10",
                 status="planned",
                 partition_date=date(2024, 4, 2),
-                fetch_params={"trade_date": "20240402", "ts_code": "000001.SZ"},
+                fetch_params={"trade_date": "20240402", "ts_code": "TESTSTK.SZ"},
             ),
         )
     )
@@ -346,6 +401,7 @@ def test_execute_preflights_full_plan_before_first_adapter_call(tmp_path: Path) 
                 raw_zone_path=tmp_path / "raw",
                 iceberg_warehouse_path=tmp_path / "warehouse",
             ),
+            execute_live=True,
         )
 
     assert adapter.calls == []
@@ -355,8 +411,8 @@ def test_public_plan_summary_does_not_leak_raw_provider_or_private_fields() -> N
     summary = public_plan_summary(_full_plan())
     encoded = json.dumps(summary, sort_keys=True)
 
-    assert "000001.SZ" not in encoded
-    assert "001753.OF" not in encoded
+    assert "TESTSTK.SZ" not in encoded
+    assert "TESTFUND.OF" not in encoded
     assert "stock_code_count" in encoded
     assert "fund_code_count" in encoded
     forbidden_terms = {
@@ -385,8 +441,8 @@ def test_public_plan_summary_drops_unknown_identifier_bounds() -> None:
                 status="rejected",
                 bounds={
                     "period": "20240331",
-                    "requested_identifiers": ["000001.SZ"],
-                    "_raw_params": {"ts_code": "000001.SZ"},
+                    "requested_identifiers": ["TESTSTK.SZ"],
+                    "_raw_params": {"ts_code": "TESTSTK.SZ"},
                 },
                 reason_type="example",
                 reason="example rejection",
@@ -398,7 +454,7 @@ def test_public_plan_summary_drops_unknown_identifier_bounds() -> None:
     encoded = json.dumps(summary, sort_keys=True)
 
     assert summary["items"][0]["bounds"] == {"period": "20240331"}
-    assert "000001.SZ" not in encoded
+    assert "TESTSTK.SZ" not in encoded
     assert "requested_identifiers" not in encoded
     assert "ts_code" not in encoded
 
@@ -412,7 +468,7 @@ def test_cli_json_report_sanitizes_identifier_bounds(tmp_path: Path) -> None:
             "--dataset",
             "top10_holders",
             "--stock-code",
-            "000001.SZ",
+            "TESTSTK.SZ",
             "--period",
             "20240331",
             "--json-report",
@@ -430,15 +486,64 @@ def test_cli_json_report_sanitizes_identifier_bounds(tmp_path: Path) -> None:
         "stock_code_class": "stock_code",
         "stock_code_count": 1,
     }
-    assert "000001.SZ" not in encoded
+    assert "TESTSTK.SZ" not in encoded
     assert "ts_code" not in encoded
+
+
+def test_cli_execute_live_requires_env_gate_before_live_objects(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cli = _load_holdings_backfill_cli()
+    monkeypatch.delenv("DP_TUSHARE_LIVE_HOLDINGS_BACKFILL", raising=False)
+    monkeypatch.setattr(
+        cli,
+        "RawWriter",
+        lambda *_args, **_kwargs: pytest.fail("RawWriter must not be constructed"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "execute_holdings_backfill_plan",
+        lambda *_args, **_kwargs: pytest.fail("execution must not be called"),
+    )
+
+    exit_code = cli.main(
+        [
+            "--dataset",
+            "top10_holders",
+            "--stock-code",
+            "TESTSTK.SZ",
+            "--period",
+            "20240331",
+            "--execute-live",
+            "--raw-zone-path",
+            str(tmp_path / "raw"),
+            "--iceberg-warehouse-path",
+            str(tmp_path / "warehouse"),
+        ]
+    )
+
+    assert exit_code == 2
+
+
+class RecordingRawWriter(RawWriter):
+    def __init__(self, *, raw_zone_path: Path, iceberg_warehouse_path: Path) -> None:
+        super().__init__(
+            raw_zone_path=raw_zone_path,
+            iceberg_warehouse_path=iceberg_warehouse_path,
+        )
+        self.write_arrow_calls = 0
+
+    def write_arrow(self, *args: Any, **kwargs: Any) -> Any:
+        self.write_arrow_calls += 1
+        return super().write_arrow(*args, **kwargs)
 
 
 def _full_plan() -> Any:
     return build_holdings_backfill_plan(
         datasets=SUPPORTED_HOLDINGS_BACKFILL_DATASETS,
-        stock_codes=["000001.SZ"],
-        fund_codes=["001753.OF"],
+        stock_codes=["TESTSTK.SZ"],
+        fund_codes=["TESTFUND.OF"],
         periods=["20240331"],
         trade_dates=["20240402"],
         market_types=["1"],
@@ -469,9 +574,9 @@ def _row_for_asset(asset: Any, params: dict[str, Any]) -> dict[str, Any]:
     date_value = params.get("period") or params.get("trade_date") or "20240331"
     for field in asset.schema:
         if field.name == "ts_code":
-            row[field.name] = params.get("ts_code", "000001.SZ")
+            row[field.name] = params.get("ts_code", "TESTSTK.SZ")
         elif field.name == "symbol":
-            row[field.name] = "000001.SZ"
+            row[field.name] = "TESTSTK.SZ"
         elif field.name in {"ann_date", "end_date", "trade_date"}:
             row[field.name] = date_value
         elif field.name == "market_type":


### PR DESCRIPTION
## Summary
- Adds code-level live double gate behavior for holdings producer proofing.
- Prepares producer-facing mart and lineage schema for holdings outputs.
- Applies northbound z-score fail-closed filtering.

## Scope notes
- No live, backfill, or provider runs were executed.
- No contracts repository changes are included.
- This does not enter graph-engine #55 scope.
- `DP_TUSHARE_LIVE_HOLDINGS_BACKFILL` is a gate name, not a secret.

## Tests passed
- `.venv/bin/python -m pytest tests/dbt/test_holdings_derivation_marts.py tests/dbt/test_marts_models.py tests/unit/test_holdings_backfill.py -q`
