### PR TITLE
[codex] Polish public docs paths

### DIFF
--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -48,7 +48,7 @@ data_platform（顶层包）+ pyproject.toml + scripts/
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 ruff check src tests
@@ -97,9 +97,9 @@ data_platform.config
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 cp .env.example .env.test
-DP_PG_DSN="postgresql://u:p@localhost/dp" pytest tests/test_config.py -q
+DP_PG_DSN="<postgres-dsn>" pytest tests/test_config.py -q
 ```
 
 #### 依赖
@@ -145,12 +145,12 @@ data_platform.ddl
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 docker run -d --rm --name dp-pg -e POSTGRES_PASSWORD=dp -p 5433:5432 postgres:16
 sleep 3
-DP_PG_DSN="postgresql://postgres:dp@localhost:5433/postgres" python -m data_platform.ddl.runner --upgrade
-DP_PG_DSN="postgresql://postgres:dp@localhost:5433/postgres" python -m data_platform.ddl.runner --upgrade
-psql "postgresql://postgres:dp@localhost:5433/postgres" -c "select * from dp_schema_migrations;"
+DP_PG_DSN="<postgres-dsn>" python -m data_platform.ddl.runner --upgrade
+DP_PG_DSN="<postgres-dsn>" python -m data_platform.ddl.runner --upgrade
+psql "<postgres-dsn>" -c "select * from dp_schema_migrations;"
 docker rm -f dp-pg
 ```
 
@@ -196,10 +196,10 @@ data_platform.ddl + data_platform.serving.catalog
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
-mkdir -p /tmp/dp_warehouse
-DP_ICEBERG_WAREHOUSE_PATH=/tmp/dp_warehouse \
-DP_PG_DSN="postgresql://postgres:dp@localhost:5433/postgres" \
+cd <workspace>/data-platform
+mkdir -p <proof-workspace>/dp_warehouse
+DP_ICEBERG_WAREHOUSE_PATH=<proof-workspace>/dp_warehouse \
+DP_PG_DSN="<postgres-dsn>" \
   python scripts/init_iceberg_catalog.py
 python -c "from data_platform.serving.catalog import load_catalog; print(load_catalog().list_namespaces())"
 ```
@@ -247,9 +247,9 @@ data_platform.raw
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
-DP_DATA_STORAGE_ROOT_PATH=/tmp/dp_data pytest tests/raw/ -q
-ls /tmp/dp_data/raw
+cd <workspace>/data-platform
+DP_DATA_STORAGE_ROOT_PATH=<proof-workspace>/dp_data pytest tests/raw/ -q
+ls <proof-workspace>/dp_data/raw
 ```
 
 #### 依赖
@@ -294,7 +294,7 @@ data_platform.ddl + data_platform.serving
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 python -m data_platform.ddl.iceberg_tables --ensure
 python -c "from data_platform.serving.catalog import load_catalog; \
 c=load_catalog(); print(c.load_table('canonical.stock_basic').schema())"
@@ -343,7 +343,7 @@ data_platform.adapters.base
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 pytest tests/adapters/test_base.py -q --cov=data_platform.adapters.base --cov-report=term
 mypy src/data_platform/adapters/base.py
 ```
@@ -391,10 +391,10 @@ data_platform.adapters.tushare
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 pytest tests/adapters/test_tushare.py -q
 # 真实拉取（需要 token，可选）
-DP_TUSHARE_TOKEN="${DP_TUSHARE_TOKEN:?set DP_TUSHARE_TOKEN}" DP_DATA_STORAGE_ROOT_PATH=/tmp/dp_data \
+DP_TUSHARE_TOKEN="${DP_TUSHARE_TOKEN:?set DP_TUSHARE_TOKEN}" DP_DATA_STORAGE_ROOT_PATH=<proof-workspace>/dp_data \
   python -m data_platform.adapters.tushare.adapter --asset tushare_stock_basic --date 20260415
 ```
 
@@ -441,7 +441,7 @@ data_platform.dbt（dbt project root）
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 cp src/data_platform/dbt/profiles.yml.example src/data_platform/dbt/profiles.yml
 DBT_PROFILES_DIR=src/data_platform/dbt dbt parse --project-dir src/data_platform/dbt
 DBT_PROFILES_DIR=src/data_platform/dbt dbt debug --project-dir src/data_platform/dbt
@@ -489,10 +489,10 @@ data_platform.dbt/models/staging
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
-cp -r tests/dbt/fixtures/raw /tmp/dp_data/raw
-DP_DATA_STORAGE_ROOT_PATH=/tmp/dp_data ./scripts/dbt.sh run --select stg_stock_basic
-DP_DATA_STORAGE_ROOT_PATH=/tmp/dp_data ./scripts/dbt.sh test --select stg_stock_basic
+cd <workspace>/data-platform
+cp -r tests/dbt/fixtures/raw <proof-workspace>/dp_data/raw
+DP_DATA_STORAGE_ROOT_PATH=<proof-workspace>/dp_data ./scripts/dbt.sh run --select stg_stock_basic
+DP_DATA_STORAGE_ROOT_PATH=<proof-workspace>/dp_data ./scripts/dbt.sh test --select stg_stock_basic
 duckdb $DP_DUCKDB_PATH "select count(*), min(list_date), max(list_date) from stg_stock_basic"
 ```
 
@@ -540,7 +540,7 @@ data_platform.serving.canonical_writer
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 python -m data_platform.serving.canonical_writer --table stock_basic
 duckdb -c "INSTALL iceberg; LOAD iceberg; \
   select count(*) from iceberg_scan('$DP_ICEBERG_WAREHOUSE_PATH/canonical/stock_basic');"
@@ -588,7 +588,7 @@ data_platform.serving.reader
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 python -c "from data_platform.serving.reader import get_canonical_stock_basic; \
 print(get_canonical_stock_basic().num_rows)"
 pytest tests/serving/test_reader.py -q
@@ -643,7 +643,7 @@ tests/spike/iceberg_write_chain
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 DATABASE_URL=<redacted> DP_PG_DSN=<redacted> .venv/bin/pytest -m spike tests/spike/test_iceberg_write_chain.py -v
 cat docs/spike/iceberg-write-chain.md
 ```
@@ -693,15 +693,15 @@ scripts/smoke + tests/integration
 - **两条验证路径，环境变量要求不同**：
   - `make smoke-p1a` → `scripts/smoke_p1a.sh` → 要求 `DP_PG_DSN`；脚本第 26 行明确 "DATABASE_URL is not used by this destructive smoke path"。
   - `pytest tests/integration/test_p1a_smoke.py` → `postgres_dsn` fixture → 要求 `DATABASE_URL`（fixture 读 `os.environ.get("DATABASE_URL")`，line ~38）。
-- **make 路径验收已通过**：2026-05-04 post-merge run 使用 `DP_ENV=test`、`DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE=1`、`DP_PG_DSN=postgresql://dp:<redacted>@localhost:5432/dp_p1a_smoke_20260504`、`DP_ICEBERG_CATALOG_NAME=data_platform_p1a_smoke_20260504`、`DP_SMOKE_WORK_DIR=/tmp/data-platform-p1a-smoke-20260504`，且 `DP_RAW_ZONE_PATH` / `DP_ICEBERG_WAREHOUSE_PATH` / `DP_DUCKDB_PATH` 均在该 workdir 下，然后执行 `make smoke-p1a`。
-- **结果**：`P1a smoke OK duration_s=8 log_dir=/tmp/data-platform-p1a-smoke-20260504/logs`；wrapper duration 9s。日志只保留在 `/tmp`，不提交入仓。
+- **make 路径验收已通过**：2026-05-04 post-merge run 使用 `DP_ENV=test`、`DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE=1`、`DP_PG_DSN=<postgres-dsn>`、`DP_ICEBERG_CATALOG_NAME=data_platform_p1a_smoke_20260504`、`DP_SMOKE_WORK_DIR=<proof-workspace>`，且 `DP_RAW_ZONE_PATH` / `DP_ICEBERG_WAREHOUSE_PATH` / `DP_DUCKDB_PATH` 均在该 workdir 下，然后执行 `make smoke-p1a`。
+- **结果**：`P1a smoke OK duration_s=8 log_dir=<proof-workspace>/logs`；wrapper duration 9s。日志只保留在 `<proof-workspace>`，不提交入仓。
 - **pytest 路径说明**：`pytest tests/integration/test_p1a_smoke.py -v` 仍要求具备 `CREATE DATABASE` 权限的 `DATABASE_URL`；2026-05-04 evidence 采用已经隔离好的 smoke database + destructive confirmation 的 `make smoke-p1a` 路径。
 
 #### 验证命令
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 # make 路径：shell 脚本读 DP_PG_DSN，DATABASE_URL 被脚本明确忽略
-DP_ENV=test DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE=1 DP_PG_DSN=postgresql://dp:<redacted>@localhost:5432/dp_p1a_smoke_20260504 DP_ICEBERG_CATALOG_NAME=data_platform_p1a_smoke_20260504 DP_SMOKE_WORK_DIR=/tmp/data-platform-p1a-smoke-20260504 make smoke-p1a
+DP_ENV=test DP_SMOKE_P1A_CONFIRM_DESTRUCTIVE=1 DP_PG_DSN=<postgres-dsn> DP_ICEBERG_CATALOG_NAME=data_platform_p1a_smoke_20260504 DP_SMOKE_WORK_DIR=<proof-workspace> make smoke-p1a
 # pytest 路径：fixture 读 DATABASE_URL
 DATABASE_URL=<redacted> pytest tests/integration/test_p1a_smoke.py -v
 ```

--- a/docs/runbook/external-smoke-tushare-corpus.md
+++ b/docs/runbook/external-smoke-tushare-corpus.md
@@ -1,7 +1,7 @@
 # Runbook: External smoke — Tushare corpus
 
 This is the **external smoke lane** for the local Tushare corpus
-mounted at `/Volumes/dockcase2tb/database_all`. It's Phase C of
+mounted at `<external-corpus-root>`. It's Phase C of
 `TUSHARE_TEST_FIXTURE_PLAN.md`.
 
 Unlike the git-tracked fixture lanes (audit-eval shared cases +
@@ -27,7 +27,7 @@ running this under CI produces false failures.
 ## How to run
 
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
+cd <workspace>/data-platform
 ./scripts/external_smoke_tushare_corpus.sh
 ```
 
@@ -41,7 +41,7 @@ PYTHONPATH=src .venv/bin/python scripts/external_smoke_tushare_corpus.py
 
 | Name | Default | Effect |
 |---|---|---|
-| `DP_EXTERNAL_CORPUS_ROOT` | `/Volumes/dockcase2tb/database_all` | Override the corpus root. The target **must be a structural mirror of the default mount**: same dataset paths relative to the root + same audit CSV at `_workspace/_meta/analysis/api_download_completeness_audit_20260420.csv`. The `fixture_traceability` check remaps declared absolute paths into the override root before resolving, so override targets that structurally mirror the default pass cleanly; it fails only if the remapped target doesn't resolve (genuine corpus defect), not on the root string itself differing. |
+| `DP_EXTERNAL_CORPUS_ROOT` | `<external-corpus-root>` | Override the corpus root. The target **must be a structural mirror of the default mount**: same dataset paths relative to the root + same audit CSV at `_workspace/_meta/analysis/api_download_completeness_audit_20260420.csv`. The `fixture_traceability` check remaps declared absolute paths into the override root before resolving, so override targets that structurally mirror the default pass cleanly; it fails only if the remapped target doesn't resolve (genuine corpus defect), not on the root string itself differing. |
 | `DP_EXTERNAL_SMOKE_STRICT` | unset | When `1` / `true` / `yes`, treats "drive unmounted" as a hard failure (exit 1). Default is skip-on-unmount (exit 0) so scheduled runs don't alert when the drive is unplugged. |
 
 **Override caveat**: The script does NOT support an override pointing
@@ -92,9 +92,9 @@ have to re-run to see the second one.
 ## Expected output (green mount + green corpus)
 
 ```
-external smoke — Tushare corpus @ /Volumes/dockcase2tb/database_all
+external smoke — Tushare corpus @ <external-corpus-root>
 ────────────────────────────────────────────────────────────────────────
-  ✓ mount: mounted + readable at /Volumes/dockcase2tb/database_all
+  ✓ mount: mounted + readable at <external-corpus-root>
   ✓ audit_csv_gate: all 12 required datasets are access=available + completeness=未见明显遗漏
   ✓ dataset_presence: all 12 dataset_paths present on disk
   ✓ ts_code_presence: all 6 Phase-B ts_codes resolve in their datasets
@@ -107,9 +107,9 @@ external smoke — Tushare corpus @ /Volumes/dockcase2tb/database_all
 ## Expected output (drive unmounted)
 
 ```
-external smoke — Tushare corpus @ /Volumes/dockcase2tb/database_all
+external smoke — Tushare corpus @ <external-corpus-root>
 ────────────────────────────────────────────────────────────────────────
-  ✗ mount: corpus root /Volumes/dockcase2tb/database_all does not exist (drive not mounted)
+  ✗ mount: corpus root <external-corpus-root> does not exist (drive not mounted)
       This is the expected state in CI and on dev machines where the external drive
       hasn't been plugged in; the caller usually treats this as a skip, not a failure.
 ────────────────────────────────────────────────────────────────────────
@@ -122,7 +122,7 @@ Exit code is **0** by default so a cron / launchd job won't alert.
 
 ## Why this is NOT a pytest test
 
-1. `/Volumes/dockcase2tb/database_all` is a developer-local mount;
+1. `<external-corpus-root>` is a developer-local mount;
    CI containers don't have it and shouldn't pretend they do.
 2. Phase B's fixture assertions already ensure the in-repo fixture
    content is internally consistent. This smoke's job is the
@@ -138,9 +138,9 @@ job (macOS) or cron entry:
 
 ```bash
 # crontab -e (daily 09:00)
-0 9 * * * cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform \
+0 9 * * * cd <workspace>/data-platform \
             && ./scripts/external_smoke_tushare_corpus.sh \
-            > /tmp/dp-external-smoke-$(date +\%Y\%m\%d).log 2>&1 \
+            > <proof-workspace>/dp-external-smoke-$(date +\%Y\%m\%d).log 2>&1 \
             || osascript -e 'display notification "Tushare corpus smoke FAILED" with title "data-platform"'
 ```
 

--- a/docs/runbook/iceberg-catalog.md
+++ b/docs/runbook/iceberg-catalog.md
@@ -15,10 +15,10 @@ these namespaces:
 ## Initialize Locally
 
 ```bash
-cd /Users/fanjie/Desktop/Cowork/project-ult/data-platform
-mkdir -p /tmp/dp_warehouse
-DP_ICEBERG_WAREHOUSE_PATH=/tmp/dp_warehouse \
-DP_PG_DSN="postgresql://postgres:dp@localhost:5433/postgres" \
+cd <workspace>/data-platform
+mkdir -p <proof-workspace>/dp_warehouse
+DP_ICEBERG_WAREHOUSE_PATH=<proof-workspace>/dp_warehouse \
+DP_PG_DSN="<postgres-dsn>" \
   python scripts/init_iceberg_catalog.py
 ```
 


### PR DESCRIPTION
## Summary
- Replace developer-local workspace paths in public docs with `<workspace>`.
- Replace proof/runtime paths with `<proof-workspace>` and example DSN literals with `<postgres-dsn>`.
- Keep env var names such as `DP_PG_DSN` and `DATABASE_URL`; no code, JSON evidence, or runtime artifacts changed.

## Scope
- docs/TASK_BREAKDOWN.md
- docs/runbook/external-smoke-tushare-corpus.md
- docs/runbook/iceberg-catalog.md

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src:../contracts/src .venv/bin/python -m pytest -p no:cacheprovider -q tests/queue/test_submit_candidate.py tests/cycle/test_holdings_ex3_queue_freeze_bridge.py`
- `set -a; source .env; set +a; PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src:../contracts/src .venv/bin/python -m pytest -p no:cacheprovider -q tests/queue/test_submit_candidate.py tests/cycle/test_holdings_ex3_queue_freeze_bridge.py`
- `git diff --check`
- Added-line hygiene scan for local paths, runtime paths, DSN literals, tokens, and raw payload wording
