### PR TITLE
Add MVP20 bounded holdings backfill planning

### DIFF
--- a/scripts/holdings_backfill.py
+++ b/scripts/holdings_backfill.py
@@ -11,10 +11,14 @@ from pathlib import Path
 from typing import Any
 
 from data_platform.holdings_backfill import (
+    DEFAULT_MAX_PLAN_ITEMS,
+    MVP20_BOUNDED_BACKFILL_MAX_PLAN_ITEMS,
     SUPPORTED_HOLDINGS_BACKFILL_DATASETS,
     build_holdings_backfill_plan,
+    build_mvp20_bounded_backfill_manifest,
     execute_holdings_backfill_plan,
     public_execution_summary,
+    public_mvp20_bounded_backfill_summary,
     public_plan_summary,
     validate_holdings_backfill_live_gate,
 )
@@ -24,6 +28,26 @@ from data_platform.raw import RawWriter
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     try:
+        if args.mvp20_bounded_backfill:
+            if args.execute_live:
+                msg = "--mvp20-bounded-backfill is plan-only and cannot execute live"
+                raise ValueError(msg)
+            manifest = build_mvp20_bounded_backfill_manifest(
+                stock_codes=_split_many(args.stock_code),
+                end_month=args.mvp20_end_month,
+                max_plan_items=_max_plan_items(
+                    args.max_plan_items,
+                    default=MVP20_BOUNDED_BACKFILL_MAX_PLAN_ITEMS,
+                ),
+            )
+            payload: dict[str, Any] = {
+                "mode": "mvp20_bounded_backfill",
+                "execute_live": False,
+                "manifest": public_mvp20_bounded_backfill_summary(manifest),
+            }
+            _emit_payload(payload, args.json_report)
+            return 0 if manifest.ok else 2
+
         plan = build_holdings_backfill_plan(
             datasets=_split_many(args.dataset),
             stock_codes=_split_many(args.stock_code),
@@ -34,7 +58,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             end_date=args.end_date,
             market_types=_split_many(args.market_type),
             exchanges=_split_many(args.exchange),
-            max_plan_items=args.max_plan_items,
+            max_plan_items=_max_plan_items(args.max_plan_items, default=DEFAULT_MAX_PLAN_ITEMS),
         )
         payload: dict[str, Any] = {
             "mode": "holdings_backfill",
@@ -63,8 +87,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             payload["execution"] = public_execution_summary(result)
         _emit_payload(payload, args.json_report)
     except Exception as exc:
+        mode = "mvp20_bounded_backfill" if args.mvp20_bounded_backfill else "holdings_backfill"
         payload = {
-            "mode": "holdings_backfill",
+            "mode": mode,
             "execute_live": args.execute_live,
             "ok": False,
             "error": str(exc),
@@ -80,13 +105,16 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument(
         "--dataset",
         action="append",
-        required=True,
         help=(
             "Holdings dataset to backfill. Repeat or comma-separate. Supported: "
             + ", ".join(SUPPORTED_HOLDINGS_BACKFILL_DATASETS)
         ),
     )
-    parser.add_argument("--stock-code", action="append", help="Bounded A-share code scope.")
+    parser.add_argument(
+        "--stock-code",
+        action="append",
+        help="Bounded A-share code scope. Required exactly 20 times or comma-separated for MVP20.",
+    )
     parser.add_argument("--fund-code", action="append", help="Bounded fund code scope.")
     parser.add_argument("--period", action="append", help="Report period in YYYYMMDD.")
     parser.add_argument("--trade-date", action="append", help="Trade date in YYYYMMDD.")
@@ -94,7 +122,16 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument("--end-date", help="Inclusive trade-date range end in YYYYMMDD.")
     parser.add_argument("--market-type", action="append", help="Bounded hsgt_top10 market type.")
     parser.add_argument("--exchange", action="append", help="Bounded hsgt_hold_top10 exchange.")
-    parser.add_argument("--max-plan-items", type=int, default=5_000)
+    parser.add_argument("--max-plan-items", type=int)
+    parser.add_argument(
+        "--mvp20-bounded-backfill",
+        action="store_true",
+        help="Emit the fixed MVP20 20-stock, two-hop, 120-month plan-only manifest.",
+    )
+    parser.add_argument(
+        "--mvp20-end-month",
+        help="MVP20 window end month in YYYYMM or YYYYMMDD. Defaults to provider cutoff month.",
+    )
     parser.add_argument(
         "--execute-live",
         action="store_true",
@@ -103,7 +140,10 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument("--raw-zone-path", type=Path)
     parser.add_argument("--iceberg-warehouse-path", type=Path)
     parser.add_argument("--json-report", type=Path, help="Write JSON payload to this path.")
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if not args.mvp20_bounded_backfill and not args.dataset:
+        parser.error("--dataset is required unless --mvp20-bounded-backfill is set")
+    return args
 
 
 def _split_many(values: Sequence[str] | None) -> list[str]:
@@ -113,6 +153,10 @@ def _split_many(values: Sequence[str] | None) -> list[str]:
     for value in values:
         result.extend(part.strip() for part in value.split(",") if part.strip())
     return result
+
+
+def _max_plan_items(value: int | None, *, default: int) -> int:
+    return default if value is None else value
 
 
 def _emit_payload(payload: dict[str, Any], path: Path | None) -> None:

--- a/src/data_platform/holdings_backfill.py
+++ b/src/data_platform/holdings_backfill.py
@@ -41,11 +41,19 @@ PUBLIC_SAFE_BOUND_KEYS = frozenset(
         "market_type",
         "max_plan_items",
         "missing",
+        "omitted_month_count",
         "period",
         "planned_count",
+        "provider_available_end_date",
+        "capped_month_count",
+        "related_entity_hops",
         "start_date",
         "end_date",
+        "start_month",
+        "end_month",
+        "stock_count",
         "trade_date",
+        "window_months",
     }
 )
 PUBLIC_IDENTIFIER_VALUE_RE = re.compile(
@@ -57,6 +65,13 @@ HSGT_HOLD_TOP10_BACKFILL_LAST_DATE = date(2024, 8, 20)
 DEFAULT_MAX_PLAN_ITEMS = 5_000
 DATE_FORMAT = "%Y%m%d"
 LIVE_HOLDINGS_BACKFILL_ENV = "DP_TUSHARE_LIVE_HOLDINGS_BACKFILL"
+MVP20_BOUNDED_BACKFILL_WINDOW_MONTHS = 120
+MVP20_BOUNDED_BACKFILL_STOCK_COUNT = 20
+MVP20_BOUNDED_BACKFILL_MAX_PLAN_ITEMS = 20_000
+MVP20_BOUNDED_BACKFILL_END_MONTH = date(2024, 8, 31)
+MVP20_HSGT_MARKET_TYPES = ("1", "3")
+MVP20_HSGT_EXCHANGES = ("SH", "SZ")
+MVP20_A_SHARE_STOCK_CODE_RE = re.compile(r"^\d{6}\.(?:BJ|SH|SZ)$")
 
 
 class HoldingsBackfillPlanError(ValueError):
@@ -136,6 +151,53 @@ class HoldingsBackfillExecutionResult:
         return tuple(item.artifact for item in self.items if item.artifact is not None)
 
 
+@dataclass(frozen=True, slots=True)
+class ProviderGap:
+    """One explicit gap in a provider-available planning manifest."""
+
+    scope: str
+    reason_type: str
+    reason: str
+    dataset: str | None = None
+    bounds: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "bounds", dict(self.bounds))
+
+
+@dataclass(frozen=True, slots=True)
+class MVP20BoundedBackfillManifest:
+    """Plan-only MVP20 bounded backfill manifest with explicit provider gaps."""
+
+    seed_stock_codes: tuple[str, ...]
+    window_month_ends: tuple[date, ...]
+    report_periods: tuple[date, ...]
+    trade_dates: tuple[date, ...]
+    hsgt_hold_trade_dates: tuple[date, ...]
+    holdings_plan: HoldingsBackfillPlan
+    provider_gaps: tuple[ProviderGap, ...]
+    related_fund_codes: tuple[str, ...] = ()
+    related_entity_hops: int = 2
+    completeness_status: str = "bounded_provider_available_with_recorded_gaps"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "seed_stock_codes", tuple(self.seed_stock_codes))
+        object.__setattr__(self, "window_month_ends", tuple(self.window_month_ends))
+        object.__setattr__(self, "report_periods", tuple(self.report_periods))
+        object.__setattr__(self, "trade_dates", tuple(self.trade_dates))
+        object.__setattr__(self, "hsgt_hold_trade_dates", tuple(self.hsgt_hold_trade_dates))
+        object.__setattr__(self, "provider_gaps", tuple(self.provider_gaps))
+        object.__setattr__(self, "related_fund_codes", tuple(self.related_fund_codes))
+
+    @property
+    def ok(self) -> bool:
+        return self.holdings_plan.ok
+
+    @property
+    def complete(self) -> bool:
+        return False
+
+
 def build_holdings_backfill_plan(
     *,
     datasets: Sequence[str],
@@ -200,6 +262,106 @@ def build_holdings_backfill_plan(
         )
 
     return HoldingsBackfillPlan(tuple(items), max_plan_items=max_plan_items)
+
+
+def build_mvp20_bounded_backfill_manifest(
+    *,
+    stock_codes: Sequence[str],
+    end_month: str | date | None = None,
+    related_fund_codes: Sequence[str] = (),
+    max_plan_items: int = MVP20_BOUNDED_BACKFILL_MAX_PLAN_ITEMS,
+) -> MVP20BoundedBackfillManifest:
+    """Build the fixed MVP20 plan-only manifest without touching live providers."""
+
+    normalized_stock_codes = _normalize_mvp20_stock_codes(stock_codes)
+    normalized_fund_codes = _normalize_non_empty_strings(related_fund_codes)
+    month_ends = _month_end_window(
+        _parse_end_month(end_month),
+        months=MVP20_BOUNDED_BACKFILL_WINDOW_MONTHS,
+    )
+    report_periods = tuple(value for value in month_ends if value.month in {3, 6, 9, 12})
+    hsgt_hold_trade_dates, hsgt_hold_gaps = _hsgt_hold_provider_available_dates(month_ends)
+
+    plans = [
+        build_holdings_backfill_plan(
+            datasets=("top10_holders", "top10_floatholders"),
+            stock_codes=normalized_stock_codes,
+            periods=tuple(f"{period:%Y%m%d}" for period in report_periods),
+            max_plan_items=max_plan_items,
+        ),
+        build_holdings_backfill_plan(
+            datasets=("hsgt_top10",),
+            stock_codes=normalized_stock_codes,
+            trade_dates=tuple(f"{trade_date:%Y%m%d}" for trade_date in month_ends),
+            market_types=MVP20_HSGT_MARKET_TYPES,
+            max_plan_items=max_plan_items,
+        ),
+    ]
+    if hsgt_hold_trade_dates:
+        plans.append(
+            build_holdings_backfill_plan(
+                datasets=("hsgt_hold_top10",),
+                stock_codes=normalized_stock_codes,
+                trade_dates=tuple(f"{trade_date:%Y%m%d}" for trade_date in hsgt_hold_trade_dates),
+                exchanges=MVP20_HSGT_EXCHANGES,
+                max_plan_items=max_plan_items,
+            )
+        )
+
+    provider_gaps: list[ProviderGap] = list(hsgt_hold_gaps)
+    if normalized_fund_codes:
+        plans.append(
+            build_holdings_backfill_plan(
+                datasets=("fund_portfolio",),
+                fund_codes=normalized_fund_codes,
+                periods=tuple(f"{period:%Y%m%d}" for period in report_periods),
+                max_plan_items=max_plan_items,
+            )
+        )
+    else:
+        provider_gaps.append(
+            ProviderGap(
+                scope="two_hop_related_entities",
+                dataset="fund_portfolio",
+                reason_type="related_fund_codes_unresolved_plan_only",
+                reason=(
+                    "fund_portfolio needs fund codes discovered from observed holdings; "
+                    "the plan-only MVP20 manifest records the gap instead of fabricating "
+                    "two-hop fund coverage"
+                ),
+                bounds={
+                    "stock_count": len(normalized_stock_codes),
+                    "related_entity_hops": 2,
+                    "window_months": MVP20_BOUNDED_BACKFILL_WINDOW_MONTHS,
+                },
+            )
+        )
+
+    provider_gaps.append(
+        ProviderGap(
+            scope="two_hop_related_entities",
+            reason_type="holder_identity_resolution_deferred",
+            reason=(
+                "holder and co-held-security expansion must be derived from fetched "
+                "provider rows; this manifest does not enumerate unknown holder entities"
+            ),
+            bounds={
+                "stock_count": len(normalized_stock_codes),
+                "related_entity_hops": 2,
+            },
+        )
+    )
+
+    return MVP20BoundedBackfillManifest(
+        seed_stock_codes=normalized_stock_codes,
+        window_month_ends=month_ends,
+        report_periods=report_periods,
+        trade_dates=month_ends,
+        hsgt_hold_trade_dates=hsgt_hold_trade_dates,
+        holdings_plan=_combine_holdings_backfill_plans(plans, max_plan_items=max_plan_items),
+        provider_gaps=tuple(provider_gaps),
+        related_fund_codes=normalized_fund_codes,
+    )
 
 
 def execute_holdings_backfill_plan(
@@ -315,6 +477,93 @@ def public_execution_summary(result: HoldingsBackfillExecutionResult) -> dict[st
             for item in result.items
         ],
     }
+
+
+def public_mvp20_bounded_backfill_summary(
+    manifest: MVP20BoundedBackfillManifest,
+) -> dict[str, Any]:
+    """Return a redacted MVP20 plan manifest summary with provider gaps."""
+
+    return {
+        "ok": manifest.ok,
+        "complete": manifest.complete,
+        "completeness_status": manifest.completeness_status,
+        "seed_stock_count": len(manifest.seed_stock_codes),
+        "related_entity_hops": manifest.related_entity_hops,
+        "window": {
+            "window_months": len(manifest.window_month_ends),
+            "start_month": f"{manifest.window_month_ends[0]:%Y%m}",
+            "end_month": f"{manifest.window_month_ends[-1]:%Y%m}",
+            "report_period_count": len(manifest.report_periods),
+            "trade_date_count": len(manifest.trade_dates),
+            "hsgt_hold_trade_date_count": len(manifest.hsgt_hold_trade_dates),
+        },
+        "plan": {
+            "planned_count": len(manifest.holdings_plan.planned_items),
+            "skipped_count": len(manifest.holdings_plan.skipped_items),
+            "rejected_count": len(manifest.holdings_plan.rejected_items),
+            "max_plan_items": manifest.holdings_plan.max_plan_items,
+            "planned_count_by_dataset": _plan_item_counts_by_dataset(
+                manifest.holdings_plan.planned_items
+            ),
+            "skipped_count_by_dataset": _plan_item_counts_by_dataset(
+                manifest.holdings_plan.skipped_items
+            ),
+            "rejected_count_by_dataset": _plan_item_counts_by_dataset(
+                manifest.holdings_plan.rejected_items
+            ),
+        },
+        "provider_gap_count": len(manifest.provider_gaps),
+        "provider_gaps": [_public_provider_gap(gap) for gap in manifest.provider_gaps],
+    }
+
+
+def _combine_holdings_backfill_plans(
+    plans: Sequence[HoldingsBackfillPlan],
+    *,
+    max_plan_items: int,
+) -> HoldingsBackfillPlan:
+    items = tuple(item for plan in plans for item in plan.items)
+    planned_count = sum(1 for item in items if item.status == "planned")
+    if planned_count <= max_plan_items:
+        return HoldingsBackfillPlan(items, max_plan_items=max_plan_items)
+    return HoldingsBackfillPlan(
+        (
+            *items,
+            _rejected_item(
+                "holdings",
+                "plan_item_limit_exceeded",
+                (
+                    f"bounded holdings backfill plan has {planned_count} planned items; "
+                    f"limit is {max_plan_items}"
+                ),
+                bounds={"planned_count": planned_count, "max_plan_items": max_plan_items},
+            ),
+        ),
+        max_plan_items=max_plan_items,
+    )
+
+
+def _plan_item_counts_by_dataset(
+    items: Sequence[HoldingsBackfillPlanItem],
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        counts[item.dataset] = counts.get(item.dataset, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _public_provider_gap(gap: ProviderGap) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "scope": gap.scope,
+        "reason_type": gap.reason_type,
+        "reason": gap.reason,
+    }
+    if gap.dataset is not None:
+        payload["dataset"] = gap.dataset
+    if gap.bounds:
+        payload["bounds"] = _json_safe_public_value(gap.bounds)
+    return payload
 
 
 def _plan_dataset(
@@ -627,6 +876,123 @@ def _parse_yyyymmdd(value: str) -> date | None:
     return parsed
 
 
+def _parse_end_month(value: str | date | None) -> date:
+    if value is None:
+        return MVP20_BOUNDED_BACKFILL_END_MONTH
+    if isinstance(value, date):
+        return _month_end(value.year, value.month)
+
+    normalized = value.strip()
+    if re.fullmatch(r"\d{6}", normalized):
+        year = int(normalized[:4])
+        month = int(normalized[4:])
+        if not 1 <= month <= 12:
+            msg = "end_month must use a valid YYYYMM month"
+            raise ValueError(msg)
+        return _month_end(year, month)
+
+    parsed = _parse_yyyymmdd(normalized)
+    if parsed is None:
+        msg = "end_month must use YYYYMM or YYYYMMDD"
+        raise ValueError(msg)
+    return _month_end(parsed.year, parsed.month)
+
+
+def _month_end_window(end_month: date, *, months: int) -> tuple[date, ...]:
+    if months != MVP20_BOUNDED_BACKFILL_WINDOW_MONTHS:
+        msg = "MVP20 bounded backfill uses a fixed 120-month window"
+        raise ValueError(msg)
+
+    values = []
+    end_year = end_month.year
+    end_month_number = end_month.month
+    for offset in range(months - 1, -1, -1):
+        year, month = _shift_month(end_year, end_month_number, -offset)
+        values.append(_month_end(year, month))
+    return tuple(values)
+
+
+def _shift_month(year: int, month: int, offset: int) -> tuple[int, int]:
+    month_index = year * 12 + month - 1 + offset
+    return month_index // 12, month_index % 12 + 1
+
+
+def _month_end(year: int, month: int) -> date:
+    if month == 12:
+        return date(year + 1, 1, 1) - timedelta(days=1)
+    return date(year, month + 1, 1) - timedelta(days=1)
+
+
+def _hsgt_hold_provider_available_dates(
+    month_ends: Sequence[date],
+) -> tuple[tuple[date, ...], tuple[ProviderGap, ...]]:
+    available_dates: list[date] = []
+    capped_months: list[date] = []
+    omitted_months: list[date] = []
+    cutoff = HSGT_HOLD_TOP10_BACKFILL_LAST_DATE
+    for month_end in month_ends:
+        if month_end <= cutoff:
+            available_dates.append(month_end)
+            continue
+        if month_end.year == cutoff.year and month_end.month == cutoff.month:
+            available_dates.append(cutoff)
+            capped_months.append(month_end)
+            continue
+        omitted_months.append(month_end)
+
+    gaps: list[ProviderGap] = []
+    if capped_months:
+        gaps.append(
+            ProviderGap(
+                scope="provider_available_window",
+                dataset="hsgt_hold_top10",
+                reason_type="partial_month_provider_cutoff",
+                reason=(
+                    "hsgt_hold_top10 daily publication is only provider-verifiable "
+                    f"through {cutoff:%Y-%m-%d}; the cutoff month is capped to that date"
+                ),
+                bounds={
+                    "capped_month_count": len(capped_months),
+                    "end_month": f"{capped_months[-1]:%Y%m}",
+                    "provider_available_end_date": f"{cutoff:%Y%m%d}",
+                },
+            )
+        )
+    if omitted_months:
+        gaps.append(
+            ProviderGap(
+                scope="provider_available_window",
+                dataset="hsgt_hold_top10",
+                reason_type="post_publication_cutoff",
+                reason=(
+                    "hsgt_hold_top10 daily publication is not provider-verifiable after "
+                    f"{cutoff:%Y-%m-%d}; post-cutoff months are omitted from the plan"
+                ),
+                bounds={
+                    "omitted_month_count": len(omitted_months),
+                    "start_month": f"{omitted_months[0]:%Y%m}",
+                    "end_month": f"{omitted_months[-1]:%Y%m}",
+                    "provider_available_end_date": f"{cutoff:%Y%m%d}",
+                },
+            )
+        )
+    return _dedupe_dates(available_dates), tuple(gaps)
+
+
+def _normalize_mvp20_stock_codes(stock_codes: Sequence[str]) -> tuple[str, ...]:
+    normalized = _normalize_non_empty_strings(stock_codes)
+    if (
+        len(normalized) != MVP20_BOUNDED_BACKFILL_STOCK_COUNT
+        or len(frozenset(normalized)) != len(normalized)
+    ):
+        msg = "mvp20 bounded backfill requires exactly 20 unique stock_codes"
+        raise ValueError(msg)
+    if any(MVP20_A_SHARE_STOCK_CODE_RE.fullmatch(stock_code) is None for stock_code in normalized):
+        msg = "mvp20 bounded backfill stock_codes must be A-share ts_codes"
+        raise ValueError(msg)
+    return normalized
+
+
 def _normalize_non_empty_strings(values: Sequence[str]) -> tuple[str, ...]:
     normalized: list[str] = []
     seen: set[str] = set()
@@ -890,11 +1256,19 @@ __all__ = [
     "HoldingsBackfillPlanError",
     "HoldingsBackfillPlanItem",
     "LIVE_HOLDINGS_BACKFILL_ENV",
+    "MVP20BoundedBackfillManifest",
+    "MVP20_BOUNDED_BACKFILL_STOCK_COUNT",
+    "MVP20_BOUNDED_BACKFILL_END_MONTH",
+    "MVP20_BOUNDED_BACKFILL_MAX_PLAN_ITEMS",
+    "MVP20_BOUNDED_BACKFILL_WINDOW_MONTHS",
+    "ProviderGap",
     "SUPPORTED_HOLDINGS_BACKFILL_DATASETS",
     "build_holdings_backfill_plan",
+    "build_mvp20_bounded_backfill_manifest",
     "default_holdings_assets_by_dataset",
     "execute_holdings_backfill_plan",
     "public_execution_summary",
+    "public_mvp20_bounded_backfill_summary",
     "public_plan_summary",
     "validate_holdings_backfill_live_gate",
 ]

--- a/tests/unit/test_holdings_backfill.py
+++ b/tests/unit/test_holdings_backfill.py
@@ -21,12 +21,16 @@ from data_platform.adapters.tushare import (  # noqa: E402
     TUSHARE_TOP10_HOLDERS_ASSET,
 )
 from data_platform.holdings_backfill import (  # noqa: E402
+    MVP20_BOUNDED_BACKFILL_STOCK_COUNT,
+    MVP20_BOUNDED_BACKFILL_WINDOW_MONTHS,
     SUPPORTED_HOLDINGS_BACKFILL_DATASETS,
     HoldingsBackfillPlan,
     HoldingsBackfillPlanError,
     HoldingsBackfillPlanItem,
     build_holdings_backfill_plan,
+    build_mvp20_bounded_backfill_manifest,
     execute_holdings_backfill_plan,
+    public_mvp20_bounded_backfill_summary,
     public_plan_summary,
 )
 from data_platform.raw import RawWriter  # noqa: E402
@@ -70,6 +74,69 @@ def test_five_holdings_interfaces_generate_bounded_plan() -> None:
     ]
     assert {item.status for item in plan.items} == {"planned"}
     assert {item.dataset for item in plan.items} == set(SUPPORTED_HOLDINGS_BACKFILL_DATASETS)
+
+
+def _mvp20_stock_codes() -> tuple[str, ...]:
+    return tuple(f"{index:06d}.SZ" for index in range(1, 21))
+
+
+def test_mvp20_manifest_builds_fixed_20_stock_120_month_provider_available_plan() -> None:
+    stock_codes = _mvp20_stock_codes()
+    manifest = build_mvp20_bounded_backfill_manifest(stock_codes=stock_codes)
+    planned_counts = public_mvp20_bounded_backfill_summary(manifest)["plan"][
+        "planned_count_by_dataset"
+    ]
+
+    assert manifest.ok is True
+    assert manifest.complete is False
+    assert len(manifest.seed_stock_codes) == MVP20_BOUNDED_BACKFILL_STOCK_COUNT
+    assert manifest.seed_stock_codes == stock_codes
+    assert len(manifest.window_month_ends) == MVP20_BOUNDED_BACKFILL_WINDOW_MONTHS
+    assert len(manifest.report_periods) == 40
+    assert len(manifest.trade_dates) == 120
+    assert len(manifest.hsgt_hold_trade_dates) == 120
+    assert planned_counts == {
+        "hsgt_hold_top10": 4_800,
+        "hsgt_top10": 4_800,
+        "top10_floatholders": 800,
+        "top10_holders": 800,
+    }
+    assert manifest.holdings_plan.rejected_items == ()
+    assert manifest.holdings_plan.skipped_items == ()
+
+
+def test_mvp20_manifest_records_provider_gaps_without_claiming_completeness() -> None:
+    stock_codes = _mvp20_stock_codes()
+    manifest = build_mvp20_bounded_backfill_manifest(
+        stock_codes=stock_codes,
+        end_month="202605",
+    )
+    summary = public_mvp20_bounded_backfill_summary(manifest)
+    encoded = json.dumps(summary, sort_keys=True)
+    reason_types = {gap["reason_type"] for gap in summary["provider_gaps"]}
+
+    assert summary["ok"] is True
+    assert summary["complete"] is False
+    assert summary["completeness_status"] == "bounded_provider_available_with_recorded_gaps"
+    assert summary["window"]["window_months"] == 120
+    assert summary["provider_gap_count"] == 4
+    assert {
+        "holder_identity_resolution_deferred",
+        "partial_month_provider_cutoff",
+        "post_publication_cutoff",
+        "related_fund_codes_unresolved_plan_only",
+    }.issubset(reason_types)
+    assert "fund_portfolio" not in summary["plan"]["planned_count_by_dataset"]
+    assert "ts_code" not in encoded
+    assert "fetch_params" not in encoded
+    assert "artifact" not in encoded
+    for stock_code in stock_codes:
+        assert stock_code not in encoded
+
+
+def test_mvp20_manifest_requires_explicit_20_stock_codes() -> None:
+    with pytest.raises(ValueError, match="exactly 20 unique"):
+        build_mvp20_bounded_backfill_manifest(stock_codes=_mvp20_stock_codes()[:19])
 
 
 @pytest.mark.parametrize(
@@ -488,6 +555,34 @@ def test_cli_json_report_sanitizes_identifier_bounds(tmp_path: Path) -> None:
     }
     assert "TESTSTK.SZ" not in encoded
     assert "ts_code" not in encoded
+
+
+def test_cli_mvp20_json_report_is_plan_only_and_sanitized(tmp_path: Path) -> None:
+    report_path = tmp_path / "reports" / "mvp20.json"
+    cli = _load_holdings_backfill_cli()
+
+    exit_code = cli.main(
+        [
+            "--mvp20-bounded-backfill",
+            "--stock-code",
+            ",".join(_mvp20_stock_codes()),
+            "--json-report",
+            str(report_path),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    encoded = json.dumps(payload, sort_keys=True)
+    assert payload["mode"] == "mvp20_bounded_backfill"
+    assert payload["execute_live"] is False
+    assert "execution" not in payload
+    assert payload["manifest"]["seed_stock_count"] == 20
+    assert payload["manifest"]["complete"] is False
+    assert "ts_code" not in encoded
+    assert "fetch_params" not in encoded
+    for stock_code in _mvp20_stock_codes():
+        assert stock_code not in encoded
 
 
 def test_cli_execute_live_requires_env_gate_before_live_objects(


### PR DESCRIPTION
## Summary
- add plan-only MVP20 holdings backfill manifest helper
- require exactly 20 explicit A-share stock codes from caller/manifest
- record provider and two-hop gaps without live provider execution

## Tests
- .venv/bin/python -m pytest tests/unit/test_holdings_backfill.py tests/integration/test_daily_refresh.py
- git diff --check