### PR TITLE
Harden holdings queue freeze runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Already present and relevant to the next roadmap:
 - M4.3 bridge evidence now includes a non-skipped `make smoke-p1c` run
   against isolated PostgreSQL database `dp_p1c_smoke_m4bridge`, proving
   `candidate_queue` submit/validate/freeze into `cycle_candidate_selection`.
+- Queue/freeze operational hardening for bounded holdings rollout is landed:
+  idempotent-required Ex-3 submit, safe public receipts, worker rejection
+  metrics, and targeted `freeze_cycle_candidates(..., submitted_by=...,
+  payload_type=...)` filters. This supports bounded holdings evidence only; it
+  is not a broad/default rollout.
 
 Known planning constraints:
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -42,6 +42,15 @@
 >   `docs/evidence/holdings-backfill-derivation-evidence-20260506.md`；raw
 >   logs/provider payloads/dbt build artifacts/runtime noise 不入仓。
 >
+> **Queue/freeze operational hardening sync**：
+>
+> - Holdings queue/freeze runbook hardening now treats idempotent Ex-3 submit,
+>   safe public receipts, worker rejection metrics, and targeted freeze filters
+>   as landed operational checks for bounded holdings rollout evidence.
+> - This sync does **not** mark P1c broad/default rollout complete, does not
+>   enable unfiltered production freezes, and does not introduce financial-doc
+>   scope or contracts subtypes.
+>
 > 后续 `ISSUE-015+`（P1b / P1c）的真实进度不在本次 doc-sync 范围内，保留 `⬜ 未开始` 标记待各自 issue 走完正式流程后再更新。
 
 ---

--- a/docs/runbook/holdings-queue-freeze-rollout.md
+++ b/docs/runbook/holdings-queue-freeze-rollout.md
@@ -1,11 +1,71 @@
 # Holdings Queue/Freeze Rollout Evidence Template
 
-This runbook records only sanitized queue/freeze evidence for a holdings
-production rollout. Do not paste proof-only database names, DSNs, tokens, raw
-provider payloads, dbt logs, runtime paths, `.env` values, or full producer
-payloads.
+This runbook records only sanitized queue/freeze evidence for a bounded
+holdings production rollout. It is an operational checks template, not a
+broad/default rollout declaration.
 
-## Command Shape
+Do not paste proof-only database names, DSNs, tokens, raw provider payloads,
+runtime artifacts, parquet paths, manifest paths, dbt logs, stdout/stderr,
+exitcode files, `.env` values, local runtime paths, or full producer payloads.
+
+## Scope State
+
+Landed and required for holdings queue/freeze evidence:
+
+- idempotent-required Ex-3 submission through `submit_candidate_idempotent`
+- safe receipt recording through `CandidateSubmitReceipt.as_public_dict()`
+- worker rejection metrics: `rejection_counts` and
+  `rejections_by_reason_type`
+- targeted freeze filters: `submitted_by="subsystem-holdings"` and
+  `payload_type="Ex-3"`
+
+This does not enable broad/default freeze rollout, full propagation, financial
+document scope, new contracts subtypes, or any default producer migration.
+
+## Preflight Operational Checks
+
+Before recording evidence:
+
+- confirm the rollout is bounded to a named cycle and the holdings producer
+  identity `subsystem-holdings`
+- confirm Ex-3 candidate producers use `submit_candidate_idempotent`; bare
+  `submit_candidate` is not acceptable for holdings rollout evidence
+- confirm duplicate Ex-3 `delta_id` submissions replay the existing row and
+  return `replayed=true` instead of inserting another candidate
+- confirm the worker command uses `--once` and a bounded `--limit`
+- confirm freeze calls include both targeted filters:
+  `submitted_by="subsystem-holdings"` and `payload_type="Ex-3"`
+- confirm evidence stores parsed counts and sanitized receipts only
+
+Safe status-count query shape:
+
+```sql
+SELECT validation_status, count(*) AS row_count
+FROM data_platform.candidate_queue
+WHERE submitted_by = 'subsystem-holdings'
+  AND payload_type = 'Ex-3'
+GROUP BY validation_status
+ORDER BY validation_status;
+```
+
+Record the result as bounded counts only.
+
+## Idempotent Submit Requirement
+
+Holdings rollout evidence must use the idempotent submit path:
+
+```python
+from data_platform.queue import submit_candidate_idempotent
+
+receipt = submit_candidate_idempotent(holdings_ex3_envelope)
+public_receipt = receipt.as_public_dict()
+```
+
+The runbook may record `public_receipt` fields only. Do not record
+`holdings_ex3_envelope`, provider payload fragments, source row values, local
+paths, or runtime artifacts.
+
+## Worker Command Shape
 
 Use redacted placeholders and bounded counts:
 
@@ -15,6 +75,36 @@ PYTHONPATH=src:../contracts/src \
 python -m data_platform.queue.worker --once --limit <bounded-limit>
 ```
 
+Record the parsed summary, not raw stdout/stderr:
+
+```json
+{
+  "scanned": 42,
+  "accepted": 40,
+  "rejected": 2,
+  "duration_ms": 1234,
+  "rejection_counts": {
+    "<sanitized rejection reason>": 2
+  },
+  "rejections_by_reason_type": {
+    "CandidateValidationError": 2
+  }
+}
+```
+
+Operational checks:
+
+- `scanned == accepted + rejected`
+- `rejection_counts` is present even when empty
+- `rejections_by_reason_type` is present even when empty
+- any non-zero `rejected` count has a sanitized reason summary and an
+  operator decision: retry after producer fix, accept the bounded rejection,
+  or block the rollout
+
+## Targeted Freeze Shape
+
+Holdings production evidence must use a targeted freeze:
+
 ```python
 freeze_cycle_candidates(
     "CYCLE_<YYYYMMDD>",
@@ -22,6 +112,14 @@ freeze_cycle_candidates(
     payload_type="Ex-3",
 )
 ```
+
+For holdings production evidence, a freeze without both filters is invalid.
+Unfiltered freeze calls may remain useful in isolated tests or smoke fixtures,
+but they are not acceptable as rollout evidence and do not imply broad/default
+rollout.
+
+Record only selected count and cutoff metadata from the returned cycle
+metadata.
 
 ## Receipt Shape
 
@@ -49,6 +147,7 @@ Record:
 
 - cycle id and rollout date
 - command shape with redacted placeholders
+- idempotent submit receipt count and replay count
 - worker `scanned`, `accepted`, `rejected`, `rejection_counts`, and
   `rejections_by_reason_type`
 - targeted freeze filters: `submitted_by=subsystem-holdings`,
@@ -56,9 +155,21 @@ Record:
 - selected count and cutoff metadata
 - code commit hash
 - sanitized receipt hash or count, never raw payload
+- explicit statement that the evidence is bounded holdings rollout support,
+  not broad/default rollout
 
 ## Blocker Recording
 
 If a safety gate blocks live execution, record only the blocker code, command
 shape, status, and relevant counts. Do not run a destructive smoke path without
 its explicit safety gate.
+
+Block the rollout when:
+
+- idempotent submit is bypassed for holdings Ex-3 candidates
+- receipts contain producer payloads, provider fields, DSNs, tokens, paths, or
+  runtime artifacts
+- worker rejection metrics are missing from the evidence
+- targeted freeze filters are missing
+- selected count or cutoff metadata cannot be reconciled with the bounded
+  queue counts

--- a/tests/test_repository_artifact_guard.py
+++ b/tests/test_repository_artifact_guard.py
@@ -124,17 +124,65 @@ def test_gitignore_excludes_generated_python_artifacts() -> None:
 def test_holdings_queue_freeze_runbook_uses_sanitized_evidence_shape() -> None:
     text = HOLDINGS_QUEUE_FREEZE_RUNBOOK.read_text(encoding="utf-8")
 
-    assert '"payload":' not in _receipt_json_block(text)
-    assert "provider_payload" not in _receipt_json_block(text)
-    assert "raw_payload_path" not in _receipt_json_block(text)
+    receipt_block = _fenced_block_after(text, "## Receipt Shape", "json")
+    targeted_freeze_block = _fenced_block_after(
+        text,
+        "## Targeted Freeze Shape",
+        "python",
+    )
+
+    assert '"payload":' not in receipt_block
+    assert "provider_payload" not in receipt_block
+    assert "raw_payload_path" not in receipt_block
+    assert "submit_candidate_idempotent" in text
+    assert "CandidateSubmitReceipt.as_public_dict()" in text
+    assert "`submit_candidate` is not acceptable" in text
     assert "DP_PG_DSN=<redacted-dsn>" in text
+    assert "stdout/stderr" in text
+    assert "rejection_counts" in text
+    assert "rejections_by_reason_type" in text
     assert "submitted_by=\"subsystem-holdings\"" in text
     assert "payload_type=\"Ex-3\"" in text
+    assert "submitted_by=\"subsystem-holdings\"" in targeted_freeze_block
+    assert "payload_type=\"Ex-3\"" in targeted_freeze_block
+    assert "not broad/default rollout" in text
+    assert "does not enable broad/default freeze rollout" in text
     assert "commit hash" in text
+    assert _unexpected_runbook_fragments(text) == []
 
 
-def _receipt_json_block(text: str) -> str:
-    marker = "```json"
-    start = text.index(marker) + len(marker)
+def _fenced_block_after(text: str, heading: str, language: str) -> str:
+    section_start = text.index(heading)
+    marker = f"```{language}"
+    start = text.index(marker, section_start) + len(marker)
     end = text.index("```", start)
     return text[start:end]
+
+
+def _unexpected_runbook_fragments(text: str) -> list[str]:
+    forbidden_fragments = (
+        "/Users/",
+        "/Volumes/",
+        ".parquet",
+        "_manifest.json",
+        "stdout_tail",
+        "stderr_tail",
+        '"stdout"',
+        '"stderr"',
+        "exitcode:",
+        "raw_payload_path",
+        "provider_payload",
+        "DATABASE_URL=",
+        "NEO4J_PASSWORD=",
+        "postgresql://",
+        "bolt://",
+        "neo4j+s://",
+    )
+    matches = [fragment for fragment in forbidden_fragments if fragment in text]
+    non_redacted_pg_dsn = [
+        line.strip()
+        for line in text.splitlines()
+        if "DP_PG_DSN=" in line and "DP_PG_DSN=<redacted-dsn>" not in line
+    ]
+    matches.extend(non_redacted_pg_dsn)
+    return matches


### PR DESCRIPTION
## Summary
- expand holdings queue/freeze operational checks for idempotent Ex-3 submit, safe receipts, worker rejection metrics, and targeted freeze filters
- align README/PROGRESS with bounded holdings evidence support only
- strengthen runbook artifact/secret boundary tests

## Tests
- PYTHONPATH=src:../contracts/src .venv/bin/pytest tests/test_repository_artifact_guard.py tests/queue/test_submit_candidate.py tests/queue/test_worker.py tests/cycle/test_freeze_cycle_candidates.py tests/cycle/test_holdings_ex3_queue_freeze_bridge.py -q -rA
- git diff --check
- artifact scan for parquet/manifest/stdout/stderr/exitcode

PG-backed tests skipped locally because no DATABASE_URL/DP_PG_DSN was provided.

## Scope
This is queue/freeze runbook hardening only. It does not enable broad/default rollout, unfiltered production freeze, financial-doc scope, contracts subtype work, or M4.7 completion.