### PR TITLE
[codex] Harden queue freeze rollout path

### DIFF
--- a/docs/runbook/holdings-queue-freeze-rollout.md
+++ b/docs/runbook/holdings-queue-freeze-rollout.md
@@ -1,0 +1,64 @@
+# Holdings Queue/Freeze Rollout Evidence Template
+
+This runbook records only sanitized queue/freeze evidence for a holdings
+production rollout. Do not paste proof-only database names, DSNs, tokens, raw
+provider payloads, dbt logs, runtime paths, `.env` values, or full producer
+payloads.
+
+## Command Shape
+
+Use redacted placeholders and bounded counts:
+
+```bash
+DP_PG_DSN=<redacted-dsn> \
+PYTHONPATH=src:../contracts/src \
+python -m data_platform.queue.worker --once --limit <bounded-limit>
+```
+
+```python
+freeze_cycle_candidates(
+    "CYCLE_<YYYYMMDD>",
+    submitted_by="subsystem-holdings",
+    payload_type="Ex-3",
+)
+```
+
+## Receipt Shape
+
+Record idempotent submit receipts in this shape only:
+
+```json
+{
+  "candidate_id": 123,
+  "payload_type": "Ex-3",
+  "submitted_by": "subsystem-holdings",
+  "submitted_at": "<iso8601>",
+  "ingest_seq": 456,
+  "validation_status": "pending",
+  "rejection_reason": null,
+  "replayed": false
+}
+```
+
+Receipt evidence must not include `payload`, provider response fields, local
+paths, DSNs, tokens, raw dbt output, or runtime artifact paths.
+
+## Evidence Fields
+
+Record:
+
+- cycle id and rollout date
+- command shape with redacted placeholders
+- worker `scanned`, `accepted`, `rejected`, `rejection_counts`, and
+  `rejections_by_reason_type`
+- targeted freeze filters: `submitted_by=subsystem-holdings`,
+  `payload_type=Ex-3`
+- selected count and cutoff metadata
+- code commit hash
+- sanitized receipt hash or count, never raw payload
+
+## Blocker Recording
+
+If a safety gate blocks live execution, record only the blocker code, command
+shape, status, and relevant counts. Do not run a destructive smoke path without
+its explicit safety gate.

--- a/src/data_platform/cycle/freeze.py
+++ b/src/data_platform/cycle/freeze.py
@@ -6,14 +6,24 @@ from data_platform.cycle.models import CycleMetadata, _cycle_date_from_id
 from data_platform.cycle.repository import CycleRepository
 
 
-def freeze_cycle_candidates(cycle_id: str) -> CycleMetadata:
+def freeze_cycle_candidates(
+    cycle_id: str,
+    *,
+    submitted_by: str | None = None,
+    payload_type: str | None = None,
+) -> CycleMetadata:
     """Freeze accepted candidate_queue rows for one cycle."""
 
     _cycle_date_from_id(cycle_id)
     repository = CycleRepository()
     try:
         with repository.begin() as connection:
-            return repository.freeze_selection(cycle_id, connection)
+            return repository.freeze_selection(
+                cycle_id,
+                connection,
+                submitted_by=submitted_by,
+                payload_type=payload_type,
+            )
     finally:
         repository.close()
 

--- a/src/data_platform/cycle/repository.py
+++ b/src/data_platform/cycle/repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Mapping
 from datetime import date
-from typing import Any, Final
+from typing import Any, Final, get_args
 
 from data_platform.cycle.models import (
     CYCLE_CANDIDATE_SELECTION_TABLE,
@@ -17,7 +17,7 @@ from data_platform.cycle.models import (
     _validate_cycle_status,
     cycle_id_for_date,
 )
-from data_platform.queue.models import CANDIDATE_QUEUE_TABLE
+from data_platform.queue.models import CANDIDATE_QUEUE_TABLE, CandidatePayloadType
 
 _FORWARD_TRANSITIONS: Final[dict[CycleStatus, CycleStatus]] = {
     "pending": "phase0",
@@ -27,6 +27,9 @@ _FORWARD_TRANSITIONS: Final[dict[CycleStatus, CycleStatus]] = {
 }
 _FAILED_SOURCES: Final[frozenset[CycleStatus]] = frozenset(
     ("pending", "phase0", "phase1", "phase2", "phase3")
+)
+_CANDIDATE_PAYLOAD_TYPES: Final[frozenset[str]] = frozenset(
+    get_args(CandidatePayloadType)
 )
 
 
@@ -95,7 +98,14 @@ class CycleRepository:
 
         return self._engine.begin()
 
-    def freeze_selection(self, cycle_id: str, connection: Any) -> CycleMetadata:
+    def freeze_selection(
+        self,
+        cycle_id: str,
+        connection: Any,
+        *,
+        submitted_by: str | None = None,
+        payload_type: str | None = None,
+    ) -> CycleMetadata:
         """Freeze accepted queue candidates for one cycle in the caller transaction.
 
         Under PostgreSQL READ COMMITTED, the freeze boundary is the
@@ -108,6 +118,12 @@ class CycleRepository:
         """
 
         _cycle_date_from_id(cycle_id)
+        params: dict[str, Any] = {"cycle_id": cycle_id}
+        filter_clause = _freeze_filter_clause(
+            submitted_by=submitted_by,
+            payload_type=payload_type,
+            params=params,
+        )
         current = connection.execute(
             _text(
                 f"""
@@ -136,6 +152,7 @@ class CycleRepository:
                     SELECT candidate_queue.id AS candidate_id
                     FROM {CANDIDATE_QUEUE_TABLE} AS candidate_queue
                     WHERE candidate_queue.validation_status = 'accepted'
+                      {filter_clause}
                       AND NOT EXISTS (
                           SELECT 1
                           FROM {CYCLE_CANDIDATE_SELECTION_TABLE} AS selection
@@ -186,7 +203,7 @@ class CycleRepository:
                     cycle_metadata.updated_at
                 """
             ),
-            {"cycle_id": cycle_id},
+            params,
         ).mappings().one()
         return _metadata_from_row(row)
 
@@ -397,6 +414,31 @@ def _sqlalchemy_postgres_uri(dsn: str) -> str:
     if dsn.startswith("postgres://"):
         return "postgresql+psycopg://" + dsn.removeprefix("postgres://")
     return dsn
+
+
+def _freeze_filter_clause(
+    *,
+    submitted_by: str | None,
+    payload_type: str | None,
+    params: dict[str, Any],
+) -> str:
+    clauses: list[str] = []
+    if submitted_by is not None:
+        if not submitted_by.strip():
+            msg = "submitted_by filter must be a non-empty string"
+            raise ValueError(msg)
+        params["filter_submitted_by"] = submitted_by
+        clauses.append("AND candidate_queue.submitted_by = :filter_submitted_by")
+    if payload_type is not None:
+        if payload_type not in _CANDIDATE_PAYLOAD_TYPES:
+            msg = f"payload_type filter must be one of {sorted(_CANDIDATE_PAYLOAD_TYPES)}"
+            raise ValueError(msg)
+        params["filter_payload_type"] = payload_type
+        clauses.append(
+            "AND candidate_queue.payload_type = "
+            "CAST(:filter_payload_type AS data_platform.candidate_payload_type)"
+        )
+    return "\n                      ".join(clauses)
 
 
 def _transition_target(cycle_id: str, status: str) -> CycleStatus:

--- a/src/data_platform/ddl/migrations/0006_candidate_queue_production_hardening.sql
+++ b/src/data_platform/ddl/migrations/0006_candidate_queue_production_hardening.sql
@@ -1,8 +1,11 @@
-CREATE UNIQUE INDEX IF NOT EXISTS candidate_queue_ex3_delta_id_key
+DROP INDEX IF EXISTS data_platform.candidate_queue_ex3_delta_id_key;
+
+CREATE UNIQUE INDEX candidate_queue_ex3_delta_id_key
 ON data_platform.candidate_queue (
     submitted_by,
     payload_type,
     (payload->>'delta_id')
 )
 WHERE payload_type = 'Ex-3'
-  AND payload ? 'delta_id';
+  AND jsonb_typeof(payload->'delta_id') = 'string'
+  AND payload->>'delta_id' <> '';

--- a/src/data_platform/ddl/migrations/0006_candidate_queue_production_hardening.sql
+++ b/src/data_platform/ddl/migrations/0006_candidate_queue_production_hardening.sql
@@ -1,0 +1,8 @@
+CREATE UNIQUE INDEX IF NOT EXISTS candidate_queue_ex3_delta_id_key
+ON data_platform.candidate_queue (
+    submitted_by,
+    payload_type,
+    (payload->>'delta_id')
+)
+WHERE payload_type = 'Ex-3'
+  AND payload ? 'delta_id';

--- a/src/data_platform/queue/__init__.py
+++ b/src/data_platform/queue/__init__.py
@@ -1,11 +1,12 @@
 """PostgreSQL-backed Lite candidate queue APIs and types."""
 
-from data_platform.queue.api import ExPayload, submit_candidate
+from data_platform.queue.api import ExPayload, submit_candidate, submit_candidate_idempotent
 from data_platform.queue.models import (
     CANDIDATE_QUEUE_TABLE,
     INGEST_METADATA_VIEW,
     CandidatePayloadType,
     CandidateQueueItem,
+    CandidateSubmitReceipt,
     IngestMetadataRecord,
     ValidationStatus,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "CandidateQueueItem",
     "CandidateQueueWriteError",
     "CandidateRepository",
+    "CandidateSubmitReceipt",
     "CandidateValidationError",
     "CandidateValidator",
     "EnvelopeCandidateValidator",
@@ -37,5 +39,6 @@ __all__ = [
     "IngestMetadataRecord",
     "ValidationStatus",
     "submit_candidate",
+    "submit_candidate_idempotent",
     "validate_candidate_envelope",
 ]

--- a/src/data_platform/queue/api.py
+++ b/src/data_platform/queue/api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from data_platform.queue.models import CandidateQueueItem
+from data_platform.queue.models import CandidateQueueItem, CandidateSubmitReceipt
 from data_platform.queue.repository import CandidateRepository
 from data_platform.queue.validation import ExPayload, validate_candidate_envelope
 
@@ -18,4 +18,15 @@ def submit_candidate(payload: ExPayload) -> CandidateQueueItem:
         repository.close()
 
 
-__all__ = ["ExPayload", "submit_candidate"]
+def submit_candidate_idempotent(payload: ExPayload) -> CandidateSubmitReceipt:
+    """Validate and idempotently insert one producer Ex payload into candidate_queue."""
+
+    envelope = validate_candidate_envelope(payload)
+    repository = CandidateRepository()
+    try:
+        return repository.insert_candidate_idempotent(envelope)
+    finally:
+        repository.close()
+
+
+__all__ = ["ExPayload", "submit_candidate", "submit_candidate_idempotent"]

--- a/src/data_platform/queue/models.py
+++ b/src/data_platform/queue/models.py
@@ -24,6 +24,64 @@ _FORBIDDEN_PAYLOAD_KEYS: Final[frozenset[str]] = frozenset(("submitted_at", "ing
 
 
 @dataclass(frozen=True, slots=True)
+class CandidateSubmitReceipt:
+    """Sanitized receipt for an idempotent candidate_queue submission."""
+
+    candidate_id: int
+    payload_type: CandidatePayloadType
+    submitted_by: str
+    submitted_at: datetime
+    ingest_seq: int
+    validation_status: ValidationStatus
+    rejection_reason: str | None
+    replayed: bool
+
+    def __post_init__(self) -> None:
+        if self.candidate_id < 1:
+            msg = "candidate_id must be positive"
+            raise ValueError(msg)
+        _validate_payload_type(self.payload_type)
+        _validate_validation_status(self.validation_status)
+        if self.ingest_seq < 1:
+            msg = "ingest_seq must be positive"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_candidate(
+        cls,
+        item: CandidateQueueItem,
+        *,
+        replayed: bool,
+    ) -> CandidateSubmitReceipt:
+        """Build a public receipt without returning producer payload contents."""
+
+        return cls(
+            candidate_id=item.id,
+            payload_type=item.payload_type,
+            submitted_by=item.submitted_by,
+            submitted_at=item.submitted_at,
+            ingest_seq=item.ingest_seq,
+            validation_status=item.validation_status,
+            rejection_reason=item.rejection_reason,
+            replayed=replayed,
+        )
+
+    def as_public_dict(self) -> dict[str, object]:
+        """Return a JSON-shaped receipt safe for runbooks and evidence."""
+
+        return {
+            "candidate_id": self.candidate_id,
+            "payload_type": self.payload_type,
+            "submitted_by": self.submitted_by,
+            "submitted_at": self.submitted_at.isoformat(),
+            "ingest_seq": self.ingest_seq,
+            "validation_status": self.validation_status,
+            "rejection_reason": self.rejection_reason,
+            "replayed": self.replayed,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class CandidateQueueItem:
     """A row from data_platform.candidate_queue."""
 

--- a/src/data_platform/queue/repository.py
+++ b/src/data_platform/queue/repository.py
@@ -59,7 +59,8 @@ ON CONFLICT (
     ((payload->>'delta_id'))
 )
 WHERE payload_type = 'Ex-3'
-  AND payload ? 'delta_id'
+  AND jsonb_typeof(payload->'delta_id') = 'string'
+  AND payload->>'delta_id' <> ''
 DO NOTHING
 RETURNING {", ".join(_RETURNING_COLUMNS)}
 """
@@ -68,7 +69,7 @@ SELECT {", ".join(_RETURNING_COLUMNS)}
 FROM {CANDIDATE_QUEUE_TABLE}
 WHERE submitted_by = :submitted_by
   AND payload_type = 'Ex-3'
-  AND payload ? 'delta_id'
+  AND jsonb_typeof(payload->'delta_id') = 'string'
   AND payload->>'delta_id' = :delta_id
 ORDER BY ingest_seq ASC
 LIMIT 1

--- a/src/data_platform/queue/repository.py
+++ b/src/data_platform/queue/repository.py
@@ -12,6 +12,7 @@ from data_platform.queue.models import (
     CANDIDATE_QUEUE_TABLE,
     CandidatePayloadType,
     CandidateQueueItem,
+    CandidateSubmitReceipt,
     ValidationStatus,
 )
 from data_platform.queue.validation import CandidateEnvelope
@@ -40,6 +41,37 @@ VALUES (
     :submitted_by
 )
 RETURNING {", ".join(_RETURNING_COLUMNS)}
+"""
+_INSERT_CANDIDATE_IDEMPOTENT_EX3_SQL: Final[str] = f"""
+INSERT INTO {CANDIDATE_QUEUE_TABLE} (
+    payload_type,
+    payload,
+    submitted_by
+)
+VALUES (
+    :payload_type,
+    CAST(:payload AS jsonb),
+    :submitted_by
+)
+ON CONFLICT (
+    submitted_by,
+    payload_type,
+    ((payload->>'delta_id'))
+)
+WHERE payload_type = 'Ex-3'
+  AND payload ? 'delta_id'
+DO NOTHING
+RETURNING {", ".join(_RETURNING_COLUMNS)}
+"""
+_FETCH_EXISTING_EX3_DELTA_SQL: Final[str] = f"""
+SELECT {", ".join(_RETURNING_COLUMNS)}
+FROM {CANDIDATE_QUEUE_TABLE}
+WHERE submitted_by = :submitted_by
+  AND payload_type = 'Ex-3'
+  AND payload ? 'delta_id'
+  AND payload->>'delta_id' = :delta_id
+ORDER BY ingest_seq ASC
+LIMIT 1
 """
 _FETCH_PENDING_FOR_UPDATE_SQL: Final[str] = f"""
 SELECT {", ".join(_RETURNING_COLUMNS)}
@@ -106,6 +138,64 @@ class CandidateRepository:
             raise
 
         return _row_to_candidate_queue_item(row)
+
+    def insert_candidate_idempotent(
+        self,
+        envelope: CandidateEnvelope,
+    ) -> CandidateSubmitReceipt:
+        """Insert a candidate and replay an existing Ex-3 ``delta_id`` row.
+
+        Only Ex-3 envelopes with a present ``delta_id`` use the production
+        idempotency key. Other payloads keep normal insert behavior and return
+        ``replayed=False``.
+        """
+
+        if not _is_ex3_delta_envelope(envelope):
+            return CandidateSubmitReceipt.from_candidate(
+                self.insert_candidate(envelope),
+                replayed=False,
+            )
+
+        try:
+            text = _sqlalchemy_text()
+            payload = json.dumps(dict(envelope.payload), allow_nan=False)
+            params = {
+                "payload_type": envelope.payload_type,
+                "payload": payload,
+                "submitted_by": envelope.submitted_by,
+                "delta_id": str(envelope.payload["delta_id"]),
+            }
+            with self._engine.begin() as connection:
+                inserted_row = (
+                    connection.execute(
+                        text(_INSERT_CANDIDATE_IDEMPOTENT_EX3_SQL),
+                        params,
+                    )
+                    .mappings()
+                    .one_or_none()
+                )
+                if inserted_row is not None:
+                    item = _row_to_candidate_queue_item(inserted_row)
+                    return CandidateSubmitReceipt.from_candidate(item, replayed=False)
+
+                existing_row = (
+                    connection.execute(text(_FETCH_EXISTING_EX3_DELTA_SQL), params)
+                    .mappings()
+                    .one()
+                )
+        except CandidateQueueWriteError:
+            raise
+        except Exception as exc:
+            if _is_sqlalchemy_error(exc):
+                raise CandidateQueueWriteError(
+                    "candidate queue idempotent insert failed", exc
+                ) from exc
+            raise
+
+        return CandidateSubmitReceipt.from_candidate(
+            _row_to_candidate_queue_item(existing_row),
+            replayed=True,
+        )
 
     def begin(self) -> Any:
         """Begin a PostgreSQL transaction for queue operations."""
@@ -244,6 +334,11 @@ def _sqlalchemy_postgres_uri(dsn: str) -> str:
     if dsn.startswith("postgres://"):
         return "postgresql+psycopg://" + dsn.removeprefix("postgres://")
     return dsn
+
+
+def _is_ex3_delta_envelope(envelope: CandidateEnvelope) -> bool:
+    delta_id = envelope.payload.get("delta_id")
+    return envelope.payload_type == "Ex-3" and isinstance(delta_id, str) and bool(delta_id)
 
 
 def _row_to_candidate_queue_item(row: Mapping[str, Any]) -> CandidateQueueItem:

--- a/src/data_platform/queue/validation.py
+++ b/src/data_platform/queue/validation.py
@@ -12,7 +12,20 @@ from data_platform.queue.models import CandidatePayloadType, CandidateQueueItem
 
 ExPayload: TypeAlias = Mapping[str, Any]
 FORBIDDEN_PRODUCER_FIELDS: Final[frozenset[str]] = frozenset(
-    {"submitted_at", "ingest_seq"}
+    {
+        "dbt_log_path",
+        "dsn",
+        "ex_type",
+        "ingest_seq",
+        "layer_b_receipt_id",
+        "produced_at",
+        "provider_payload",
+        "provider_response",
+        "raw_payload",
+        "raw_payload_path",
+        "runtime_path",
+        "submitted_at",
+    }
 )
 _CANDIDATE_PAYLOAD_TYPES: Final[frozenset[str]] = frozenset(
     cast(tuple[str, ...], get_args(CandidatePayloadType))

--- a/src/data_platform/queue/worker.py
+++ b/src/data_platform/queue/worker.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
-from dataclasses import asdict, dataclass
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
 import json
 import logging
 import sys
@@ -30,6 +31,8 @@ class QueueValidationSummary:
     accepted: int
     rejected: int
     duration_ms: int
+    rejection_counts: Mapping[str, int] = field(default_factory=dict)
+    rejections_by_reason_type: Mapping[str, int] = field(default_factory=dict)
 
 
 def validate_pending_candidates(
@@ -49,6 +52,8 @@ def validate_pending_candidates(
     accepted = 0
     rejected = 0
     scanned = 0
+    rejection_counts: Counter[str] = Counter()
+    rejections_by_reason_type: Counter[str] = Counter()
 
     try:
         with repository.begin() as connection:
@@ -60,10 +65,13 @@ def validate_pending_candidates(
                     candidate_validator.validate(candidate)
                 except CandidateValidationError as exc:
                     rejected += 1
+                    rejection_reason = _format_rejection_reason(exc)
+                    rejection_counts[rejection_reason] += 1
+                    rejections_by_reason_type[exc.__class__.__name__] += 1
                     repository.mark_validation_result(
                         candidate.id,
                         "rejected",
-                        _format_rejection_reason(exc),
+                        rejection_reason,
                         connection,
                     )
                 except Exception:
@@ -91,6 +99,8 @@ def validate_pending_candidates(
         accepted=accepted,
         rejected=rejected,
         duration_ms=duration_ms,
+        rejection_counts=dict(sorted(rejection_counts.items())),
+        rejections_by_reason_type=dict(sorted(rejections_by_reason_type.items())),
     )
 
 

--- a/tests/cycle/test_current_selection.py
+++ b/tests/cycle/test_current_selection.py
@@ -24,7 +24,7 @@ from data_platform.cycle.repository import create_cycle, get_cycle
 from data_platform.raw import RawWriter
 
 
-EXPECTED_MIGRATIONS = ["0001", "0002", "0003", "0004", "0005"]
+EXPECTED_MIGRATIONS = ["0001", "0002", "0003", "0004", "0005", "0006"]
 
 
 def test_selector_selects_latest_open_trade_day_and_records_evidence(

--- a/tests/cycle/test_cycle_metadata.py
+++ b/tests/cycle/test_cycle_metadata.py
@@ -114,7 +114,7 @@ def migrated_postgres_dsn(postgres_dsn: str) -> str:
         reason="PostgreSQL cycle metadata tests require the migration runner",
     )
     applied_versions = runner_module.MigrationRunner().apply_pending(postgres_dsn)
-    assert applied_versions == ["0001", "0002", "0003", "0004", "0005"]
+    assert applied_versions == ["0001", "0002", "0003", "0004", "0005", "0006"]
     assert runner_module.MigrationRunner().apply_pending(postgres_dsn) == []
     return postgres_dsn
 

--- a/tests/cycle/test_freeze_cycle_candidates.py
+++ b/tests/cycle/test_freeze_cycle_candidates.py
@@ -25,7 +25,7 @@ from data_platform.cycle import (
 
 
 EXPECTED_SELECTION_COLUMNS = ["cycle_id", "candidate_id", "selected_at"]
-EXPECTED_MIGRATIONS = ["0001", "0002", "0003", "0004", "0005"]
+EXPECTED_MIGRATIONS = ["0001", "0002", "0003", "0004", "0005", "0006"]
 
 
 def test_cycle_candidate_selection_model_exposes_contract() -> None:
@@ -167,6 +167,48 @@ def test_freeze_selects_only_accepted_candidates_and_sets_cutoffs(
     selected_submitted_at = [row["submitted_at"] for row in accepted]
     assert metadata.cutoff_submitted_at == max(selected_submitted_at)
     assert all(metadata.cutoff_submitted_at >= submitted_at for submitted_at in selected_submitted_at)
+
+
+def test_freeze_filter_selects_only_targeted_holdings_ex3_candidates(
+    cycle_repository_env: str,
+    cycle_engine: Any,
+) -> None:
+    create_cycle(date(2026, 4, 16))
+    with cycle_engine.begin() as connection:
+        selected = _insert_candidate(
+            connection,
+            validation_status="accepted",
+            candidate="holdings-ex3",
+            payload_type="Ex-3",
+            submitted_by="subsystem-holdings",
+            delta_id="holdings-freeze-target",
+        )
+        _insert_candidate(
+            connection,
+            validation_status="accepted",
+            candidate="other-ex3",
+            payload_type="Ex-3",
+            submitted_by="other-subsystem",
+            delta_id="other-freeze-target",
+        )
+        _insert_candidate(
+            connection,
+            validation_status="accepted",
+            candidate="holdings-ex1",
+            payload_type="Ex-1",
+            submitted_by="subsystem-holdings",
+        )
+
+    metadata = freeze_cycle_candidates(
+        "CYCLE_20260416",
+        submitted_by="subsystem-holdings",
+        payload_type="Ex-3",
+    )
+
+    assert metadata.status == "phase0"
+    assert metadata.candidate_count == 1
+    assert metadata.cutoff_ingest_seq == selected["ingest_seq"]
+    assert _selection_ids(cycle_engine, "CYCLE_20260416") == [int(selected["id"])]
 
 
 def test_freeze_metadata_matches_actual_selection_rows(
@@ -429,12 +471,17 @@ def _insert_candidate(
     *,
     validation_status: str,
     candidate: str,
+    payload_type: str = "Ex-1",
+    submitted_by: str = "freeze-test",
+    delta_id: str | None = None,
 ) -> Mapping[str, Any]:
     payload = {
-        "payload_type": "Ex-1",
-        "submitted_by": "freeze-test",
+        "payload_type": payload_type,
+        "submitted_by": submitted_by,
         "candidate": candidate,
     }
+    if delta_id is not None:
+        payload["delta_id"] = delta_id
     return connection.execute(
         _text(
             """
@@ -446,9 +493,9 @@ def _insert_candidate(
                 rejection_reason
             )
             VALUES (
-                'Ex-1',
+                :payload_type,
                 CAST(:payload AS jsonb),
-                'freeze-test',
+                :submitted_by,
                 CAST(:validation_status AS data_platform.validation_status),
                 :rejection_reason
             )
@@ -456,7 +503,9 @@ def _insert_candidate(
             """
         ),
         {
+            "payload_type": payload_type,
             "payload": json.dumps(payload, allow_nan=False),
+            "submitted_by": submitted_by,
             "validation_status": validation_status,
             "rejection_reason": (
                 "rejected by freeze test" if validation_status == "rejected" else None

--- a/tests/cycle/test_freeze_performance.py
+++ b/tests/cycle/test_freeze_performance.py
@@ -16,7 +16,7 @@ from data_platform.queue.validation import CandidateValidationError
 from data_platform.queue.worker import validate_pending_candidates
 
 
-EXPECTED_MIGRATIONS = ["0001", "0002", "0003", "0004", "0005"]
+EXPECTED_MIGRATIONS = ["0001", "0002", "0003", "0004", "0005", "0006"]
 FREEZE_CYCLE_ID = "CYCLE_20260416"
 FREEZE_CYCLE_DATE = date(2026, 4, 16)
 FREEZE_PERFORMANCE_SECONDS = 3.0

--- a/tests/cycle/test_holdings_ex3_queue_freeze_bridge.py
+++ b/tests/cycle/test_holdings_ex3_queue_freeze_bridge.py
@@ -116,13 +116,12 @@ def test_holdings_ex3_queue_submit_freeze_phase1_reader_round_trip(
         assert _FORBIDDEN_RECEIPT_FIELDS.isdisjoint(wire_payload)
 
 
-def test_holdings_ex3_phase1_reader_rejects_private_receipt_field(
+def test_holdings_ex3_submit_rejects_private_receipt_field_before_insert(
     holdings_bridge_env: str,
+    holdings_bridge_engine: Any,
 ) -> None:
     assert holdings_bridge_env
-    cycle_id = "CYCLE_20260508"
-    create_cycle(date(2026, 5, 8))
-
+    before_count = _candidate_count(holdings_bridge_engine)
     payload = _holdings_ex3_envelope(
         delta_id="holdings-private-field-proof",
         source_node="ENT_NORTHBOUND_CHANNEL",
@@ -133,25 +132,10 @@ def test_holdings_ex3_phase1_reader_rejects_private_receipt_field(
     )
     payload["layer_b_receipt_id"] = "must-not-cross-phase1"
 
-    receipt = submit_candidate(payload)
-    assert receipt.validation_status == "pending"
+    with pytest.raises(ForbiddenIngestMetadataError, match="layer_b_receipt_id"):
+        submit_candidate(payload)
 
-    summary = validate_pending_candidates(limit=10)
-    assert summary.scanned == 1
-    assert summary.accepted == 1
-    assert summary.rejected == 0
-
-    metadata = freeze_cycle_candidates(cycle_id)
-    assert metadata.candidate_count == 1
-
-    reader = PostgresCandidateDeltaReader.from_env()
-    with pytest.raises(Exception) as exc_info:
-        reader.read_candidate_graph_deltas(
-            cycle_id=cycle_id,
-            selection_ref=f"cycle_candidate_selection:{cycle_id}",
-        )
-
-    assert "layer_b_receipt_id" in str(exc_info.value)
+    assert _candidate_count(holdings_bridge_engine) == before_count
 
 
 def test_holdings_ex3_submit_rejects_layer_b_ingest_metadata_before_insert(

--- a/tests/cycle/test_publish_manifest.py
+++ b/tests/cycle/test_publish_manifest.py
@@ -28,7 +28,7 @@ from data_platform.cycle import (
 )
 
 
-EXPECTED_MIGRATIONS = ["0001", "0002", "0003", "0004", "0005"]
+EXPECTED_MIGRATIONS = ["0001", "0002", "0003", "0004", "0005", "0006"]
 EXPECTED_SNAPSHOT_COLUMNS = ["table", "snapshot_id"]
 EXPECTED_MANIFEST_COLUMNS = [
     "published_cycle_id",

--- a/tests/ddl/test_runner.py
+++ b/tests/ddl/test_runner.py
@@ -132,9 +132,9 @@ def test_create_engine_rewrites_plain_postgres_dsn_to_psycopg(
 def test_apply_pending_is_idempotent_and_creates_schema(postgres_dsn: str) -> None:
     runner = MigrationRunner()
 
-    assert runner.apply_pending(postgres_dsn) == ["0001", "0002", "0003", "0004", "0005"]
+    assert runner.apply_pending(postgres_dsn) == ["0001", "0002", "0003", "0004", "0005", "0006"]
     assert runner.apply_pending(postgres_dsn) == []
-    assert fetch_versions(postgres_dsn) == ["0001", "0002", "0003", "0004", "0005"]
+    assert fetch_versions(postgres_dsn) == ["0001", "0002", "0003", "0004", "0005", "0006"]
     assert fetch_scalar(postgres_dsn, "SELECT to_regclass('public.dp_schema_migrations')")
     assert (
         fetch_scalar(

--- a/tests/queue/test_candidate_queue_schema.py
+++ b/tests/queue/test_candidate_queue_schema.py
@@ -106,7 +106,7 @@ def migrated_postgres_dsn(postgres_dsn: str) -> str:
         reason="PostgreSQL candidate queue schema tests require the migration runner",
     )
     applied_versions = runner_module.MigrationRunner().apply_pending(postgres_dsn)
-    assert applied_versions == ["0001", "0002", "0003", "0004", "0005"]
+    assert applied_versions == ["0001", "0002", "0003", "0004", "0005", "0006"]
     assert runner_module.MigrationRunner().apply_pending(postgres_dsn) == []
     return postgres_dsn
 
@@ -277,7 +277,26 @@ def test_migration_creates_candidate_queue_schema(migrated_postgres_dsn: str) ->
                         """
                     )
                 )
-            } >= {"candidate_queue_pkey", "candidate_queue_ingest_seq_key"}
+            } >= {
+                "candidate_queue_pkey",
+                "candidate_queue_ingest_seq_key",
+                "candidate_queue_ex3_delta_id_key",
+            }
+            ex3_delta_index = connection.execute(
+                _text(
+                    """
+                    SELECT indexdef
+                    FROM pg_indexes
+                    WHERE schemaname = 'data_platform'
+                      AND tablename = 'candidate_queue'
+                      AND indexname = 'candidate_queue_ex3_delta_id_key'
+                    """
+                )
+            ).scalar_one()
+            assert "(payload ->> 'delta_id'::text)" in str(ex3_delta_index)
+            assert "WHERE ((payload_type = 'Ex-3'::data_platform.candidate_payload_type)" in str(
+                ex3_delta_index
+            )
     finally:
         engine.dispose()
 

--- a/tests/queue/test_candidate_queue_schema.py
+++ b/tests/queue/test_candidate_queue_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Generator
 from dataclasses import FrozenInstanceError, fields, is_dataclass
@@ -297,6 +298,51 @@ def test_migration_creates_candidate_queue_schema(migrated_postgres_dsn: str) ->
             assert "WHERE ((payload_type = 'Ex-3'::data_platform.candidate_payload_type)" in str(
                 ex3_delta_index
             )
+            assert "jsonb_typeof((payload -> 'delta_id'::text)) = 'string'::text" in str(
+                ex3_delta_index
+            )
+            assert "(payload ->> 'delta_id'::text) <> ''::text" in str(ex3_delta_index)
+    finally:
+        engine.dispose()
+
+
+def test_candidate_queue_ex3_delta_unique_index_matches_idempotency_domain(
+    migrated_postgres_dsn: str,
+) -> None:
+    sqlalchemy_error = pytest.importorskip(
+        "sqlalchemy.exc",
+        reason="PostgreSQL candidate queue schema tests require SQLAlchemy",
+    ).SQLAlchemyError
+    engine = _create_engine(migrated_postgres_dsn)
+    insert_sql = _text(
+        """
+        INSERT INTO data_platform.candidate_queue (
+            payload_type,
+            payload,
+            submitted_by
+        )
+        VALUES ('Ex-3', CAST(:payload AS jsonb), 'subsystem-holdings')
+        """
+    )
+
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                insert_sql,
+                {"payload": json.dumps({"delta_id": "holdings-delta-unique"})},
+            )
+
+        with pytest.raises(sqlalchemy_error):
+            with engine.begin() as connection:
+                connection.execute(
+                    insert_sql,
+                    {"payload": json.dumps({"delta_id": "holdings-delta-unique"})},
+                )
+
+        with engine.begin() as connection:
+            for delta_id in ("", 42):
+                connection.execute(insert_sql, {"payload": json.dumps({"delta_id": delta_id})})
+                connection.execute(insert_sql, {"payload": json.dumps({"delta_id": delta_id})})
     finally:
         engine.dispose()
 

--- a/tests/queue/test_submit_candidate.py
+++ b/tests/queue/test_submit_candidate.py
@@ -437,6 +437,43 @@ def test_idempotent_ex3_delta_id_replays_existing_row(
         engine.dispose()
 
 
+@pytest.mark.parametrize("delta_id", ["", 42])
+def test_idempotent_ex3_invalid_delta_id_uses_non_idempotent_insert(
+    migrated_postgres_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+    delta_id: object,
+) -> None:
+    _set_required_settings_env(monkeypatch, migrated_postgres_dsn)
+
+    payload = {
+        "payload_type": "Ex-3",
+        "submitted_by": "subsystem-holdings",
+        "subsystem_id": "subsystem-holdings",
+        "delta_id": delta_id,
+        "delta_type": "edge_upsert",
+        "source_node": "source",
+        "target_node": "target",
+        "relation_type": "CO_HOLDING",
+        "properties": {"source_mart": "mart_deriv_fund_co_holding"},
+        "evidence": ["proof-row"],
+    }
+    engine = _create_engine(migrated_postgres_dsn)
+    try:
+        before_count = _candidate_count(engine)
+        first = submit_candidate_idempotent(payload)
+        second = submit_candidate_idempotent({**payload, "properties": {"repeat": True}})
+
+        assert _candidate_count(engine) == before_count + 2
+        assert first.replayed is False
+        assert second.replayed is False
+        assert second.candidate_id != first.candidate_id
+        assert second.ingest_seq > first.ingest_seq
+        assert "payload" not in first.as_public_dict()
+        assert "payload" not in second.as_public_dict()
+    finally:
+        engine.dispose()
+
+
 @pytest.fixture()
 def migrated_postgres_dsn() -> Generator[str]:
     admin_dsn = os.environ.get("DATABASE_URL") or os.environ.get("DP_PG_DSN")

--- a/tests/queue/test_submit_candidate.py
+++ b/tests/queue/test_submit_candidate.py
@@ -12,9 +12,11 @@ import pytest
 from data_platform.queue import (
     CandidateEnvelope,
     CandidateQueueItem,
+    CandidateSubmitReceipt,
     CandidateValidationError,
     ForbiddenIngestMetadataError,
     submit_candidate,
+    submit_candidate_idempotent,
     validate_candidate_envelope,
 )
 from data_platform.queue import api as queue_api
@@ -125,6 +127,67 @@ def test_submit_candidate_accepts_sdk_bridge_shaped_ex3_envelope(
     ]
 
 
+def test_submit_candidate_idempotent_returns_sanitized_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_envelopes: list[CandidateEnvelope] = []
+
+    class FakeRepository:
+        def insert_candidate_idempotent(
+            self,
+            envelope: CandidateEnvelope,
+        ) -> CandidateSubmitReceipt:
+            seen_envelopes.append(envelope)
+            return CandidateSubmitReceipt(
+                candidate_id=12,
+                payload_type=envelope.payload_type,
+                submitted_by=envelope.submitted_by,
+                submitted_at=datetime.now(UTC),
+                ingest_seq=101,
+                validation_status="pending",
+                rejection_reason=None,
+                replayed=False,
+            )
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(queue_api, "CandidateRepository", FakeRepository)
+
+    payload = {
+        "payload_type": "Ex-3",
+        "submitted_by": "subsystem-holdings",
+        "delta_id": "delta-safe-receipt",
+        "provider_payload": "must not be accepted",
+    }
+
+    with pytest.raises(ForbiddenIngestMetadataError, match="provider_payload"):
+        submit_candidate_idempotent(payload)
+
+    safe_payload = {
+        "payload_type": "Ex-3",
+        "submitted_by": "subsystem-holdings",
+        "delta_id": "delta-safe-receipt",
+        "candidate": {"id": "alpha"},
+    }
+    receipt = submit_candidate_idempotent(safe_payload)
+
+    public_receipt = receipt.as_public_dict()
+    assert receipt.candidate_id == 12
+    assert receipt.replayed is False
+    assert "payload" not in public_receipt
+    assert "provider_payload" not in public_receipt
+    assert "raw_payload_path" not in public_receipt
+    assert "dsn" not in public_receipt
+    assert seen_envelopes == [
+        CandidateEnvelope(
+            payload_type="Ex-3",
+            submitted_by="subsystem-holdings",
+            payload=safe_payload,
+        )
+    ]
+
+
 def test_validate_candidate_envelope_returns_immutable_payload_copy() -> None:
     payload = {
         "payload_type": "Ex-2",
@@ -198,6 +261,31 @@ def test_submit_candidate_rejects_top_level_ingest_metadata(
                 "payload_type": "Ex-1",
                 "submitted_by": "test-subsystem",
                 forbidden_key: "not producer-owned",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "forbidden_key",
+    ["layer_b_receipt_id", "ex_type", "produced_at", "raw_payload_path"],
+)
+def test_submit_candidate_rejects_private_receipt_fields_before_insert(
+    monkeypatch: pytest.MonkeyPatch,
+    forbidden_key: str,
+) -> None:
+    class UnexpectedRepository:
+        def __init__(self) -> None:
+            raise AssertionError("repository must not be created for invalid payloads")
+
+    monkeypatch.setattr(queue_api, "CandidateRepository", UnexpectedRepository)
+
+    with pytest.raises(ForbiddenIngestMetadataError, match=forbidden_key):
+        submit_candidate(
+            {
+                "payload_type": "Ex-3",
+                "submitted_by": "subsystem-holdings",
+                "delta_id": "delta-private-receipt",
+                forbidden_key: "private-receipt-value",
             }
         )
 
@@ -313,6 +401,40 @@ def test_repository_maps_pg_returning_fields(migrated_postgres_dsn: str) -> None
     assert item.ingest_seq > 0
     assert item.validation_status == "pending"
     assert item.rejection_reason is None
+
+
+def test_idempotent_ex3_delta_id_replays_existing_row(
+    migrated_postgres_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_settings_env(monkeypatch, migrated_postgres_dsn)
+
+    payload = {
+        "payload_type": "Ex-3",
+        "submitted_by": "subsystem-holdings",
+        "subsystem_id": "subsystem-holdings",
+        "delta_id": "holdings-delta-replay",
+        "delta_type": "edge_upsert",
+        "source_node": "source",
+        "target_node": "target",
+        "relation_type": "CO_HOLDING",
+        "properties": {"source_mart": "mart_deriv_fund_co_holding"},
+        "evidence": ["proof-row"],
+    }
+    engine = _create_engine(migrated_postgres_dsn)
+    try:
+        before_count = _candidate_count(engine)
+        first = submit_candidate_idempotent(payload)
+        second = submit_candidate_idempotent({**payload, "properties": {"ignored": True}})
+
+        assert _candidate_count(engine) == before_count + 1
+        assert first.replayed is False
+        assert second.replayed is True
+        assert second.candidate_id == first.candidate_id
+        assert second.ingest_seq == first.ingest_seq
+        assert "payload" not in first.as_public_dict()
+    finally:
+        engine.dispose()
 
 
 @pytest.fixture()

--- a/tests/queue/test_worker.py
+++ b/tests/queue/test_worker.py
@@ -79,6 +79,8 @@ def test_cli_prints_json_summary(
     assert json.loads(captured.out) == {
         "accepted": 0,
         "duration_ms": 1,
+        "rejection_counts": {},
+        "rejections_by_reason_type": {},
         "rejected": 0,
         "scanned": 0,
     }
@@ -104,6 +106,8 @@ def test_worker_accepts_and_rejects_pending_candidates(
     assert summary.scanned == 3
     assert summary.accepted == 2
     assert summary.rejected == 1
+    assert summary.rejection_counts == {"fake validator rejected candidate": 1}
+    assert summary.rejections_by_reason_type == {"CandidateValidationError": 1}
 
     rows = _queue_rows(queue_engine)
     assert rows[accepted_first]["validation_status"] == "accepted"
@@ -134,6 +138,8 @@ def test_worker_respects_limit(
     assert summary.scanned == 10
     assert summary.accepted == 10
     assert summary.rejected == 0
+    assert summary.rejection_counts == {}
+    assert summary.rejections_by_reason_type == {}
     assert _status_counts(queue_engine) == {"accepted": 10, "pending": 2}
 
 
@@ -203,6 +209,8 @@ def test_cli_succeeds_on_empty_queue(
     assert summary["accepted"] == 0
     assert summary["rejected"] == 0
     assert summary["scanned"] == 0
+    assert summary["rejection_counts"] == {}
+    assert summary["rejections_by_reason_type"] == {}
     assert isinstance(summary["duration_ms"], int)
     assert summary["duration_ms"] >= 0
     assert captured.err == ""

--- a/tests/test_repository_artifact_guard.py
+++ b/tests/test_repository_artifact_guard.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 GUARD_SCRIPT = PROJECT_ROOT / "scripts" / "check_repository_artifacts.py"
+HOLDINGS_QUEUE_FREEZE_RUNBOOK = (
+    PROJECT_ROOT / "docs" / "runbook" / "holdings-queue-freeze-rollout.md"
+)
 
 
 def _load_guard_module() -> object:
@@ -96,3 +99,22 @@ def test_gitignore_excludes_generated_python_artifacts() -> None:
     assert "__pycache__/" in gitignore
     assert "*.py[cod]" in gitignore
     assert "*.egg-info/" in gitignore
+
+
+def test_holdings_queue_freeze_runbook_uses_sanitized_evidence_shape() -> None:
+    text = HOLDINGS_QUEUE_FREEZE_RUNBOOK.read_text(encoding="utf-8")
+
+    assert '"payload":' not in _receipt_json_block(text)
+    assert "provider_payload" not in _receipt_json_block(text)
+    assert "raw_payload_path" not in _receipt_json_block(text)
+    assert "DP_PG_DSN=<redacted-dsn>" in text
+    assert "submitted_by=\"subsystem-holdings\"" in text
+    assert "payload_type=\"Ex-3\"" in text
+    assert "commit hash" in text
+
+
+def _receipt_json_block(text: str) -> str:
+    marker = "```json"
+    start = text.index(marker) + len(marker)
+    end = text.index("```", start)
+    return text[start:end]


### PR DESCRIPTION
## Summary

- Adds candidate_queue Ex-3 delta_id idempotency migration and idempotent submit receipt API.
- Adds backward-compatible freeze filters for targeted subsystem/payload selection.
- Adds worker rejection metrics while preserving existing summary counts.
- Adds sanitized holdings queue/freeze rollout runbook and tests for receipt/evidence guardrails.

## Validation

- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src:../contracts/src .venv/bin/python -m pytest -p no:cacheprovider -q -ra tests/queue/test_submit_candidate.py tests/queue/test_worker.py tests/cycle/test_freeze_cycle_candidates.py tests/cycle/test_graph_phase1_adapters.py tests/test_repository_artifact_guard.py tests/queue/test_candidate_queue_schema.py tests/ddl/test_runner.py tests/cycle/test_holdings_ex3_queue_freeze_bridge.py
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m ruff check src/data_platform/queue src/data_platform/cycle tests/queue/test_submit_candidate.py tests/queue/test_worker.py tests/cycle/test_freeze_cycle_candidates.py tests/cycle/test_holdings_ex3_queue_freeze_bridge.py tests/test_repository_artifact_guard.py tests/queue/test_candidate_queue_schema.py tests/ddl/test_runner.py
- git diff --check origin/main...HEAD && git diff --check

## Notes

DB-backed tests skipped locally where DATABASE_URL/DP_PG_DSN was not configured. No contracts, logs, runtime artifacts, secrets, DSNs, provider payloads, or subsystem-holdings runner were changed.